### PR TITLE
Add initial view focusing code

### DIFF
--- a/heart/include/hrt/hrt_server.h
+++ b/heart/include/hrt/hrt_server.h
@@ -60,4 +60,6 @@ void hrt_server_finish(struct hrt_server *server);
 
 struct wlr_scene_tree *hrt_server_scene_tree(struct hrt_server *server);
 
+struct hrt_seat *hrt_server_seat(struct hrt_server *server);
+
 #endif

--- a/heart/include/hrt/hrt_view.h
+++ b/heart/include/hrt/hrt_view.h
@@ -1,10 +1,12 @@
 #include <stdint.h>
 #include <wayland-server-core.h>
-#include "hrt/hrt_server.h"
+#include <hrt/hrt_server.h>
+#include "hrt_input.h"
 
 struct hrt_view;
 
 typedef void (*view_destroy_handler)(struct hrt_view *view);
+typedef void (*new_view_handler)(struct hrt_view *view);
 
 struct hrt_view {
 	int width, height;
@@ -21,6 +23,7 @@ struct hrt_view {
 	struct wl_listener unmap;
 	struct wl_listener commit;
 	struct wl_listener destroy;
+	new_view_handler new_view_handler;
 	view_destroy_handler destroy_handler;
 };
 
@@ -29,7 +32,7 @@ struct hrt_view_callbacks {
 	 * A new view has been created. Must call `hrt_view_init` for the
 	 * view to be displayed.
 	 **/
-	void (*new_view)(struct hrt_view *view);
+	new_view_handler new_view;
 	view_destroy_handler view_destroyed;
 };
 
@@ -47,3 +50,14 @@ uint32_t hrt_view_set_size(struct hrt_view *view, int width, int height);
  * Sets the view to the given coordinates relative to its parent.
  **/
 void hrt_view_set_relative(struct hrt_view *view, int x, int y);
+
+/**
+ * Focus the given view and perform the needed tasks to make
+ * it visible to the user.
+ **/
+void hrt_view_focus(struct hrt_view *view, struct hrt_seat *seat);
+
+/**
+ * Unfocus the given view.
+ **/
+void hrt_view_unfocus(struct hrt_view *view, struct hrt_seat *seat);

--- a/heart/src/input.c
+++ b/heart/src/input.c
@@ -116,16 +116,17 @@ bool hrt_seat_init(struct hrt_seat *seat, struct hrt_server *server,
   seat->new_input.notify = new_input_notify;
   wl_signal_add(&server->backend->events.new_input, &seat->new_input);
 
-  if(!hrt_cursor_init(seat, server)) {
-     return false;
-  }
-  hrt_keyboard_init(seat);
-
   seat->seat = wlr_seat_create(server->wl_display, "seat-0");
   if(!seat->seat) {
     return false;
   }
   wl_list_init(&seat->inputs);
+
+  if(!hrt_cursor_init(seat, server)) {
+     return false;
+  }
+
+  hrt_keyboard_init(seat);
 
   seat->cursor_image = "left_ptr";
 

--- a/heart/src/keyboard.c
+++ b/heart/src/keyboard.c
@@ -107,6 +107,8 @@ void hrt_keyboard_init(struct hrt_seat *seat) {
   wl_signal_add(&kb->events.key, &seat->keyboard_key);
   seat->keyboard_modifiers.notify = seat_handle_modifiers;
   wl_signal_add(&kb->events.modifiers, &seat->keyboard_modifiers);
+
+  wlr_seat_set_keyboard(seat->seat, kb);
 }
 
 void hrt_keyboard_destroy(struct hrt_seat *seat) {

--- a/heart/src/server.c
+++ b/heart/src/server.c
@@ -126,3 +126,7 @@ void hrt_server_finish(struct hrt_server *server) {
 struct wlr_scene_tree *hrt_server_scene_tree(struct hrt_server *server) {
 	return &server->scene->tree;
 }
+
+struct hrt_seat *hrt_server_seat(struct hrt_server *server) {
+	return &server->seat;
+}

--- a/heart/src/view.c
+++ b/heart/src/view.c
@@ -1,10 +1,15 @@
+#include <assert.h>
 #include <stdint.h>
+#include <time.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/types/wlr_scene.h>
 
+#include "hrt/hrt_input.h"
 #include "hrt/hrt_view.h"
+#include "wlr/util/log.h"
 
 void hrt_view_init(struct hrt_view *view, struct wlr_scene_tree *tree) {
+  assert(view->scene_tree == NULL && "View already initialized");
   view->scene_tree = wlr_scene_tree_create(tree);
   view->width = 0;
   view->height = 0;
@@ -26,4 +31,32 @@ uint32_t hrt_view_set_size(struct hrt_view *view, int width, int height) {
 
 void hrt_view_set_relative(struct hrt_view *view, int x, int y) {
 	wlr_scene_node_set_position(&view->scene_tree->node, x, y);
+}
+
+void hrt_view_focus(struct hrt_view *view, struct hrt_seat *seat) {
+  wlr_log(WLR_DEBUG, "view focused!");
+  struct wlr_seat *wlr_seat = seat->seat;
+  struct wlr_surface *prev_surface = wlr_seat->keyboard_state.focused_surface;
+  struct wlr_xdg_toplevel *toplevel = view->xdg_toplevel;
+
+  if (prev_surface == toplevel->base->surface) {
+	  // Don't re-focus an already focused surface:
+	  return;
+  }
+  struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(wlr_seat);
+
+  wlr_xdg_toplevel_set_activated(toplevel, true);
+
+  if (keyboard != NULL) {
+	wlr_log(WLR_DEBUG, "Keyboard enter!");
+    wlr_seat_keyboard_notify_enter(wlr_seat, toplevel->base->surface,
+                                   keyboard->keycodes, keyboard->num_keycodes,
+                                   &keyboard->modifiers);
+  }
+}
+
+void hrt_view_unfocus(struct hrt_view *view, struct hrt_seat *seat) {
+	struct wlr_xdg_toplevel *toplevel = view->xdg_toplevel;
+	wlr_xdg_toplevel_set_activated(toplevel, false);
+	wlr_seat_keyboard_notify_clear_focus(seat->seat);
 }

--- a/lisp/bindings/hrt-bindings.yml
+++ b/lisp/bindings/hrt-bindings.yml
@@ -6,8 +6,8 @@ arguments:
   - "-DWLR_USE_UNSTABLE"
   - "-Iheart/include"
 files:
-  - build/include/hrt/hrt_view.h
   - build/include/hrt/hrt_input.h
+  - build/include/hrt/hrt_view.h
   - build/include/hrt/hrt_output.h
   - build/include/hrt/hrt_server.h
 pointer-expansion:

--- a/lisp/bindings/package.lisp
+++ b/lisp/bindings/package.lisp
@@ -26,10 +26,13 @@
 	   #:view
 	   #:view-init
 	   #:view-hrt-view
+	   #:focus-view
+	   #:unfocus-view
 	   ;; seat callbacks
 	   #:button-event #:wheel-event #:keyboard-keypress-event
 	   #:hrt-server
 	   #:hrt-server-scene-tree
+	   #:hrt-server-seat
 	   #:hrt-server-init
 	   #:hrt-server-start
 	   #:hrt-server-stop

--- a/lisp/bindings/wrappers.lisp
+++ b/lisp/bindings/wrappers.lisp
@@ -24,6 +24,16 @@
     (hrt-view-init hrt-view scene-tree)
     (the view view)))
 
+(declaim (inline focus-view))
+(defun focus-view (view seat)
+  (declare (type view view))
+  (hrt-view-focus (view-hrt-view view) seat))
+
+(declaim (inline unfocus-view))
+(defun unfocus-view (view seat)
+  (declare (type view view))
+  (hrt-view-unfocus (view-hrt-view view) seat))
+
 (defmethod mh/interface:set-dimensions ((view view) width height)
   (hrt-view-set-size (view-hrt-view view) width height))
 

--- a/lisp/group.lisp
+++ b/lisp/group.lisp
@@ -1,18 +1,18 @@
 (in-package #:mahogany)
 
-(defun group-focus-frame (group frame)
+(defun group-focus-frame (group frame seat)
   (with-accessors ((current-frame mahogany-group-current-frame)) group
     (when current-frame
-      (group-unfocus-frame group current-frame))
-    (tree:mark-frame-focused frame)
+      (group-unfocus-frame group current-frame seat))
+    (tree:mark-frame-focused frame seat)
     (setf current-frame frame)))
 
-(defun group-unfocus-frame (group frame)
+(defun group-unfocus-frame (group frame seat)
   (with-accessors ((current-frame mahogany-group-current-frame)) group
-    (tree:unmark-frame-focused frame)
+    (tree:unmark-frame-focused frame seat)
     (setf current-frame nil)))
 
-(defun group-add-output (group output)
+(defun group-add-output (group output seat)
   (declare (type mahogany-output output)
 	   (type mahogany-group group))
   (with-accessors ((output-map mahogany-group-output-map)
@@ -23,7 +23,7 @@
 	(let ((new-tree (tree:make-basic-tree :x x :y y :width width :height height)))
 	(setf (gethash (mahogany-output-full-name output) output-map) new-tree)
 	(when (not current-frame)
-	  (group-focus-frame group (tree:find-first-leaf new-tree))))))
+	  (group-focus-frame group (tree:find-first-leaf new-tree) seat)))))
     (log-string :trace "Group map: ~S" output-map)))
 
 (defun group-reconfigure-outputs (group outputs)
@@ -48,7 +48,7 @@ to match."
       (declare (ignore found key))
       value)))
 
