### PR TITLE
Store outputs in frontend

### DIFF
--- a/heart/include/hrt/hrt_output.h
+++ b/heart/include/hrt/hrt_output.h
@@ -10,7 +10,6 @@
 struct hrt_output {
   struct wlr_output *wlr_output;
   struct hrt_server *server;
-  struct wl_list link;
 
   struct wl_listener frame;
   struct wl_listener destroy;

--- a/heart/include/hrt/hrt_server.h
+++ b/heart/include/hrt/hrt_server.h
@@ -22,7 +22,6 @@ struct hrt_server {
   struct wlr_allocator *allocator;
 
   struct wlr_scene *scene;
-  struct wl_list outputs;
   struct wl_listener new_output;
   struct wlr_output_manager_v1 *output_manager;
   struct wlr_output_layout *output_layout;

--- a/heart/src/output.c
+++ b/heart/src/output.c
@@ -21,7 +21,6 @@ static void handle_frame_notify(struct wl_listener *listener, void *data) {
 static void handle_output_destroy(struct wl_listener *listener, void *data) {
   wlr_log(WLR_DEBUG, "Output destroyed");
   struct hrt_output *output = wl_container_of(listener, output, destroy);
-  wl_list_remove(&output->link);
   struct hrt_server *server = output->server;
   server->output_callback->output_removed(output);
 
@@ -70,7 +69,6 @@ static void handle_new_output(struct wl_listener *listener, void *data) {
 
   output->destroy.notify = handle_output_destroy;
   wl_signal_add(&wlr_output->events.destroy, &output->destroy);
-  wl_list_insert(&server->outputs, &output->link);
 
   struct wlr_output_mode *mode = wlr_output_preferred_mode(wlr_output);
   if (mode != NULL) {
@@ -108,8 +106,6 @@ bool hrt_output_init(struct hrt_server *server, const struct hrt_output_callback
   }
   server->output_manager_apply.notify = handle_output_manager_apply;
   server->output_manager_test.notify = handle_output_manager_test;
-
-  wl_list_init(&server->outputs);
 
   // temporary random seed:
   srand(time(0));

--- a/lisp/bindings/hrt-bindings.lisp
+++ b/lisp/bindings/hrt-bindings.lisp
@@ -105,7 +105,6 @@ See themes section of man xcursor(3) to find where to find valid cursor names."
 (cffi:defcstruct hrt-output
   (wlr-output :pointer #| (:struct wlr-output) |# )
   (server (:pointer (:struct hrt-server)))
-  (link (:struct wl-list))
   (frame (:struct wl-listener))
   (destroy (:struct wl-listener))
   (color :float :count 4))
@@ -127,7 +126,6 @@ See themes section of man xcursor(3) to find where to find valid cursor names."
   (compositor :pointer #| (:struct wlr-compositor) |# )
   (allocator :pointer #| (:struct wlr-allocator) |# )
   (scene :pointer #| (:struct wlr-scene) |# )
-  (outputs (:struct wl-list))
   (new-output (:struct wl-listener))
   (output-manager :pointer #| (:struct wlr-output-manager-v1) |# )
   (output-layout :pointer #| (:struct wlr-output-layout) |# )

--- a/lisp/main.lisp
+++ b/lisp/main.lisp
@@ -4,10 +4,6 @@
   (declare (ignore seat))
   (log-string :trace "cursor callback called"))
 
-(cffi:defcallback output-callback :void ((seat (:pointer (:struct hrt-output))))
-  (declare (ignore seat))
-  (log-string :trace "output change callback called"))
-
 (cffi:defcallback keyboard-callback :bool
     ((seat (:pointer (:struct hrt-seat)))
      (info (:pointer (:struct hrt-keypress-info))))
@@ -46,8 +42,8 @@
 			      (view-callbacks '(:struct hrt-view-callbacks))
 			      (server '(:struct hrt-server)))
     (init-callback-struct output-callbacks (:struct hrt-output-callbacks)
-      (output-added output-callback)
-      (output-removed  output-callback))
+      (output-added handle-new-output)
+      (output-removed handle-output-removed))
     (init-callback-struct seat-callbacks (:struct hrt-seat-callbacks)
       (button-event cursor-callback)
       (wheel-event cursor-callback)

--- a/lisp/output.lisp
+++ b/lisp/output.lisp
@@ -1,0 +1,13 @@
+(in-package #:mahogany)
+
+(defstruct (mahogany-output (:constructor make-mahogany-output (hrt-output)))
+  (hrt-output cffi:null-pointer :type cffi:foreign-pointer :read-only t))
+
+(cffi:defcallback handle-new-output :void ((output (:pointer (:struct hrt-output))))
+  (log-string :trace "New output added")
+  (vector-push-extend (make-mahogany-output output) (mahogany-state-outputs *compositor-state*)))
+
+(cffi:defcallback handle-output-removed :void ((output (:pointer (:struct hrt-output))))
+  (log-string :trace "Output removed")
+  (with-accessors ((outputs mahogany-state-outputs)) *compositor-state*
+    (setf outputs (delete output outputs :key #'mahogany-output-hrt-output))))

--- a/lisp/state.lisp
+++ b/lisp/state.lisp
@@ -10,6 +10,12 @@
    (keybindings :type list
 		:initform nil
 		:reader mahogany-state-keybindings)
+   (outputs :type vector
+	    :initform (make-array 0
+				  :element-type 'mahogany-output
+				  :adjustable t
+				  :fill-pointer t)
+	    :accessor mahogany-state-outputs)
    (views :type list
 	  :initform nil
 	  :reader mahogany-state-views)))

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -40,6 +40,7 @@
 	       			     (:file "frame" :depends-on ("tree-interface"))
 				     (:file "view" :depends-on ("tree-interface"))))
 	       (:file "state" :depends-on ("package"))
+	       (:file "output" :depends-on ("package" "bindings"))
 	       (:file "view" :depends-on ("package" "bindings"))
 	       (:file "input" :depends-on ("state" "keyboard"))
 	       (:file "globals" :depends-on ("state" "system"))


### PR DESCRIPTION
Actually listen to output add / remove events so that the front end keeps track of which outputs are attached.