### PR TITLE
Initialize views in front end code

### DIFF
--- a/heart/example/main.c
+++ b/heart/example/main.c
@@ -5,17 +5,26 @@
 #include <hrt/hrt_server.h>
 #include <hrt/hrt_output.h>
 #include <hrt/hrt_input.h>
+#include <hrt/hrt_view.h>
 
-void cursor_callback(struct hrt_seat *seat) {
+static void cursor_callback(struct hrt_seat *seat) {
   puts("Cursor callback called");
 }
 
-void output_callback(struct hrt_output *output) {
+static void output_callback(struct hrt_output *output) {
   puts("Output callback called");
 }
 
+static void new_view_callback(struct hrt_view *view) {
+  puts("New view callback called!");
+}
+
+static void view_destroy_callback(struct hrt_view *view) {
+  puts("View destroy callback called");
+}
+
 static bool showNormalCursor = true;
-bool keyboard_callback(struct hrt_seat *seat, struct hrt_keypress_info *info) {
+static bool keyboard_callback(struct hrt_seat *seat, struct hrt_keypress_info *info) {
   puts("Keyboard callback called");
   printf("Modifiers: %d\n", info->modifiers);
   printf("Keys pressed:");
@@ -42,9 +51,14 @@ static const struct hrt_output_callbacks output_callbacks = {
 };
 
 static const struct hrt_seat_callbacks seat_callbacks = {
-  .button_event = &cursor_callback,
-  .wheel_event = &cursor_callback,
-  .keyboard_keypress_event = &keyboard_callback,
+    .button_event = &cursor_callback,
+    .wheel_event = &cursor_callback,
+    .keyboard_keypress_event = &keyboard_callback,
+};
+
+static const struct hrt_view_callbacks view_callbacks = {
+	.new_view = &new_view_callback,
+	.view_destroyed = &view_destroy_callback,
 };
 
 int main(int argc, char *argv[]) {
@@ -52,7 +66,7 @@ int main(int argc, char *argv[]) {
 
   struct hrt_server server;
 
-  if(!hrt_server_init(&server, &output_callbacks, &seat_callbacks, WLR_DEBUG)) {
+  if(!hrt_server_init(&server, &output_callbacks, &seat_callbacks, &view_callbacks, WLR_DEBUG)) {
     return 1;
   }
 

--- a/heart/include/hrt/hrt_server.h
+++ b/heart/include/hrt/hrt_server.h
@@ -35,15 +35,21 @@ struct hrt_server {
   struct wl_listener new_xdg_surface;
 
   const struct hrt_output_callbacks *output_callback;
+  const struct hrt_view_callbacks *view_callbacks;
 };
 
-bool hrt_server_init(struct hrt_server *server, const struct hrt_output_callbacks *output_callbacks,
-					 const struct hrt_seat_callbacks *seat_callbacks, enum wlr_log_importance log_level);
+bool hrt_server_init(struct hrt_server *server,
+					 const struct hrt_output_callbacks *output_callbacks,
+					 const struct hrt_seat_callbacks *seat_callbacks,
+					 const struct hrt_view_callbacks *view_callbacks,
+					 enum wlr_log_importance log_level);
 
 bool hrt_server_start(struct hrt_server *server);
 
 void hrt_server_stop(struct hrt_server *server);
 
 void hrt_server_finish(struct hrt_server *server);
+
+struct wlr_scene_tree *hrt_server_scene_tree(struct hrt_server *server);
 
 #endif

--- a/heart/include/hrt/hrt_view.h
+++ b/heart/include/hrt/hrt_view.h
@@ -1,10 +1,31 @@
+#include <stdint.h>
 #include <wayland-server-core.h>
 #include "hrt/hrt_server.h"
 
 struct hrt_view {
+	struct wlr_xdg_surface *xdg_surface;
 	struct wlr_xdg_toplevel *xdg_toplevel;
+	/*
+	  Contains the tree with the xdg surface tree
+	  plus decorations and that sort of thing.
+	 */
 	struct wlr_scene_tree *scene_tree;
 	struct wl_listener map;
 	struct wl_listener unmap;
 	struct wl_listener destroy;
 };
+
+/**
+ * Fully initialize the view and place it in the given scene tree.
+ **/
+void hrt_view_init(struct hrt_view *view, struct wlr_scene_tree *tree);
+
+/**
+ * Request that this view be the given size. Returns the associated configure serial.
+ **/
+uint32_t hrt_view_set_size(struct hrt_view *view, int width, int height);
+
+/**
+ * Sets the view to the given coordinates relative to its parent.
+ **/
+void hrt_view_set_relative(struct hrt_view *view, int x, int y);

--- a/heart/include/hrt/hrt_view.h
+++ b/heart/include/hrt/hrt_view.h
@@ -2,6 +2,10 @@
 #include <wayland-server-core.h>
 #include "hrt/hrt_server.h"
 
+struct hrt_view;
+
+typedef void (*view_destroy_handler)(struct hrt_view *view);
+
 struct hrt_view {
 	struct wlr_xdg_surface *xdg_surface;
 	struct wlr_xdg_toplevel *xdg_toplevel;
@@ -10,9 +14,21 @@ struct hrt_view {
 	  plus decorations and that sort of thing.
 	 */
 	struct wlr_scene_tree *scene_tree;
+
+	// internal state:
 	struct wl_listener map;
 	struct wl_listener unmap;
 	struct wl_listener destroy;
+	view_destroy_handler destroy_handler;
+};
+
+struct hrt_view_callbacks {
+	/**
+	 * A new view has been created. Must call `hrt_view_init` for the
+	 * view to be displayed.
+	 **/
+	void (*new_view)(struct hrt_view *view);
+	view_destroy_handler view_destroyed;
 };
 
 /**

--- a/heart/src/meson.build
+++ b/heart/src/meson.build
@@ -1,9 +1,10 @@
 hrt_source_files += files(
-  'server.c',
-  'output.c',
-  'input.c',
-  'seat.c',
-  'keyboard.c',
   'cursor.c',
+  'input.c',
+  'keyboard.c',
+  'output.c',
+  'seat.c',
+  'server.c',
+  'view.c',
   'xdg_shell.c',
   )

--- a/heart/src/server.c
+++ b/heart/src/server.c
@@ -15,8 +15,11 @@
 #include <hrt/hrt_output.h>
 #include <hrt/hrt_input.h>
 
-bool hrt_server_init(struct hrt_server *server, const struct hrt_output_callbacks *output_callbacks,
-					 const struct hrt_seat_callbacks *seat_callbacks, enum wlr_log_importance log_level) {
+bool hrt_server_init(struct hrt_server *server,
+					 const struct hrt_output_callbacks *output_callbacks,
+					 const struct hrt_seat_callbacks *seat_callbacks,
+					 const struct hrt_view_callbacks *view_callbacks,
+					 enum wlr_log_importance log_level) {
   wlr_log_init(log_level, NULL);
   server->wl_display = wl_display_create();
   server->backend = wlr_backend_autocreate(server->wl_display);
@@ -46,6 +49,8 @@ bool hrt_server_init(struct hrt_server *server, const struct hrt_output_callback
   wlr_gamma_control_manager_v1_create(server->wl_display);
 
   server->output_layout = wlr_output_layout_create();
+
+  server->view_callbacks = view_callbacks;
 
   server->xdg_shell = wlr_xdg_shell_create(server->wl_display, 3);
   server->new_xdg_surface.notify = handle_new_xdg_surface;
@@ -100,4 +105,8 @@ void hrt_server_stop(struct hrt_server *server) {
 void hrt_server_finish(struct hrt_server *server) {
   wl_display_destroy_clients(server->wl_display);
   wl_display_destroy(server->wl_display);
+}
+
+struct wlr_scene_tree *hrt_server_scene_tree(struct hrt_server *server) {
+	return &server->scene->tree;
 }

--- a/heart/src/view.c
+++ b/heart/src/view.c
@@ -1,0 +1,22 @@
+#include <stdint.h>
+#include <wlr/types/wlr_xdg_shell.h>
+#include <wlr/types/wlr_scene.h>
+
+#include "hrt/hrt_view.h"
+
+void hrt_view_init(struct hrt_view *view, struct wlr_scene_tree *tree) {
+	view->scene_tree = wlr_scene_tree_create(tree);
+
+	struct wlr_scene_tree *xdg_tree =
+		wlr_scene_xdg_surface_create(view->scene_tree, view->xdg_toplevel->base);
+	xdg_tree->node.data = view;
+	view->xdg_surface->data = xdg_tree;
+}
+
+uint32_t hrt_view_set_size(struct hrt_view *view, int width, int height) {
+	return wlr_xdg_toplevel_set_size(view->xdg_toplevel, width, height);
+}
+
+void hrt_view_set_relative(struct hrt_view *view, int x, int y) {
+	wlr_scene_node_set_position(&view->scene_tree->node, x, y);
+}

--- a/lisp/bindings/hrt-bindings.lisp
+++ b/lisp/bindings/hrt-bindings.lisp
@@ -1,5 +1,41 @@
 (cl:in-package #:hrt)
 
+;; next section imported from file build/include/hrt/hrt_view.h
+
+(cffi:defcstruct hrt-view)
+
+(cffi:defctype view-destroy-handler :pointer #| function ptr void (struct hrt_view *) |#)
+
+(cffi:defcstruct hrt-view
+  (xdg-surface :pointer #| (:struct wlr-xdg-surface) |# )
+  (xdg-toplevel :pointer #| (:struct wlr-xdg-toplevel) |# )
+  (scene-tree :pointer #| (:struct wlr-scene-tree) |# )
+  (map (:struct wl-listener))
+  (unmap (:struct wl-listener))
+  (destroy (:struct wl-listener))
+  (destroy-handler view-destroy-handler))
+
+(cffi:defcstruct hrt-view-callbacks
+  (new-view :pointer #| function ptr void (struct hrt_view *) |#)
+  (view-destroyed view-destroy-handler))
+
+(cffi:defcfun ("hrt_view_init" hrt-view-init) :void
+  "Fully initialize the view and place it in the given scene tree."
+  (view (:pointer (:struct hrt-view)))
+  (tree :pointer #| (:struct wlr-scene-tree) |# ))
+
+(cffi:defcfun ("hrt_view_set_size" hrt-view-set-size) :uint32
+  "Request that this view be the given size. Returns the associated configure serial."
+  (view (:pointer (:struct hrt-view)))
+  (width :int)
+  (height :int))
+
+(cffi:defcfun ("hrt_view_set_relative" hrt-view-set-relative) :void
+  "Sets the view to the given coordinates relative to its parent."
+  (view (:pointer (:struct hrt-view)))
+  (x :int)
+  (y :int))
+
 ;; next section imported from file build/include/hrt/hrt_input.h
 
 (cffi:defcstruct hrt-server)
@@ -100,12 +136,14 @@ See themes section of man xcursor(3) to find where to find valid cursor names."
   (seat (:struct hrt-seat))
   (xdg-shell :pointer #| (:struct wlr-xdg-shell) |# )
   (new-xdg-surface (:struct wl-listener))
-  (output-callback (:pointer (:struct hrt-output-callbacks))))
+  (output-callback (:pointer (:struct hrt-output-callbacks)))
+  (view-callbacks (:pointer (:struct hrt-view-callbacks))))
 
 (cffi:defcfun ("hrt_server_init" hrt-server-init) :bool
   (server (:pointer (:struct hrt-server)))
   (output-callbacks (:pointer (:struct hrt-output-callbacks)))
   (seat-callbacks (:pointer (:struct hrt-seat-callbacks)))
+  (view-callbacks (:pointer (:struct hrt-view-callbacks)))
   (log-level :int #| enum wlr-log-importance |#))
 
 (cffi:defcfun ("hrt_server_start" hrt-server-start) :bool
@@ -117,29 +155,5 @@ See themes section of man xcursor(3) to find where to find valid cursor names."
 (cffi:defcfun ("hrt_server_finish" hrt-server-finish) :void
   (server (:pointer (:struct hrt-server))))
 
-;; next section imported from file build/include/hrt/hrt_view.h
-
-(cffi:defcstruct hrt-view
-  (xdg-surface :pointer #| (:struct wlr-xdg-surface) |# )
-  (xdg-toplevel :pointer #| (:struct wlr-xdg-toplevel) |# )
-  (scene-tree :pointer #| (:struct wlr-scene-tree) |# )
-  (map (:struct wl-listener))
-  (unmap (:struct wl-listener))
-  (destroy (:struct wl-listener)))
-
-(cffi:defcfun ("hrt_view_init" hrt-view-init) :void
-  "Fully initialize the view and place it in the given scene tree."
-  (view (:pointer (:struct hrt-view)))
-  (tree :pointer #| (:struct wlr-scene-tree) |# ))
-
-(cffi:defcfun ("hrt_view_set_size" hrt-view-set-size) :uint32
-  "Request that this view be the given size. Returns the associated configure serial."
-  (view (:pointer (:struct hrt-view)))
-  (width :int)
-  (height :int))
-
-(cffi:defcfun ("hrt_view_set_relative" hrt-view-set-relative) :void
-  "Sets the view to the given coordinates relative to its parent."
-  (view (:pointer (:struct hrt-view)))
-  (x :int)
-  (y :int))
+(cffi:defcfun ("hrt_server_scene_tree" hrt-server-scene-tree) :pointer #| (:struct wlr-scene-tree) |#
+  (server (:pointer (:struct hrt-server))))

--- a/lisp/bindings/hrt-bindings.lisp
+++ b/lisp/bindings/hrt-bindings.lisp
@@ -120,8 +120,26 @@ See themes section of man xcursor(3) to find where to find valid cursor names."
 ;; next section imported from file build/include/hrt/hrt_view.h
 
 (cffi:defcstruct hrt-view
+  (xdg-surface :pointer #| (:struct wlr-xdg-surface) |# )
   (xdg-toplevel :pointer #| (:struct wlr-xdg-toplevel) |# )
   (scene-tree :pointer #| (:struct wlr-scene-tree) |# )
   (map (:struct wl-listener))
   (unmap (:struct wl-listener))
   (destroy (:struct wl-listener)))
+
+(cffi:defcfun ("hrt_view_init" hrt-view-init) :void
+  "Fully initialize the view and place it in the given scene tree."
+  (view (:pointer (:struct hrt-view)))
+  (tree :pointer #| (:struct wlr-scene-tree) |# ))
+
+(cffi:defcfun ("hrt_view_set_size" hrt-view-set-size) :uint32
+  "Request that this view be the given size. Returns the associated configure serial."
+  (view (:pointer (:struct hrt-view)))
+  (width :int)
+  (height :int))
+
+(cffi:defcfun ("hrt_view_set_relative" hrt-view-set-relative) :void
+  "Sets the view to the given coordinates relative to its parent."
+  (view (:pointer (:struct hrt-view)))
+  (x :int)
+  (y :int))

--- a/lisp/bindings/hrt-bindings.yml
+++ b/lisp/bindings/hrt-bindings.yml
@@ -6,10 +6,10 @@ arguments:
   - "-DWLR_USE_UNSTABLE"
   - "-Iheart/include"
 files:
+  - build/include/hrt/hrt_view.h
   - build/include/hrt/hrt_input.h
   - build/include/hrt/hrt_output.h
   - build/include/hrt/hrt_server.h
-  - build/include/hrt/hrt_view.h
 pointer-expansion:
   include:
     match: "hrt.*"

--- a/lisp/bindings/package.lisp
+++ b/lisp/bindings/package.lisp
@@ -3,6 +3,11 @@
   (:nicknames #:hrt)
   (:export #:hrt-output-callbacks
 	   #:hrt-seat-callbacks
+	   #:hrt-view-callbacks
+	   #:new-view
+	   #:hrt-view
+	   #:hrt-view-init
+	   #:view-destroyed
 	   #:hrt-seat
 	   #:hrt-output
 	   #:hrt-keypress-info
@@ -10,6 +15,7 @@
 	   #:output-removed
 	   #:button-event #:wheel-event #:keyboard-keypress-event
 	   #:hrt-server
+	   #:hrt-server-scene-tree
 	   #:hrt-server-init
 	   #:hrt-server-start
 	   #:hrt-server-stop

--- a/lisp/state.lisp
+++ b/lisp/state.lisp
@@ -9,7 +9,10 @@
 	      :accessor mahogany-state-key-state)
    (keybindings :type list
 		:initform nil
-		:reader mahogany-state-keybindings)))
+		:reader mahogany-state-keybindings)
+   (views :type list
+	  :initform nil
+	  :reader mahogany-state-views)))
 
 ;; (defmethod initialize-instance :after ((object mahogany-state) &key &allow-other-keys))
 
@@ -31,3 +34,14 @@
   (setf (slot-value state 'keybindings) kmaps)
   (unless (key-state-active-p (mahogany-state-key-state state))
     (server-keystate-reset state)))
+
+(defun mahogany-state-view-add (state view)
+  (declare (type mahogany-state state))
+  (push view (slot-value state 'views))
+  (log-string :trace "Views: ~S" (slot-value state 'views)))
+
+(defun mahogany-state-view-remove (state view)
+  (declare (type mahogany-state state))
+  (with-slots (views) state
+    (setf views (remove view views :test #'cffi:pointer-eq))
+    (log-string :trace "Views: ~S" views)))

--- a/lisp/view.lisp
+++ b/lisp/view.lisp
@@ -1,0 +1,12 @@
+(in-package #:mahogany)
+
+(cffi:defcallback handle-new-view-event :void
+    ((view (:pointer (:struct hrt-view))))
+  (log-string :trace "New view callback called!")
+  (hrt-view-init view (hrt-server-scene-tree (mahogany-state-server *compositor-state*)))
+  (mahogany-state-view-add *compositor-state* view))
+
+(cffi:defcallback handle-view-destroyed-event :void
+    ((view (:pointer (:struct hrt-view))))
+  (log-string :trace "View destroyed callback called!")
+  (mahogany-state-view-remove *compositor-state*  view))

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -40,6 +40,7 @@
 	       			     (:file "frame" :depends-on ("tree-interface"))
 				     (:file "view" :depends-on ("tree-interface"))))
 	       (:file "state" :depends-on ("package"))
+	       (:file "view" :depends-on ("package" "bindings"))
 	       (:file "input" :depends-on ("state" "keyboard"))
 	       (:file "globals" :depends-on ("state" "system"))
 	       (:file "main" :depends-on ("bindings" "keyboard" "input" "package"))))


### PR DESCRIPTION
This allows us to place the views where we need them instead of having them get placed first, then moved.
+ Add the required callback functions
+ Add some wrapper functions so we don't need the lisp code to know about various wlroots functions and structs.