-(defun group-remove-output (group output)
+(defun group-remove-output (group output seat)
   (declare (type mahogany-output output)
 	   (type mahogany-group group))
   (with-accessors ((output-map mahogany-group-output-map)) group
@@ -56,11 +56,11 @@ to match."
 	   (tree-container (gethash output-name output-map)))
       (remhash output-name output-map)
       (when (equalp tree-container (tree:find-frame-container (mahogany-group-current-frame group)))
-	(group-unfocus-frame group (mahogany-group-current-frame group))
+	(group-unfocus-frame group (mahogany-group-current-frame group) seat)
 	(alexandria:when-let ((other-container (%first-hash-table-value output-map)))
-	  (group-focus-frame group (tree:find-first-leaf other-container))))
+	  (group-focus-frame group (tree:find-first-leaf other-container) seat)))
       (when (and (mahogany-group-current-frame group) (= 0 (hash-table-count output-map)))
-	(group-unfocus-frame group (mahogany-group-current-frame group))))))
+	(group-unfocus-frame group (mahogany-group-current-frame group) seat)))))
 
 (defun group-add-view (group view)
   (declare (type mahogany-group group)

--- a/lisp/main.lisp
+++ b/lisp/main.lisp
@@ -10,11 +10,6 @@
   (cffi:with-foreign-slots ((keysyms modifiers keysyms-len) info (:struct hrt-keypress-info))
     (dotimes (i keysyms-len)
       (let ((key (make-key (cffi:mem-aref keysyms :uint32 i) modifiers)))
-	(log-string :trace (lambda (s)
-			     (format s "Key Pressed: ")
-			     (print-key key s)
-			     (format s ": ~A"
-				     (xkb:keysym-get-name (mahogany/keyboard::key-keysym key)))))
 	(handle-key-event key seat)))))
 
 (defmacro init-callback-struct (variable type &body sets)

--- a/lisp/state.lisp
+++ b/lisp/state.lisp
@@ -13,6 +13,10 @@
   (declare (type mahogany-state state))
   (hrt:hrt-server-stop (mahogany-state-server state)))
 
+(declaim (inline server-seat))
+(defun server-seat (state)
+  (hrt:hrt-server-seat (mahogany-state-server state)))
+
 (defun server-keystate-reset (state)
   (setf (mahogany-state-key-state state)
 	(make-key-state (mahogany-state-keybindings state))))
@@ -33,7 +37,7 @@
     (log-string :trace "New output added ~S" (mahogany-output-full-name mh-output))
     (vector-push-extend mh-output outputs)
     (loop for g across groups
-	  do (group-add-output g mh-output))))
+	  do (group-add-output g mh-output (server-seat state)))))
 
 (defun mahogany-state-output-remove (state hrt-output)
   (with-accessors ((outputs mahogany-state-outputs)
@@ -44,7 +48,7 @@
 			   :test #'cffi:pointer-eq)))
       (log-string :trace "Output removed ~S" (mahogany-output-full-name mh-output))
       (loop for g across groups
-	    do (group-remove-output g mh-output))
+	    do (group-remove-output g mh-output (server-seat state)))
       ;; TODO: Is there a better way to remove an item from a vector when we could know the index?
       (setf outputs (delete mh-output outputs :test #'equalp)))))
 

--- a/lisp/tree/tree-interface.lisp
+++ b/lisp/tree/tree-interface.lisp
@@ -121,14 +121,18 @@ a view assigned to it."))
 (defgeneric frame-at (root x y)
   (:documentation "Get the frame that occupies the specified coordinates."))
 
-(defgeneric mark-frame-focused (frame)
+(defgeneric mark-frame-focused (frame seat)
   (:documentation "Mark the frame as being focused")
-  (:method ((frame frame))
+  (:method ((frame frame) seat)
+    (declare (ignore seat))
+    (log-string :trace "frame focused")
     (setf (slot-value frame 'focused) t)))
 
-(defgeneric unmark-frame-focused (frame)
+(defgeneric unmark-frame-focused (frame seat)
   (:documentation "Mark the frame as being focused")
-  (:method ((frame frame))
+  (:method ((frame frame) seat)
+    (declare (ignore seat))
+    (log-string :trace "frame focused")
     (setf (slot-value frame 'focused) nil)))
 
 ;; helper functions:


### PR DESCRIPTION
Add the required functions to focus a view in the backend and use it.
+ Delay notifying the frontend of new views until the first commit is
  made; this allows us to immediately call events that require the
  xdg_toplevel to be configured.
+ Guess on what we need to do to unfocs a view; it seems to work.

Also initialized the seat correctly by letting it know about the keyboard group that we are using.