### PR TITLE
Add wezterm and foot to terminal options

### DIFF
--- a/lisp/system.lisp
+++ b/lisp/system.lisp
@@ -18,7 +18,7 @@ Mahogany is running under")
     (UIOP/RUN-PROGRAM:SUBPROCESS-ERROR nil)))
 
 (defun open-terminal ()
-  (let ((programs #("konsole" "gnome-terminal")))
+  (let ((programs #("konsole" "gnome-terminal" "wezterm" "foot")))
     (loop for i across programs
 	  do (alex:when-let ((program (find-program i)))
 	       (uiop:launch-program program)


### PR DESCRIPTION
Hey,

I know this could probably be done in a more configurable manner in the future, but I thought I'd add these two terminal emulators, since these are the ones that I use.