### PR TITLE
lisp: Add command line arg to not evaluate init file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN dnf -y builddep wlroots
 RUN curl -O https://beta.quicklisp.org/quicklisp.lisp \
     && sbcl --noinform --load quicklisp.lisp --eval "(quicklisp-quickstart:install)" \
     && sbcl --noinform --load "/root/quicklisp/setup.lisp"  --eval "(progn (setf ql-util::*do-not-prompt* t)(ql:add-to-init-file))" \
-    && sbcl --noinform --eval "(ql:quickload '("alexandria" "cl-ansi-text" "terminfo" "snakes" "iterate" "cffi" "cffi-grovel" "closer-mop"))" \
-    && sbcl --noinform --eval "(ql:quickload '("prove" "fiasco"))" 
+    && sbcl --noinform --eval "(ql:quickload '("alexandria" "cl-ansi-text" "terminfo" "snakes" "iterate" "cffi" "cffi-grovel" "closer-mop" "cl-argparse"))" \
+    && sbcl --noinform --eval "(ql:quickload '("prove" "fiasco"))"
 
 COPY . .
 

--- a/README.org
+++ b/README.org
@@ -70,7 +70,7 @@ install it.
 
 Once downloaded, install the dependencies:
 #+BEGIN_SRC lisp
-  (ql:quickload '("alexandria" "cl-ansi-text" "terminfo"
+  (ql:quickload '("alexandria" "cl-ansi-text" "terminfo" "cl-argparse"
 		  "snakes" "iterate" "cffi" "cffi-grovel" "closer-mop"))
 #+END_SRC
 

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -9,6 +9,7 @@
 	       #:alexandria
 	       #:cl-ansi-text
 	       #:terminfo
+		   #:cl-argparse
 	       #:xkbcommon
 	       #:cl-wayland
 	       #:snakes
@@ -57,6 +58,6 @@
 
 (asdf:defsystem #:mahogany/executable
   :build-operation program-op
-  :entry-point "mahogany::run-server"
+  :entry-point "mahogany::main"
   :build-pathname "build/mahogany"
   :depends-on (#:mahogany))


### PR DESCRIPTION
Add dependency on cl-argparse to do this.