### PR TITLE
Pass key info to keyboard event callbacks

### DIFF
--- a/heart/example/main.c
+++ b/heart/example/main.c
@@ -13,8 +13,16 @@ void output_callback(struct hrt_output *output) {
   puts("Output callback called");
 }
 
-bool keyboard_callback() {
+bool keyboard_callback(struct hrt_keypress_info *info) {
   puts("Keyboard callback called");
+  printf("Modifiers: %d\n", info->modifiers);
+  printf("Keys pressed:");
+  for(size_t i = 0; i < info->keysyms_len; ++i) {
+	  char buffer[20];
+	  xkb_keysym_get_name(info->keysyms[i], buffer, sizeof(buffer));
+	  printf(" %s", buffer);
+  }
+  puts("\n\n");
   return false;
 }
 
@@ -26,8 +34,7 @@ static const struct hrt_output_callbacks output_callbacks = {
 static const struct hrt_seat_callbacks seat_callbacks = {
   .button_event = &cursor_callback,
   .wheel_event = &cursor_callback,
-  .keyboard_key_event = &keyboard_callback,
-  .keyboard_modifier_event = &keyboard_callback,
+  .keyboard_keypress_event = &keyboard_callback,
 };
 
 int main(int argc, char *argv[]) {

--- a/heart/include/hrt/hrt_input.h
+++ b/heart/include/hrt/hrt_input.h
@@ -4,6 +4,7 @@
 #include <wayland-server.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_keyboard_group.h>
+#include <xkbcommon/xkbcommon.h>
 
 struct hrt_server;
 
@@ -31,12 +32,23 @@ struct hrt_seat {
   const struct hrt_seat_callbacks *callbacks;
 };
 
+struct hrt_keypress_info {
+  const xkb_keysym_t *keysyms;
+  uint32_t modifiers;
+  size_t keysyms_len;
+};
+
 struct hrt_seat_callbacks {
   // TODO: these need parameters
   void (*button_event)();
   void (*wheel_event)();
-  bool (*keyboard_key_event)();
-  bool (*keyboard_modifier_event)();
+  // We will eventually want to pass in the event object, keyboard object and seat object
+  // to get anything beyond basic keybindings, but then this should work for the basics
+  // and we don't need to write wlroots bindings.
+  /**
+   * This callback is called whenever a non-modifier key is pressed (not released)
+   **/
+  bool (*keyboard_keypress_event)(struct hrt_keypress_info *info);
 };
 
 struct hrt_input {

--- a/heart/src/keyboard.c
+++ b/heart/src/keyboard.c
@@ -64,7 +64,12 @@ static void seat_handle_key(struct wl_listener *listener, void *data) {
   bool handled = false;
 
   if(event->state == WLR_KEY_PRESSED) {
-    handled = seat->callbacks->keyboard_key_event();
+    struct hrt_keypress_info key_info = {
+      .keysyms = translated_keysyms,
+      .keysyms_len = translated_keysyms_len,
+      .modifiers = translated_modifiers
+    };
+    handled = seat->callbacks->keyboard_keypress_event(&key_info);
   }
 
   if(!handled && event->state == WLR_KEY_PRESSED) {


### PR DESCRIPTION
We probably want more event information than this in the future, but just having the translated keys and the current modifiers should be good enough. This should give us the information needed to process the standard bindings like `C-t e` and other commands.