### PR TITLE
Add new views to the frame tree

### DIFF
--- a/heart/include/hrt/hrt_view.h
+++ b/heart/include/hrt/hrt_view.h
@@ -7,6 +7,7 @@ struct hrt_view;
 typedef void (*view_destroy_handler)(struct hrt_view *view);
 
 struct hrt_view {
+	int width, height;
 	struct wlr_xdg_surface *xdg_surface;
 	struct wlr_xdg_toplevel *xdg_toplevel;
 	/*

--- a/heart/src/view.c
+++ b/heart/src/view.c
@@ -5,7 +5,9 @@
 #include "hrt/hrt_view.h"
 
 void hrt_view_init(struct hrt_view *view, struct wlr_scene_tree *tree) {
-	view->scene_tree = wlr_scene_tree_create(tree);
+  view->scene_tree = wlr_scene_tree_create(tree);
+  view->width = 0;
+  view->height = 0;
 
 	struct wlr_scene_tree *xdg_tree =
 		wlr_scene_xdg_surface_create(view->scene_tree, view->xdg_toplevel->base);
@@ -14,7 +16,12 @@ void hrt_view_init(struct hrt_view *view, struct wlr_scene_tree *tree) {
 }
 
 uint32_t hrt_view_set_size(struct hrt_view *view, int width, int height) {
-	return wlr_xdg_toplevel_set_size(view->xdg_toplevel, width, height);
+  view->width = width;
+  view->height = height;
+  if(view->xdg_surface->initialized) {
+	  return wlr_xdg_toplevel_set_size(view->xdg_toplevel, width, height);
+  }
+  return 0;
 }
 
 void hrt_view_set_relative(struct hrt_view *view, int x, int y) {

--- a/heart/src/xdg_shell.c
+++ b/heart/src/xdg_shell.c
@@ -40,8 +40,7 @@ static void handle_xdg_toplevel_commit(struct wl_listener *listener,
                                        void *data) {
 	struct hrt_view *view = wl_container_of(listener, view, commit);
 	if (view->xdg_toplevel->base->initial_commit) {
-		// TODO: we probably want to explicitly pick the size here:
-		wlr_xdg_toplevel_set_size(view->xdg_toplevel, 0,0);
+		wlr_xdg_toplevel_set_size(view->xdg_toplevel, view->width,view->height);
 	}
 }
 

--- a/lisp/bindings/hrt-bindings.lisp
+++ b/lisp/bindings/hrt-bindings.lisp
@@ -7,6 +7,8 @@
 (cffi:defctype view-destroy-handler :pointer #| function ptr void (struct hrt_view *) |#)
 
 (cffi:defcstruct hrt-view
+  (width :int)
+  (height :int)
   (xdg-surface :pointer #| (:struct wlr-xdg-surface) |# )
   (xdg-toplevel :pointer #| (:struct wlr-xdg-toplevel) |# )
   (scene-tree :pointer #| (:struct wlr-scene-tree) |# )

--- a/lisp/bindings/package.lisp
+++ b/lisp/bindings/package.lisp
@@ -1,12 +1,12 @@
 (defpackage #:mahogany/core
   (:use :cl #:wayland-server-core #:xkb)
+  (:local-nicknames (#:mh/interface #:mahogany/wm-interface))
   (:nicknames #:hrt)
   (:export #:hrt-output-callbacks
 	   #:hrt-seat-callbacks
 	   #:hrt-view-callbacks
 	   #:new-view
 	   #:hrt-view
-	   #:hrt-view-init
 	   #:view-destroyed
 	   #:hrt-seat
 	   #:hrt-output
@@ -22,6 +22,10 @@
 	   ;; output methods:
 	   #:output-resolution
 	   #:output-position
+	   ;; view-methods
+	   #:view
+	   #:view-init
+	   #:view-hrt-view
 	   ;; seat callbacks
 	   #:button-event #:wheel-event #:keyboard-keypress-event
 	   #:hrt-server

--- a/lisp/bindings/wrappers.lisp
+++ b/lisp/bindings/wrappers.lisp
@@ -22,7 +22,7 @@
 (defun view-init (hrt-view scene-tree)
   (let ((view (%make-view hrt-view)))
     (hrt-view-init hrt-view scene-tree)
-    view))
+    (the view view)))
 
 (defmethod mh/interface:set-dimensions ((view view) width height)
   (hrt-view-set-size (view-hrt-view view) width height))

--- a/lisp/bindings/wrappers.lisp
+++ b/lisp/bindings/wrappers.lisp
@@ -15,3 +15,17 @@
   (declare (type cffi:foreign-pointer output))
   (with-return-by-value ((x :int) (y :int))
     (hrt-output-position output x y)))
+
+(defstruct (view (:constructor %make-view (hrt-view)))
+  (hrt-view (cffi:null-pointer) :type cffi:foreign-pointer :read-only t))
+
+(defun view-init (hrt-view scene-tree)
+  (let ((view (%make-view hrt-view)))
+    (hrt-view-init hrt-view scene-tree)
+    view))
+
+(defmethod mh/interface:set-dimensions ((view view) width height)
+  (hrt-view-set-size (view-hrt-view view) width height))
+
+(defmethod mh/interface:set-position ((view view) x y)
+  (hrt-view-set-relative (view-hrt-view view) x y))

--- a/lisp/group.lisp
+++ b/lisp/group.lisp
@@ -22,9 +22,9 @@ to match."
 		 mh-output
 	       (alexandria:when-let ((tree (gethash full-name output-map)))
 		 (multiple-value-bind (x y) (hrt:output-position hrt-output)
-		   (mahogany/tree:set-position (root-tree tree) x y))
+		   (set-position (root-tree tree) x y))
 		 (multiple-value-bind (width height) (hrt:output-resolution hrt-output)
-		   (mahogany/tree:set-dimensions (root-tree tree) width height)))))))
+		   (set-dimensions (root-tree tree) width height)))))))
 
 
 (defun group-remove-output (group output)

--- a/lisp/group.lisp
+++ b/lisp/group.lisp
@@ -44,11 +44,12 @@ to match."
 	  do (when-let ((empty (find-empty-frame tree)))
 	       (log-string :trace "Found frame for view")
 	       (put-view-in-frame view empty)
+	       (log-string :trace "Current tree: ~S" (root-tree tree))
 	       (return-from group-add-view)))
     ;; TODO: get algorithm to place new views so they can be seen:
-    (log-string :trace "Could not find frame for new view")))
+    (log-string :error "Could not find frame for new view")))
 
 (defun group-remove-view (group view)
   (declare (type mahogany-group group))
   (with-accessors ((view-list mahogany-group-views)) group
-    (setf view-list (remove view view-list :test equalp))))
+    (setf view-list (remove view view-list :test #'equalp))))

--- a/lisp/interfaces/view-interface.lisp
+++ b/lisp/interfaces/view-interface.lisp
@@ -5,40 +5,10 @@
 
 (in-package #:mahogany/wm-interface)
 
-(defclass view ()
-  ((x :initarg :view-x
-      :reader view-x
-      :initform 0
-      :type fixnum
-      :documentation "Location of surface in output coordinates")
-   (y :initarg :view-y
-      :reader view-y
-      :initform 0
-      :type fixnum
-      :documentation "Location of surface in output coordinates")
-   (opacity :initarg :opacity
-	    :accessor view-opacity
-	    :type single-float
-	    :initform 1.0)))
+(defgeneric set-position (object x y)
+  (:documentation "Set the x-y position of the object. If the object
+is part of a scene tree, this sets the position relative to the
+parent object."))
 
 (defgeneric set-dimensions (object width height)
-  (:documentation "Set the dimensions of the the object.")
-  (declare (optimize (speed 3))))
-
-(defgeneric (setf view-x) (new-value view)
-  (:documentation "Set the x coordinate of the view")
-  (:method (new-x (view view))
-    (setf (slot-value view 'x) (truncate new-x))))
-
-(defgeneric (setf view-y) (new-value view)
-  (:documentation "Set the y coordinate of the view")
-  (:method (new-y (view view))
-    (setf (slot-value view 'y) (truncate new-y))))
-
-(defmethod print-object ((object view) stream)
-  (print-unreadable-object (object stream :type t)
-    (with-slots (x y) object
-      (format stream ":x ~S :y ~S" x y))))
-
-(defgeneric set-position (object x y)
-  (:documentation "Set the x-y position of the object"))
+  (:documentation "Set the dimensions of the the object."))

--- a/lisp/objects.lisp
+++ b/lisp/objects.lisp
@@ -31,6 +31,6 @@
    (groups :type vector
 	   :accessor mahogany-state-groups
 	   :initform (make-array 0 :element-type 'mahogany-group :adjustable t :fill-pointer t))
-   (views :type list
-	  :initform nil
+   (views :type hash-table
+	  :initform (make-hash-table)
 	  :reader mahogany-state-views)))

--- a/lisp/state.lisp
+++ b/lisp/state.lisp
@@ -55,7 +55,8 @@
 	  do (group-reconfigure-outputs g (mahogany-state-outputs state)))))
 
 (defun mahogany-state-view-add (state view)
-  (declare (type mahogany-state state))
+  (declare (type mahogany-state state)
+	   (type hrt:view view))
   (push view (slot-value state 'views))
   (group-add-view (mahogany-current-group state) view)
   (log-string :trace "Views: ~S" (slot-value state 'views)))
@@ -64,5 +65,5 @@
   (declare (type mahogany-state state))
   (with-slots (views) state
     (group-remove-view (mahogany-current-group state) view)
-    (setf views (remove view views :test #'cffi:pointer-eq))
+    (setf views (remove view views :test #'cffi:pointer-eq :key #'view-hrt-view))
     (log-string :trace "Views: ~S" views)))

--- a/lisp/tree/package.lisp
+++ b/lisp/tree/package.lisp
@@ -32,10 +32,8 @@
 	   #:get-empty-frames
 	   #:get-populated-frames
 	   #:root-frame-p
+	   ;; View-frame functions / objects
 	   #:view-frame
 	   #:frame-view
-	   #:frame-modes
-	   #:fit-view-into-frame
-	   #:leafs-in
-	   #:set-dimensions
-	   #:set-position))
+	   #:put-view-in-frame
+	   #:leafs-in))

--- a/lisp/tree/view.lisp
+++ b/lisp/tree/view.lisp
@@ -4,15 +4,19 @@
   ((view :initarg :view
 	 :accessor frame-view
 	 :initform nil
-	 :documentation "The client of the frame")
-   (modes :initarg :modes
-	  :accessor frame-modes)))
+	 :type (or hrt:view null)
+	 :documentation "The client of the frame")))
 
 (defun fit-view-into-frame (view frame)
   "Make the view fit in the dimensions of the frame"
-  (setf (view-x view) (round (frame-x frame))
-	(view-y view) (round (frame-y frame)))
+  (set-position view (round (frame-x frame)) (round (frame-y frame)))
   (set-dimensions view (round (frame-width frame)) (round (frame-height frame))))
+
+(defun put-view-in-frame (view view-frame)
+  "Place the view in the frame and make it have the same dimensions
+and position as the frame"
+  (setf (frame-view view-frame) view)
+  (fit-view-into-frame view view-frame))
 
 (defmethod print-object ((object view-frame) stream)
   (print-unreadable-object (object stream :type t)
@@ -23,15 +27,19 @@
 
 (defmethod (setf frame-x) :before (new-x (frame view-frame))
   (when (frame-view frame)
-    (setf (view-x (frame-view frame)) (round new-x))))
+    (set-position (frame-view frame) (round new-x) (round (frame-y frame)))))
 
 (defmethod (setf frame-y) :before (new-y (frame view-frame))
   (when (frame-view frame)
-    (setf (view-y (frame-view frame)) (round new-y))))
+    (set-position (frame-view frame) (round (frame-x frame)) (round new-y))))
 
 (defmethod set-dimensions :before ((frame view-frame) width height)
   (when (frame-view frame)
     (set-dimensions (frame-view frame) (round width) (round height))))
+
+(defmethod set-position :before ((frame view-frame) x y)
+  (when (frame-view frame)
+    (set-position (frame-view frame) (round x) (round y))))
 
 (defmethod (setf frame-width) :before (new-width (frame view-frame))
   (when (frame-view frame)

--- a/lisp/view.lisp
+++ b/lisp/view.lisp
@@ -3,7 +3,7 @@
 (cffi:defcallback handle-new-view-event :void
     ((view (:pointer (:struct hrt-view))))
   (log-string :trace "New view callback called!")
-  (hrt-view-init view (hrt-server-scene-tree (mahogany-state-server *compositor-state*)))
+  (hrt:view-init view (hrt-server-scene-tree (mahogany-state-server *compositor-state*)))
   (mahogany-state-view-add *compositor-state* view))
 
 (cffi:defcallback handle-view-destroyed-event :void

--- a/lisp/view.lisp
+++ b/lisp/view.lisp
@@ -3,8 +3,8 @@
 (cffi:defcallback handle-new-view-event :void
     ((view (:pointer (:struct hrt-view))))
   (log-string :trace "New view callback called!")
-  (hrt:view-init view (hrt-server-scene-tree (mahogany-state-server *compositor-state*)))
-  (mahogany-state-view-add *compositor-state* view))
+  (let ((new-view (hrt:view-init view (hrt-server-scene-tree (mahogany-state-server *compositor-state*)))))
+    (mahogany-state-view-add *compositor-state* new-view)))
 
 (cffi:defcallback handle-view-destroyed-event :void
     ((view (:pointer (:struct hrt-view))))

--- a/lisp/view.lisp
+++ b/lisp/view.lisp
@@ -3,8 +3,7 @@
 (cffi:defcallback handle-new-view-event :void
     ((view (:pointer (:struct hrt-view))))
   (log-string :trace "New view callback called!")
-  (let ((new-view (hrt:view-init view (hrt-server-scene-tree (mahogany-state-server *compositor-state*)))))
-    (mahogany-state-view-add *compositor-state* new-view)))
+  (mahogany-state-view-add *compositor-state* view))
 
 (cffi:defcallback handle-view-destroyed-event :void
     ((view (:pointer (:struct hrt-view))))


### PR DESCRIPTION
Add new views to the frame tree instead of just sticking them anywhere. With this, it's possible to see that that the output layout change handler is working properly.