### PR TITLE
Add key parsing and creation

### DIFF
--- a/bindings/package.lisp
+++ b/bindings/package.lisp
@@ -13,4 +13,7 @@
 	   #:hrt-server-init
 	   #:hrt-server-start
 	   #:hrt-server-run
-	   #:hrt-server-finish))
+	   #:hrt-server-finish
+	   #:keysyms
+	   #:modifiers
+	   #:keysyms-len))

--- a/keyboard/key.lisp
+++ b/keyboard/key.lisp
@@ -1,0 +1,135 @@
+;; A large part of this file is taken directly from stumpwm:
+
+;; Copyright (C) 2003-2008 Shawn Betts
+;;
+;;  This file is part of stumpwm.
+;;
+;; stumpwm is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; stumpwm is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this software; see the file COPYING.  If not, see
+;; <http://www.gnu.org/licenses/>.
+
+;; Commentary:
+;;
+;; This file handles keymaps
+;;
+;; Code:
+
+(in-package #:mahogany/keyboard)
+
+(defstruct (key (:constructor make-key (keysym modifier-mask)))
+  (keysym 0 :read-only t :type (unsigned-byte 32))
+  (modifier-mask 0 :read-only t :type (unsigned-byte 32)))
+
+(declaim (type (unsigned-byte 32)
+	       +modifier-shift+
+	       +modifier-caps+
+	       +modifier-ctrl+
+	       +modifier-alt+
+	       +modifier-mod2+
+	       +modifier-mod3+
+	       +modifier-super+
+	       +modifier-mod5+))
+(defconstant +modifier-shift+ (ash 1 0))
+(defconstant +modifier-caps+ (ash 1 1))
+(defconstant +modifier-ctrl+ (ash 1 2))
+(defconstant +modifier-alt+ (ash 1 3))
+(defconstant +modifier-mod2+ (ash 1 4))
+(defconstant +modifier-mod3+ (ash 1  5))
+(defconstant +modifier-super+ (ash 1 6))
+(defconstant +modifier-mod5+ (ash 1 7))
+
+(defun print-key (key &optional (stream *standard-output*))
+  (declare (type key key) (type stream stream)
+	   (optimize (safety 1)))
+  (let ((mod (key-modifier-mask key)))
+    (format stream "(Keycode: ~A Modifiers: (" (key-keysym key))
+    (when (not (= mod 0))
+      (when (/= 0 (logand +modifier-shift+ mod))
+	(format stream "SHIFT"))
+      (when (/= 0 (logand +modifier-caps+ mod))
+	(format stream "CAPS"))
+      (when (/= 0 (logand +modifier-ctrl+ mod))
+	(format stream "CONTROL"))
+      (when (/= 0 (logand +modifier-alt+ mod))
+	(format stream "ALT"))
+      ;; FIXME: one of these modifiers is probably the hyper key
+      (when (/= 0 (logand +modifier-mod2+ mod))
+	(format stream "MOD2"))
+      (when (/= 0 (logand +modifier-mod3+ mod))
+	(format stream "MOD3"))
+      (when (/= 0 (logand +modifier-super+ mod))
+	(format stream "SUPER"))
+      (when (/= 0 (logand +modifier-mod5+ mod))
+	(format stream "MOD5"))))
+    (format stream "))"))
+
+
+(defun %report-kbd-parse-error (c stream)
+  (format stream "Failed to parse key string: ~s." (kdb-parse-error-string c))
+  (when-let ((reason (kdb-parse-error-reason c)))
+    (format stream "~%Reason: ~A" reason)))
+
+(define-condition kbd-parse-error (mahogany-error)
+  ((string :initarg :string
+	   :reader kdb-parse-error-string)
+   (reason :initarg :reason :reader kdb-parse-error-reason
+	   :initform nil))
+  (:report %report-kbd-parse-error)
+  (:documentation "Raised when a kbd string failed to parse."))
+
+(defun %parse-mods (mods end)
+  "MODS is a sequence of <MOD CHAR> #\- pairs. Returns a bitfield with
+ the appropriate bits set for the given modifiers chars"
+  (unless (evenp end)
+    (error 'kbd-parse-error :string mods
+	   :reason "Did you forget to separate modifier characters with '-'?"))
+  (let ((mod-mask 0))
+    (declare (type (unsigned-byte 32) mod-mask))
+    (loop for i from 0 below end by 2
+          when (char/= (char mods (1+ i)) #\-)
+            do (error 'kbd-parse-error :string mods)
+          do (setf mod-mask (logior mod-mask
+				    (case (char mods i)
+				      (#\M +modifier-alt+)
+				      (#\A +modifier-alt+)
+				      (#\C +modifier-ctrl+)
+				      (#\H (error 'kbd-parse-error
+						  :string mods
+						  :reason
+						  "Fixme: don't know which key is the Hyper modifier."))
+				      (#\s +modifier-super+)
+				      (#\S +modifier-shift+)
+				      (t (error 'kbd-parse-error :string mods
+						:reason (format nil "Unknown modifer character ~A" (char mods i))))))))
+    mod-mask))
+
+(defun parse-key (string)
+  "Parse STRING and return a key structure. Raise an error of type
+kbd-parse if the key failed to parse."
+  (let* ((p (when (> (length string) 2)
+              (position #\- string :from-end t :end (- (length string) 1))))
+         (mod-mask  (if p (%parse-mods string (1+ p)) 0))
+	 (key-part (subseq string (if p (1+ p) 0)))
+         (keysym (stumpwm-name->keysym key-part)))
+    (if keysym
+        (make-key keysym mod-mask)
+        (error 'kbd-parse-error :string string))))
+
+;; The stumpwm version can take key specs split by a newline,
+;; but since only the first value is returned out of those,
+;; it should be okay to just accept a single spec here for now:
+(defun kbd (key)
+  "This compiles a key string into a key structure."
+  ;; TODO: make this function accept a list of strings or
+  ;; a string of keyspecs separated by spaces
+  (parse-key key))

--- a/keyboard/keytrans.lisp
+++ b/keyboard/keytrans.lisp
@@ -1,0 +1,120 @@
+;; A large portion of this file was taken from Stumpwm's keytrans.lisp file:
+
+;; Copyright (C) 2006-2008 Matthew Kennedy
+;;
+;;  This file is part of stumpwm.
+;;
+;; stumpwm is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; stumpwm is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this software; see the file COPYING.  If not, see
+;; <http://www.gnu.org/licenses/>.
+
+;; Commentary:
+;;
+;; Translate between stumpwm key names and keysym names.
+;;
+;; Code:
+
+(in-package #:mahogany/keyboard)
+
+(defvar *stumpwm-name->keysym-name-translations* (make-hash-table :test #'equal)
+  "Hashtable mapping from stumpwm key names to keysym names.")
+
+(defun define-keysym-name (stumpwm-name keysym-name)
+  "Define a mapping from a STUMPWM-NAME to KEYSYM-NAME.
+This function is used to translate Emacs-like names to keysym
+names."
+  (setf (gethash stumpwm-name *stumpwm-name->keysym-name-translations*)
+        keysym-name))
+
+(defun stumpwm-name->keysym-name (stumpwm-name)
+  (multiple-value-bind (value present-p)
+      (gethash stumpwm-name *stumpwm-name->keysym-name-translations*)
+    (declare (ignore present-p))
+    value))
+
+(defun keysym-name->stumpwm-name (keysym-name)
+  (maphash (lambda (k v)
+             (when (equal v keysym-name)
+               (return-from keysym-name->stumpwm-name k)))
+           *stumpwm-name->keysym-name-translations*))
+
+(defun stumpwm-name->keysym (stumpwm-name)
+  "Return the keysym corresponding to STUMPWM-NAME.
+If no mapping for STUMPWM-NAME exists, then fallback by calling
+XKB:KEYSYM-FROM-NAME."
+  (let ((keysym-name (stumpwm-name->keysym-name stumpwm-name)))
+    (xkb:keysym-from-name (or keysym-name stumpwm-name) :no-flags)))
+
+(defun keysym->stumpwm-name (keysym)
+  "Return the stumpwm key name corresponding to KEYSYM.
+If no mapping for the stumpwm key name exists, then fall back by
+callying XKB:KEYSYM-GET-NAME."
+  (let ((keysym-name (xkb:keysym-get-name keysym)))
+    (or (keysym-name->stumpwm-name keysym-name)
+        keysym-name)))
+
+(define-keysym-name "RET" "Return")
+(define-keysym-name "ESC" "Escape")
+(define-keysym-name "TAB" "Tab")
+(define-keysym-name "DEL" "BackSpace")
+(define-keysym-name "SPC" "space")
+(define-keysym-name "!" "exclam")
+(define-keysym-name "\"" "quotedbl")
+(define-keysym-name "$" "dollar")
+(define-keysym-name "£" "sterling")
+(define-keysym-name "%" "percent")
+(define-keysym-name "&" "ampersand")
+(define-keysym-name "'" "quoteright")   ;deprecated
+(define-keysym-name "'" "apostrophe")
+(define-keysym-name "`" "quoteleft")    ;deprecated
+(define-keysym-name "`" "grave")
+(define-keysym-name "&" "ampersand")
+(define-keysym-name "(" "parenleft")
+(define-keysym-name ")" "parenright")
+(define-keysym-name "*" "asterisk")
+(define-keysym-name "+" "plus")
+(define-keysym-name "," "comma")
+(define-keysym-name "-" "minus")
+(define-keysym-name "." "period")
+(define-keysym-name "/" "slash")
+(define-keysym-name ":" "colon")
+(define-keysym-name ";" "semicolon")
+(define-keysym-name "<" "less")
+(define-keysym-name "=" "equal")
+(define-keysym-name ">" "greater")
+(define-keysym-name "?" "question")
+(define-keysym-name "@" "at")
+(define-keysym-name "[" "bracketleft")
+(define-keysym-name "\\" "backslash")
+(define-keysym-name "]" "bracketright")
+(define-keysym-name "^" "asciicircum")
+(define-keysym-name "_" "underscore")
+(define-keysym-name "#" "numbersign")
+(define-keysym-name "{" "braceleft")
+(define-keysym-name "|" "bar")
+(define-keysym-name "}" "braceright")
+(define-keysym-name "~" "asciitilde")
+(define-keysym-name "<" "quoteleft")
+(define-keysym-name ">" "quoteright")
+(define-keysym-name "«" "guillemotleft")
+(define-keysym-name "»" "guillemotright")
+(define-keysym-name "À" "Agrave")
+(define-keysym-name "à" "agrave")
+(define-keysym-name "Ç" "Ccedilla")
+(define-keysym-name "ç" "ccedilla")
+(define-keysym-name "É" "Eacute")
+(define-keysym-name "é" "eacute")
+(define-keysym-name "È" "Egrave")
+(define-keysym-name "è" "egrave")
+(define-keysym-name "Ê" "Ecircumflex")
+(define-keysym-name "ê" "ecircumflex")

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -25,6 +25,10 @@
 			:depends-on ("package")
 			:components ((:file "view-interface")
 				     ))
+	       (:module keyboard
+			:depends-on ("package" "util")
+			:components ((:file "keytrans")
+				     (:file "key")))
 	       (:module tree
 			:depends-on ("package" "log" "util" "interfaces")
 	       		:components ((:file "tree-interface")

--- a/main.lisp
+++ b/main.lisp
@@ -9,7 +9,12 @@
 (cffi:defcallback keyboard-callback :void
     ((seat (:pointer (:struct hrt-seat)))
      (info (:pointer (:struct hrt-keypress-info))))
-  (log-string :debug "keyboard callback called"))
+  (declare (ignore seat))
+  (log-string :debug "keyboard callback called")
+  (cffi:with-foreign-slots ((keysyms modifiers keysyms-len) info (:struct hrt-keypress-info))
+    (dotimes (i keysyms-len)
+      (let ((key (make-key (cffi:mem-aref keysyms :uint32 i) modifiers)))
+	(log-string :trace (lambda (s) (print key s) (print-key key s)))))))
 
 (pushnew #p"~/Programs/mahogany/build/lib64/" cffi:*foreign-library-directories* :test #'equal)
 

--- a/package.lisp
+++ b/package.lisp
@@ -45,10 +45,24 @@
 	   #:fit-view-into-frame
 	   #:leafs-in))
 
+(defpackage #:mahogany/keyboard
+  (:use :cl
+	#:alexandria
+	#:mahogany/log
+	#:mahogany/util)
+  (:export #:key
+	   #:make-key
+	   #:print-key
+	   #:key-mods-p
+	   #:parse-key
+	   #:kbd
+	   #:kbd-parse-error))
+
 (defpackage #:mahogany
   (:use :cl
 	#:alexandria
 	#:mahogany/log
 	#:mahogany/wm-interface
 	#:mahogany/core
-	#:mahogany/tree))
+	#:mahogany/tree
+	#:mahogany/keyboard))

--- a/test/keyboard-tests.lisp
+++ b/test/keyboard-tests.lisp
@@ -1,0 +1,29 @@
+(fiasco:define-test-package #:mahogany-tests/keyboard
+  (:use #:mahogany/keyboard))
+
+(in-package #:mahogany-tests/keyboard)
+
+(defun expand-key-description (code &rest desc)
+  (let ((mask 0))
+    (declare (type (unsigned-byte 32)))
+    (dolist (mod desc)
+      (setf mask (logior mod mask)))
+    (make-key code mask)))
+
+(defmacro expect-key (kbd &key to-be)
+  `(is (equalp (parse-key ,kbd) (expand-key-description ,@to-be))))
+
+(fiasco:deftest test-parse-key ()
+
+  (expect-key "C-l" :to-be (108 mahogany/keyboard::+modifier-ctrl+))
+  (expect-key "C-L" :to-be (76 mahogany/keyboard::+modifier-ctrl+))
+  (expect-key "C-s-l" :to-be (108 mahogany/keyboard::+modifier-ctrl+
+				  mahogany/keyboard::+modifier-super+))
+  (expect-key "C-S-F1" :to-be (65470 mahogany/keyboard::+modifier-ctrl+
+				     mahogany/keyboard::+modifier-shift+))
+  (expect-key "C--" :to-be (45 mahogany/keyboard::+modifier-ctrl+))
+  (expect-key "M-RET" :to-be (65293 mahogany/keyboard::+modifier-alt+))
+  (expect-key "-" :to-be (45))
+
+  (signals kbd-parse-error (parse-key "C-"))
+  (signals kdb-parse-error (parske-key "B-")))


### PR DESCRIPTION
Add key structure and key creation / parsing code. This is taken mostly from `kmap.lisp` and `keytrans.lisp` in stumpwm. 

The major changes are due to using xkbcommon instead of clx. Modifiers are stored in a bit mask in xkbcommon, so we use one here to avoid needing to translated between the two representations.

We also let xkbcommon handle altgr keycodes and key translation in general. I'm not sure if we need to do anything special for altgr keycodes like stumpwm does, but from what  I can see in xkbcommon's documentation, it should take care of that for us. I don't have a keyboard with that key to test.

We are also missing the hyper key: it's not clear to me which modifier that actually is. It will need to be fixed or removed from the parsing functions so it doesn't trip anyone up in the future.