### PR TITLE
git submodule update --init has more chances to succeed

### DIFF
--- a/README.org
+++ b/README.org
@@ -30,7 +30,7 @@
    submodules. To download them, run the following git command:
 
    #+BEGIN_SRC
-   git submodule init
+   git submodule update --init
    #+END_SRC
 
 *** Backend Library Dependencies


### PR DESCRIPTION
I'm trying to run Mahogany on FreeBSD and git submodule init failed to initialize the submodules in the dependencies folder, whereas git submodule update --init succeeded.

I usually see the latter in wikis rather than the former, and I think mahogany should do it too.