### PR TITLE
hrt: properly cleanup destroyed views

### DIFF
--- a/heart/include/hrt/hrt_view.h
+++ b/heart/include/hrt/hrt_view.h
@@ -1,3 +1,6 @@
+#ifndef HRT_VIEW
+#define HRT_VIEW
+
 #include <stdint.h>
 #include <wayland-server-core.h>
 #include <hrt/hrt_server.h>
@@ -61,3 +64,5 @@ void hrt_view_focus(struct hrt_view *view, struct hrt_seat *seat);
  * Unfocus the given view.
  **/
 void hrt_view_unfocus(struct hrt_view *view, struct hrt_seat *seat);
+
+#endif

--- a/heart/include/view_impl.h
+++ b/heart/include/view_impl.h
@@ -1,0 +1,13 @@
+#ifndef HRT_VIEW_IMPL
+#define HRT_VIEW_IMPL
+
+struct hrt_view;
+
+/**
+ * Cleanup the data initizlized during the hrt_view_init function
+ * This is internal, as it doesn't clean up everything and relies on
+ * other internal code to completely cleanup after a view.
+ */
+void hrt_view_cleanup(struct hrt_view *view);
+
+#endif

--- a/heart/src/view.c
+++ b/heart/src/view.c
@@ -20,6 +20,15 @@ void hrt_view_init(struct hrt_view *view, struct wlr_scene_tree *tree) {
 	view->xdg_surface->data = xdg_tree;
 }
 
+void hrt_view_cleanup(struct hrt_view *view) {
+	if(view->xdg_surface->data) {
+		wlr_scene_node_destroy(view->xdg_surface->data);
+	}
+	if(view->scene_tree) {
+		wlr_scene_node_destroy(&view->scene_tree->node);
+	}
+}
+
 uint32_t hrt_view_set_size(struct hrt_view *view, int width, int height) {
   view->width = width;
   view->height = height;

--- a/heart/src/xdg_shell.c
+++ b/heart/src/xdg_shell.c
@@ -8,6 +8,7 @@
 #include "hrt/hrt_input.h"
 #include "xdg_impl.h"
 #include "hrt/hrt_view.h"
+#include "view_impl.h"
 
 #include <wlr/types/wlr_xdg_shell.h>
 
@@ -33,6 +34,7 @@ static void handle_xdg_toplevel_destroy(struct wl_listener *listener,
 	wl_list_remove(&view->destroy.link);
 	wl_list_remove(&view->commit.link);
 
+	hrt_view_cleanup(view);
 	free(view);
 }
 


### PR DESCRIPTION
Free and destroy the wlr_scene objects associated with it.