### PR TITLE
hrt: Add initial surface rendering

### DIFF
--- a/heart/include/hrt/hrt_server.h
+++ b/heart/include/hrt/hrt_server.h
@@ -8,6 +8,7 @@
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_output_management_v1.h>
+#include <wlr/types/wlr_scene.h>
 #include <wlr/render/allocator.h>
 #include <wlr/util/log.h>
 
@@ -20,6 +21,7 @@ struct hrt_server {
   struct wlr_compositor *compositor;
   struct wlr_allocator *allocator;
 
+  struct wlr_scene *scene;
   struct wl_list outputs;
   struct wl_listener new_output;
   struct wlr_output_manager_v1 *output_manager;

--- a/heart/include/hrt/hrt_view.h
+++ b/heart/include/hrt/hrt_view.h
@@ -3,6 +3,7 @@
 
 struct hrt_view {
 	struct wlr_xdg_toplevel *xdg_toplevel;
+	struct wlr_scene_tree *scene_tree;
 	struct wl_listener map;
 	struct wl_listener unmap;
 	struct wl_listener destroy;

--- a/heart/src/xdg_shell.c
+++ b/heart/src/xdg_shell.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <stdlib.h>
 
 #include <wayland-server-core.h>
@@ -31,21 +32,45 @@ static void handle_xdg_toplevel_destroy(struct wl_listener *listener,
 	free(view);
 }
 
-void handle_new_xdg_surface(struct wl_listener *listener, void *data) {
-	wlr_log(WLR_DEBUG, "New XDG Surface recieved");
-	struct hrt_server *server = wl_container_of(listener, server, new_xdg_surface);
-	struct wlr_xdg_surface *xdg_surface = data;
-
-	if(xdg_surface->role == WLR_XDG_SURFACE_ROLE_POPUP) {
-		return;
-	}
-
+struct hrt_view *initialize_view(struct wlr_xdg_surface *xdg_surface, struct wlr_scene_tree *tree) {
+	// This method can only deal with toplevel xdg_surfaces:
+	assert(xdg_surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
 	struct hrt_view *view = calloc(1, sizeof(struct hrt_view));
+	view->xdg_toplevel = xdg_surface->toplevel;
 
+	// Add the view to the scene tree (we should probab
+	view->scene_tree = wlr_scene_xdg_surface_create(tree, view->xdg_toplevel->base);
+	view->scene_tree->node.data = view;
+	xdg_surface->data = view->scene_tree;
+
+	// Listen to events:
 	view->map.notify = handle_xdg_toplevel_map;
 	wl_signal_add(&xdg_surface->events.map, &view->map);
 	view->unmap.notify = handle_xdg_toplevel_unmap;
 	wl_signal_add(&xdg_surface->events.unmap, &view->unmap);
 	view->destroy.notify = handle_xdg_toplevel_destroy;
 	wl_signal_add(&xdg_surface->events.destroy, &view->destroy);
+
+	return view;
+}
+
+
+void handle_new_xdg_surface(struct wl_listener *listener, void *data) {
+	wlr_log(WLR_DEBUG, "New XDG Surface recieved");
+	struct hrt_server *server = wl_container_of(listener, server, new_xdg_surface);
+	struct wlr_xdg_surface *xdg_surface = data;
+
+	if(xdg_surface->role == WLR_XDG_SURFACE_ROLE_POPUP) {
+		// We the front end doesn't need to know about popups; wlroots handles it for us.
+		// we do need to set some internal data so that they can be rendered though.
+		struct wlr_xdg_surface *parent = wlr_xdg_surface_from_wlr_surface(xdg_surface->popup->parent);
+		struct wlr_scene_tree *parent_tree = parent->data;
+		xdg_surface->data = wlr_scene_xdg_surface_create(
+			parent_tree, xdg_surface);
+		return;
+	}
+
+	// At some point, we will want the front end to call this, as it should decide what node
+	// of the scene graph the view gets added to:
+	initialize_view(xdg_surface, &server->scene->tree);
 }

--- a/lisp/bindings/hrt-bindings.lisp
+++ b/lisp/bindings/hrt-bindings.lisp
@@ -90,6 +90,7 @@ See themes section of man xcursor(3) to find where to find valid cursor names."
   (renderer :pointer #| (:struct wlr-renderer) |# )
   (compositor :pointer #| (:struct wlr-compositor) |# )
   (allocator :pointer #| (:struct wlr-allocator) |# )
+  (scene :pointer #| (:struct wlr-scene) |# )
   (outputs (:struct wl-list))
   (new-output (:struct wl-listener))
   (output-manager :pointer #| (:struct wlr-output-manager-v1) |# )
@@ -115,3 +116,12 @@ See themes section of man xcursor(3) to find where to find valid cursor names."
 
 (cffi:defcfun ("hrt_server_finish" hrt-server-finish) :void
   (server (:pointer (:struct hrt-server))))
+
+;; next section imported from file build/include/hrt/hrt_view.h
+
+(cffi:defcstruct hrt-view
+  (xdg-toplevel :pointer #| (:struct wlr-xdg-toplevel) |# )
+  (scene-tree :pointer #| (:struct wlr-scene-tree) |# )
+  (map (:struct wl-listener))
+  (unmap (:struct wl-listener))
+  (destroy (:struct wl-listener)))

--- a/lisp/bindings/hrt-bindings.yml
+++ b/lisp/bindings/hrt-bindings.yml
@@ -9,7 +9,7 @@ files:
   - build/include/hrt/hrt_input.h
   - build/include/hrt/hrt_output.h
   - build/include/hrt/hrt_server.h
-
+  - build/include/hrt/hrt_view.h
 pointer-expansion:
   include:
     match: "hrt.*"


### PR DESCRIPTION
Render surfaces as they are received as a proof of concept.

You can set the WL_DISPLAY environment variable to have an app's surfaces rendered in to the output:

``` sh
WAYLAND_DISPLAY=wayland-1 kcalc
```