### PR TITLE
Autogenerate hrt-bindings.lisp

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing to Mahogany
+
+Want to make a change? All you need to do is submit a pull request!
+This document provides some suggestions and recommendations that will
+make your contribution more successful.
+
+## Additional Tools
+
+If you are changing the C back end's user interface, you will need
+[cl-bindgen](https://github.com/sdilts/cl-bindgen) to generate the
+lisp interface.

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,21 @@ sbcl = sbcl --non-interactive --load $(1)
 
 LISP=sbcl
 
+ROOT := $(shell pwd)
 BUILD_DIR := $(shell pwd)/build
 # In order to not watch heart build files but still detect fresh builds,
 # use files in the internal directory as as placeholder:
 CACHE := $(BUILD_DIR)/internal
 
-$(BUILD_DIR)/mahogany: $(BUILD_DIR)/heart/lib64/libheart.so build-mahogany.lisp FORCE
+# We actually want to watch the build output (build/include/hrt), but those files
+# might not exist
+HRT_INCLUDES = $(shell find $(ROOT)/heart/include/hrt/ -type f)
+
+$(BUILD_DIR)/mahogany: $(BUILD_DIR)/heart/lib64/libheart.so lisp/bindings/hrt-bindings.lisp build-mahogany.lisp FORCE
 	$(call $(LISP), build-mahogany.lisp)
+
+lisp/bindings/hrt-bindings.lisp: $(ROOT)/lisp/bindings/hrt-bindings.yml $(HRT_INCLUDES)
+	cl-bindgen b lisp/bindings/hrt-bindings.yml
 
 $(BUILD_DIR)/heart/lib64/libheart.so: $(CACHE)/wlroots-configured FORCE
 	ninja -C $(BUILD_DIR)/heart

--- a/README.org
+++ b/README.org
@@ -94,3 +94,7 @@ make:
 It is possible to run mahogany in an X11 or Wayland session, and is
 the recommended method of testing at this time. If you do choose to
 run the program in a TTY, press the =ESC= key to exit.
+
+** Contributing / Hacking
+
+See [[CONTRIBUTING.md][CONTRIBUTING.md]]

--- a/heart/include/hrt/hrt_input.h
+++ b/heart/include/hrt/hrt_input.h
@@ -7,6 +7,7 @@
 #include <xkbcommon/xkbcommon.h>
 
 struct hrt_server;
+struct hrt_seat_callbacks;
 
 struct hrt_seat {
   struct hrt_server *server;

--- a/lisp/bindings/hrt-bindings.lisp
+++ b/lisp/bindings/hrt-bindings.lisp
@@ -1,21 +1,6 @@
 (cl:in-package #:hrt)
 
-;; next section imported from file build/include/hrt/hrt_group.h
-
-#| MACRO_DEFINITION
-(defconstant +hrt-group+ ACTUAL_VALUE_HERE)
-|#
-
-(cffi:defcstruct hrt-group
-  (name (:pointer :char))
-  (scene :pointer)
-  (views (:struct wl-list)))
-
 ;; next section imported from file build/include/hrt/hrt_input.h
-
-#| MACRO_DEFINITION
-(defconstant +hrt-hrt-input-h+ ACTUAL_VALUE_HERE)
-|#
 
 (cffi:defcstruct hrt-server)
 
@@ -26,10 +11,10 @@
 
 (cffi:defcstruct hrt-seat
   (server (:pointer (:struct hrt-server)))
-  (cursor :pointer)
-  (keyboard-group :pointer)
-  (xcursor-manager :pointer)
-  (seat :pointer)
+  (cursor :pointer #| (:struct wlr-cursor) |# )
+  (keyboard-group :pointer #| (:struct wlr-keyboard-group) |# )
+  (xcursor-manager :pointer #| (:struct wlr-xcursor-manager) |# )
+  (seat :pointer #| (:struct wlr-seat) |# )
   (inputs (:struct wl-list))
   (new-input (:struct wl-listener))
   (motion (:struct wl-listener))
@@ -43,12 +28,17 @@
   (cursor-image (:pointer :char)))
 
 (cffi:defcstruct hrt-keypress-info
-  (keysyms (:pointer xkb:keysym))
+  (keysyms :pointer #| xkb-keysym-t |# )
   (modifiers :uint32)
   (keysyms-len :size))
 
+(cffi:defcstruct hrt-seat-callbacks
+  (button-event :pointer #| function ptr void (struct hrt_seat *) |#)
+  (wheel-event :pointer #| function ptr void (struct hrt_seat *) |#)
+  (keyboard-keypress-event :pointer #| function ptr _Bool (struct hrt_seat *, struct hrt_keypress_info *) |#))
+
 (cffi:defcstruct hrt-input
-  (wlr-input-device :pointer)
+  (wlr-input-device :pointer #| (:struct wlr-input-device) |# )
   (seat (:pointer (:struct hrt-seat)))
   (link (:struct wl-list))
   (destroy (:struct wl-listener)))
@@ -76,12 +66,8 @@ See themes section of man xcursor(3) to find where to find valid cursor names."
 
 ;; next section imported from file build/include/hrt/hrt_output.h
 
-#| MACRO_DEFINITION
-(defconstant +hrt-hrt-output-h+ ACTUAL_VALUE_HERE)
-|#
-
 (cffi:defcstruct hrt-output
-  (wlr-output :pointer)
+  (wlr-output :pointer #| (:struct wlr-output) |# )
   (server (:pointer (:struct hrt-server)))
   (link (:struct wl-list))
   (frame (:struct wl-listener))
@@ -98,30 +84,29 @@ See themes section of man xcursor(3) to find where to find valid cursor names."
 
 ;; next section imported from file build/include/hrt/hrt_server.h
 
-#| MACRO_DEFINITION
-(defconstant +hrt-hrt-server-h+ ACTUAL_VALUE_HERE)
-|#
-
 (cffi:defcstruct hrt-server
-  (wl-display :pointer)
-  (backend :pointer)
-  (renderer :pointer)
-  (compositor :pointer)
-  (allocator :pointer)
+  (wl-display :pointer #| (:struct wl-display) |# )
+  (backend :pointer #| (:struct wlr-backend) |# )
+  (renderer :pointer #| (:struct wlr-renderer) |# )
+  (compositor :pointer #| (:struct wlr-compositor) |# )
+  (allocator :pointer #| (:struct wlr-allocator) |# )
   (outputs (:struct wl-list))
   (new-output (:struct wl-listener))
-  (output-manager :pointer)
-  (output-layout :pointer)
+  (output-manager :pointer #| (:struct wlr-output-manager-v1) |# )
+  (output-layout :pointer #| (:struct wlr-output-layout) |# )
   (output-manager-apply (:struct wl-listener))
   (output-manager-test (:struct wl-listener))
   (seat (:struct hrt-seat))
+  (scene :pointer #| (:struct wlr-scene) |# )
+  (xdg-shell :pointer #| (:struct wlr-xdg-shell) |# )
+  (new-xdg-surface (:struct wl-listener))
   (output-callback (:pointer (:struct hrt-output-callbacks))))
 
 (cffi:defcfun ("hrt_server_init" hrt-server-init) :bool
   (server (:pointer (:struct hrt-server)))
   (output-callbacks (:pointer (:struct hrt-output-callbacks)))
   (seat-callbacks (:pointer (:struct hrt-seat-callbacks)))
-  (log-level :int))
+  (log-level :int #| enum wlr-log-importance |#))
 
 (cffi:defcfun ("hrt_server_start" hrt-server-start) :bool
   (server (:pointer (:struct hrt-server))))

--- a/lisp/bindings/hrt-bindings.yml
+++ b/lisp/bindings/hrt-bindings.yml
@@ -1,0 +1,15 @@
+output: lisp/bindings/hrt-bindings.lisp
+package: hrt
+pkg-config:
+  - wlroots
+arguments:
+  - "-DWLR_USE_UNSTABLE"
+  - "-Iheart/include"
+files:
+  - build/include/hrt/hrt_input.h
+  - build/include/hrt/hrt_output.h
+  - build/include/hrt/hrt_server.h
+
+pointer-expansion:
+  include:
+    match: "hrt.*"


### PR DESCRIPTION
Use a cl-bindgen batch file to auto-generate the bindings file. There are still a few bugs in cl-bindgen, but it's much better than getting mysterious crashes because you forgot to update bindings after change a header file.

Marked as WIP until developer documentation is added and https://github.com/sdilts/cl-bindgen/issues/8 is fixed.