### PR TITLE
Upgrade wlroots to 0.18.1

### DIFF
--- a/heart/include/hrt/hrt_input.h
+++ b/heart/include/hrt/hrt_input.h
@@ -65,9 +65,14 @@ struct hrt_input {
 };
 
 bool hrt_seat_init(struct hrt_seat *seat, struct hrt_server *server,
-		   const struct hrt_seat_callbacks *callbacks);
+                   const struct hrt_seat_callbacks *callbacks);
+void hrt_seat_destroy(struct hrt_seat *seat);
+
 bool hrt_cursor_init(struct hrt_seat *seat, struct hrt_server *server);
+void hrt_cursor_destroy(struct hrt_seat *seat);
+
 void hrt_keyboard_init(struct hrt_seat *seat);
+void hrt_keyboard_destroy(struct hrt_seat *seat);
 
 /**
  * Set the seat's default cursor image to the given cursor name.

--- a/heart/include/hrt/hrt_output.h
+++ b/heart/include/hrt/hrt_output.h
@@ -25,7 +25,7 @@ struct hrt_output_callbacks {
 };
 
 bool hrt_output_init(struct hrt_server *server, const struct hrt_output_callbacks *callbacks);
-
+void hrt_output_destroy(struct hrt_server *server);
 /**
  * Get the effective output resolution of the output that can be used to
  * set the width and height of views.

--- a/heart/include/hrt/hrt_server.h
+++ b/heart/include/hrt/hrt_server.h
@@ -4,6 +4,7 @@
 #include "wlr/backend/session.h"
 #include <stdbool.h>
 
+#include <wayland-server-core.h>
 #include <wayland-server.h>
 #include <wlr/backend.h>
 #include <wlr/types/wlr_compositor.h>
@@ -18,6 +19,7 @@
 struct hrt_server {
   struct wl_display *wl_display;
   struct wlr_backend *backend;
+  struct wl_listener backend_destroy;
   struct wlr_session *session;
   struct wlr_renderer *renderer;
   struct wlr_compositor *compositor;
@@ -35,7 +37,9 @@ struct hrt_server {
   struct hrt_seat seat;
 
   struct wlr_xdg_shell *xdg_shell;
-  struct wl_listener new_xdg_surface;
+  struct wl_listener new_xdg_toplevel;
+  struct wl_listener new_xdg_popup;
+
 
   const struct hrt_output_callbacks *output_callback;
   const struct hrt_view_callbacks *view_callbacks;

--- a/heart/include/hrt/hrt_view.h
+++ b/heart/include/hrt/hrt_view.h
@@ -18,6 +18,7 @@ struct hrt_view {
 	// internal state:
 	struct wl_listener map;
 	struct wl_listener unmap;
+	struct wl_listener commit;
 	struct wl_listener destroy;
 	view_destroy_handler destroy_handler;
 };

--- a/heart/include/xdg_impl.h
+++ b/heart/include/xdg_impl.h
@@ -1,5 +1,13 @@
 #pragma once
 
+#include <wayland-server-core.h>
 #include <wayland-server.h>
+#include "hrt/hrt_server.h"
 
-void handle_new_xdg_surface(struct wl_listener *listener, void *data);
+struct hrt_xdg_popup {
+	struct wlr_xdg_popup *xdg_popup;
+	struct wl_listener commit;
+	struct wl_listener destroy;
+};
+
+bool hrt_xdg_shell_init(struct hrt_server *server);

--- a/heart/meson.build
+++ b/heart/meson.build
@@ -27,7 +27,7 @@ wayland_protos = dependency('wayland-protocols', version: '>=1.14')
 xkbcommon      = dependency('xkbcommon')
 xcb            = dependency('xcb', required: get_option('xwayland'))
 
-wlroots_version = ['>=0.17.0', '<0.18.0']
+wlroots_version = ['>=0.18.0', '<0.19.0']
 wlroots_proj = subproject(
 	'wlroots',
 	default_options: ['examples=false'],

--- a/heart/src/cursor.c
+++ b/heart/src/cursor.c
@@ -67,3 +67,8 @@ bool hrt_cursor_init(struct hrt_seat *seat, struct hrt_server *server) {
 
   return true;
 }
+
+void hrt_cursor_destroy(struct hrt_seat *seat) {
+	wlr_xcursor_manager_destroy(seat->xcursor_manager);
+	wlr_cursor_destroy(seat->cursor);
+}

--- a/heart/src/input.c
+++ b/heart/src/input.c
@@ -123,3 +123,9 @@ bool hrt_seat_init(struct hrt_seat *seat, struct hrt_server *server,
 
   return true;
 }
+
+void hrt_seat_destroy(struct hrt_seat *seat) {
+  wlr_seat_destroy(seat->seat);
+  hrt_keyboard_destroy(seat);
+  hrt_cursor_destroy(seat);
+}

--- a/heart/src/keyboard.c
+++ b/heart/src/keyboard.c
@@ -108,3 +108,7 @@ void hrt_keyboard_init(struct hrt_seat *seat) {
   seat->keyboard_modifiers.notify = seat_handle_modifiers;
   wl_signal_add(&kb->events.modifiers, &seat->keyboard_modifiers);
 }
+
+void hrt_keyboard_destroy(struct hrt_seat *seat) {
+	wlr_keyboard_group_destroy(seat->keyboard_group);
+}

--- a/heart/src/output.c
+++ b/heart/src/output.c
@@ -132,7 +132,7 @@ bool hrt_output_init(struct hrt_server *server, const struct hrt_output_callback
   server->new_output.notify = handle_new_output;
   wl_signal_add(&server->backend->events.new_output, &server->new_output);
 
-  server->output_layout = wlr_output_layout_create();
+  server->output_layout = wlr_output_layout_create(server->wl_display);
   server->scene = wlr_scene_create();
   server->scene_layout = wlr_scene_attach_output_layout(server->scene, server->output_layout);
 
@@ -155,6 +155,7 @@ bool hrt_output_init(struct hrt_server *server, const struct hrt_output_callback
 }
 
 void hrt_output_destroy(struct hrt_server *server) {
-	wlr_scene_node_destroy(&server->scene->tree.node);
-	wlr_output_layout_destroy(server->output_layout);
+  wlr_scene_node_destroy(&server->scene->tree.node);
+  // The output layout  gets destroyed when the display does:
+  // wlr_output_layout_destroy(server->output_layout);
 }

--- a/heart/src/output.c
+++ b/heart/src/output.c
@@ -153,3 +153,8 @@ bool hrt_output_init(struct hrt_server *server, const struct hrt_output_callback
 
   return true;
 }
+
+void hrt_output_destroy(struct hrt_server *server) {
+	wlr_scene_node_destroy(&server->scene->tree.node);
+	wlr_output_layout_destroy(server->output_layout);
+}

--- a/heart/src/server.c
+++ b/heart/src/server.c
@@ -104,6 +104,11 @@ void hrt_server_stop(struct hrt_server *server) {
 
 void hrt_server_finish(struct hrt_server *server) {
   wl_display_destroy_clients(server->wl_display);
+  hrt_output_destroy(server);
+
+  wlr_allocator_destroy(server->allocator);
+  wlr_renderer_destroy(server->renderer);
+  wlr_backend_destroy(server->backend);
   wl_display_destroy(server->wl_display);
 }
 

--- a/heart/src/xdg_shell.c
+++ b/heart/src/xdg_shell.c
@@ -11,6 +11,7 @@
 
 #include <wlr/types/wlr_xdg_shell.h>
 
+
 static void handle_xdg_toplevel_map(struct wl_listener *listener, void *data) {
 	wlr_log(WLR_DEBUG, "XDG Toplevel Mapped!");
 }
@@ -30,15 +31,25 @@ static void handle_xdg_toplevel_destroy(struct wl_listener *listener,
 	wl_list_remove(&view->map.link);
 	wl_list_remove(&view->unmap.link);
 	wl_list_remove(&view->destroy.link);
+	wl_list_remove(&view->commit.link);
 
 	free(view);
 }
 
-static struct hrt_view *create_view_from_xdg_surface(struct wlr_xdg_surface *xdg_surface, view_destroy_handler destroy_handler) {
-	// This method can only deal with toplevel xdg_surfaces:
-	assert(xdg_surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
+static void handle_xdg_toplevel_commit(struct wl_listener *listener,
+                                       void *data) {
+	struct hrt_view *view = wl_container_of(listener, view, commit);
+	if (view->xdg_toplevel->base->initial_commit) {
+		// TODO: we probably want to explicitly pick the size here:
+		wlr_xdg_toplevel_set_size(view->xdg_toplevel, 0,0);
+	}
+}
+
+static struct hrt_view *create_view_from_xdg_surface(struct wlr_xdg_toplevel *xdg_toplevel, view_destroy_handler destroy_handler) {
 	struct hrt_view *view = calloc(1, sizeof(struct hrt_view));
-	view->xdg_toplevel = xdg_surface->toplevel;
+	view->xdg_toplevel = xdg_toplevel;
+	struct wlr_xdg_surface *xdg_surface = xdg_toplevel->base;
+	// TODO: Maybe remove view->xdg_surface? We can get to it via the toplevel.
 	view->xdg_surface = xdg_surface;
 	view->destroy_handler = destroy_handler;
 
@@ -48,38 +59,79 @@ static struct hrt_view *create_view_from_xdg_surface(struct wlr_xdg_surface *xdg
 	wl_signal_add(&xdg_surface->surface->events.unmap, &view->unmap);
 	view->destroy.notify = handle_xdg_toplevel_destroy;
 	wl_signal_add(&xdg_surface->events.destroy, &view->destroy);
+	view->commit.notify = handle_xdg_toplevel_commit;
+	wl_signal_add(&xdg_toplevel->base->surface->events.commit, &view->commit);
+	// TODO: We need to listen to the commit event so we can send the configure message on first commit
 
 	return view;
 }
 
-void handle_new_xdg_surface(struct wl_listener *listener, void *data) {
-	wlr_log(WLR_DEBUG, "New XDG Surface recieved");
-	struct hrt_server *server = wl_container_of(listener, server, new_xdg_surface);
-	struct wlr_xdg_surface *xdg_surface = data;
-
-	if(xdg_surface->role == WLR_XDG_SURFACE_ROLE_POPUP) {
-		// The front end doesn't need to know about popups; wlroots handles it for us.
-		// we do need to set some internal data so that they can be rendered though.
-		struct wlr_xdg_surface *parent = wlr_xdg_surface_try_from_wlr_surface(xdg_surface->popup->parent);
-		struct wlr_scene_tree *parent_tree = parent->data;
-		// The parent view might not have been initizlized properly. In that case, it
-		// isn't being displayed, so we just ignore it:
-		if (parent_tree) {
-			xdg_surface->data = wlr_scene_xdg_surface_create(parent_tree, xdg_surface);
-		} else {
-			wlr_log(WLR_ERROR, "Encountered XDG Popup without properly configured parent");
-		}
-		return;
+static void handle_xdg_popup_commit(struct wl_listener *listener, void *data) {
+	struct hrt_xdg_popup *popup = wl_container_of(listener, popup, commit);
+	if (popup->xdg_popup->base->initial_commit) {
+		wlr_xdg_surface_schedule_configure(popup->xdg_popup->base);
 	}
+}
 
-	// Initialization occurs in two steps so the consumer can place the view where it needs to go;
+static void handle_xdg_popup_destroy(struct wl_listener *listener, void *data) {
+	struct hrt_xdg_popup *popup = wl_container_of(listener, popup, destroy);
+
+	wl_list_remove(&popup->destroy.link);
+	wl_list_remove(&popup->commit.link);
+
+	free(popup);
+}
+
+static void handle_new_xdg_popup(struct wl_listener *listener, void *data) {
+  wlr_log(WLR_DEBUG, "New xdg popup received");
+  struct hrt_server *server = wl_container_of(listener, server, new_xdg_popup);
+  struct wlr_xdg_popup *xdg_popup = data;
+
+  // The front end doesn't need to know about popups; wlroots handles it for us.
+  // we do need to set some internal data so that they can be rendered though.
+  struct wlr_xdg_surface *parent = wlr_xdg_surface_try_from_wlr_surface(xdg_popup->parent);
+  struct wlr_scene_tree *parent_tree = parent->data;
+
+  // The parent view might not have been initizlized properly. In that case, it
+  // isn't being displayed, so we just ignore it:
+  if (parent_tree) {
+	  xdg_popup->base->data = wlr_scene_xdg_surface_create(parent_tree, xdg_popup->base);
+	  struct hrt_xdg_popup *popup = calloc(1, sizeof(*popup));
+	  popup->commit.notify = handle_xdg_popup_commit;
+	  wl_signal_add(&xdg_popup->base->surface->events.commit,
+					&popup->commit);
+
+	  popup->destroy.notify = handle_xdg_popup_destroy;
+	  wl_signal_add(&xdg_popup->events.destroy, &popup->destroy);
+
+  } else {
+	  wlr_log(WLR_ERROR, "Encountered XDG Popup without properly configured parent");
+  }
+}
+
+static void handle_new_xdg_toplevel(struct wl_listener *listener, void * data) {
+	wlr_log(WLR_DEBUG, "New XDG Popup received");
+	struct hrt_server *server =
+		wl_container_of(listener, server, new_xdg_toplevel);
+	struct wlr_xdg_toplevel *toplevel = data;
+  	// Initialization occurs in two steps so the consumer can place the view where it needs to go;
 	// in order to create a scene tree node, it must have a parent.
 	// We don't have it until the callback.
-	struct hrt_view *view = create_view_from_xdg_surface(xdg_surface,
+	struct hrt_view *view = create_view_from_xdg_surface(toplevel,
 														 server->view_callbacks->view_destroyed);
 	// At some point, we will want the front end to call this, as it should decide what node
 	// of the scene graph the view gets added to:
 	// hrt_view_init(view, &server->scene->tree);
 
 	server->view_callbacks->new_view(view);
+}
+
+bool hrt_xdg_shell_init(struct hrt_server *server) {
+  server->xdg_shell = wlr_xdg_shell_create(server->wl_display, 3);
+  server->new_xdg_popup.notify = handle_new_xdg_popup;
+  wl_signal_add(&server->xdg_shell->events.new_popup, &server->new_xdg_popup);
+
+  server->new_xdg_toplevel.notify = handle_new_xdg_toplevel;
+  wl_signal_add(&server->xdg_shell->events.new_toplevel, &server->new_xdg_toplevel);
+  return true;
 }

--- a/lisp/bindings/hrt-bindings.lisp
+++ b/lisp/bindings/hrt-bindings.lisp
@@ -12,6 +12,7 @@
   (scene-tree :pointer #| (:struct wlr-scene-tree) |# )
   (map (:struct wl-listener))
   (unmap (:struct wl-listener))
+  (commit (:struct wl-listener))
   (destroy (:struct wl-listener))
   (destroy-handler view-destroy-handler))
 
@@ -159,6 +160,7 @@ set the width and height of views."
 (cffi:defcstruct hrt-server
   (wl-display :pointer #| (:struct wl-display) |# )
   (backend :pointer #| (:struct wlr-backend) |# )
+  (backend-destroy (:struct wl-listener))
   (session :pointer #| (:struct wlr-session) |# )
   (renderer :pointer #| (:struct wlr-renderer) |# )
   (compositor :pointer #| (:struct wlr-compositor) |# )
@@ -173,7 +175,8 @@ set the width and height of views."
   (output-manager-destroy (:struct wl-listener))
   (seat (:struct hrt-seat))
   (xdg-shell :pointer #| (:struct wlr-xdg-shell) |# )
-  (new-xdg-surface (:struct wl-listener))
+  (new-xdg-toplevel (:struct wl-listener))
+  (new-xdg-popup (:struct wl-listener))
   (output-callback (:pointer (:struct hrt-output-callbacks)))
   (view-callbacks (:pointer (:struct hrt-view-callbacks))))
 

--- a/lisp/bindings/hrt-bindings.lisp
+++ b/lisp/bindings/hrt-bindings.lisp
@@ -84,11 +84,20 @@
   (server (:pointer (:struct hrt-server)))
   (callbacks (:pointer (:struct hrt-seat-callbacks))))
 
+(cffi:defcfun ("hrt_seat_destroy" hrt-seat-destroy) :void
+  (seat (:pointer (:struct hrt-seat))))
+
 (cffi:defcfun ("hrt_cursor_init" hrt-cursor-init) :bool
   (seat (:pointer (:struct hrt-seat)))
   (server (:pointer (:struct hrt-server))))
 
+(cffi:defcfun ("hrt_cursor_destroy" hrt-cursor-destroy) :void
+  (seat (:pointer (:struct hrt-seat))))
+
 (cffi:defcfun ("hrt_keyboard_init" hrt-keyboard-init) :void
+  (seat (:pointer (:struct hrt-seat))))
+
+(cffi:defcfun ("hrt_keyboard_destroy" hrt-keyboard-destroy) :void
   (seat (:pointer (:struct hrt-seat))))
 
 (cffi:defcfun ("hrt_seat_set_cursor_img" hrt-seat-set-cursor-img) :void
@@ -117,6 +126,9 @@ See themes section of man xcursor(3) to find where to find valid cursor names."
 (cffi:defcfun ("hrt_output_init" hrt-output-init) :bool
   (server (:pointer (:struct hrt-server)))
   (callbacks (:pointer (:struct hrt-output-callbacks))))
+
+(cffi:defcfun ("hrt_output_destroy" hrt-output-destroy) :void
+  (server (:pointer (:struct hrt-server))))
 
 (cffi:defcfun ("hrt_output_resolution" hrt-output-resolution) :void
   "Get the effective output resolution of the output that can be used to

--- a/lisp/bindings/hrt-libs.lisp
+++ b/lisp/bindings/hrt-libs.lisp
@@ -4,7 +4,7 @@
   (:unix "libheart.so"))
 
 (cffi:define-foreign-library libwlroots
-  (:unix "libwlroots.so"))
+  (:unix "libwlroots-0.18.so"))
 
 (defun load-foreign-libraries ()
   (cffi:use-foreign-library libwlroots)


### PR DESCRIPTION
In order for the program to exit cleanly with the new version, various wlroots objects needed to be cleaned up before destroying the display.

All of the other changes are explained in the wlroots release notes: https://gitlab.freedesktop.org/wlroots/wlroots/-/releases/0.18.0.