### PR TITLE
hrt: follow XDG protocol for fullscreen/maximize

### DIFF
--- a/heart/include/hrt/hrt_view.h
+++ b/heart/include/hrt/hrt_view.h
@@ -26,6 +26,10 @@ struct hrt_view {
 	struct wl_listener unmap;
 	struct wl_listener commit;
 	struct wl_listener destroy;
+
+	struct wl_listener request_maximize;
+	struct wl_listener request_fullscreen;
+
 	new_view_handler new_view_handler;
 	view_destroy_handler destroy_handler;
 };


### PR DESCRIPTION
Even though we don't support these actions, the XDG spec says we need to respond to these requests by sending a configure event.