### PR TITLE
Disable FPU exceptions

### DIFF
--- a/lisp/main.lisp
+++ b/lisp/main.lisp
@@ -20,7 +20,14 @@
 				     (xkb:keysym-get-name (mahogany/keyboard::key-keysym key)))))
 	(handle-key-event key seat)))))
 
+(defun disable-fpu-exceptions ()
+  #+sbcl
+  (sb-int:set-floating-point-modes :traps nil)
+  #+ccl
+  (set-fpu-mode :overflow nil))
+
 (defun run-server ()
+  (disable-fpu-exceptions)
   (hrt:load-foreign-libraries)
   (log-init :level :trace)
   (cffi:with-foreign-objects ((output-callbacks '(:struct hrt-output-callbacks))


### PR DESCRIPTION
Normal C programs don't care when FPU exceptions occur. CL environments do, however, so we can get FPU exceptions deep in foreign code that we have no control over. These are usually harmless, so disable them.

See #45.