### PR TITLE
Fix wlroots version specifier

### DIFF
--- a/heart/meson.build
+++ b/heart/meson.build
@@ -27,7 +27,7 @@ wayland_protos = dependency('wayland-protocols', version: '>=1.14')
 xkbcommon      = dependency('xkbcommon')
 xcb            = dependency('xcb', required: get_option('xwayland'))
 
-wlroots_version = ['>=0.15.0', '<=0.16.0']
+wlroots_version = ['>=0.16.0', '<0.17.0']
 wlroots_proj = subproject(
 	'wlroots',
 	default_options: ['examples=false'],


### PR DESCRIPTION
Fix boundary to include all 0.16.x releases