### PR TITLE
Fix binding generation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CACHE := $(BUILD_DIR)/internal
 HRT_INCLUDES = $(shell find $(ROOT)/heart/include/hrt/ -type f)
 # WLR_INCLUDES = $(shell find $(ROOT)/heart/subprojects/wlroots/include/wlr/ -type f)
 
-$(BUILD_DIR)/mahogany: $(BUILD_DIR)/heart/lib64/libheart.so lisp/bindings/hrt-bindings.lisp lisp/bindings/wlr-bindings.lisp build-mahogany.lisp FORCE
+$(BUILD_DIR)/mahogany: $(BUILD_DIR)/heart/lib64/libheart.so build-mahogany.lisp FORCE
 	$(call $(LISP), build-mahogany.lisp)
 
 lisp/bindings/hrt-bindings.lisp: $(ROOT)/lisp/bindings/hrt-bindings.yml $(HRT_INCLUDES)

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ $(BUILD_DIR)/mahogany: $(BUILD_DIR)/heart/lib64/libheart.so lisp/bindings/hrt-bi
 	$(call $(LISP), build-mahogany.lisp)
 
 lisp/bindings/hrt-bindings.lisp: $(ROOT)/lisp/bindings/hrt-bindings.yml $(HRT_INCLUDES)
-	cl-bindgen b lisp/bindings/hrt-bindings.yml
+	PKG_CONFIG_PATH=$(BUILD_DIR)/lib/pkgconfig cl-bindgen b lisp/bindings/hrt-bindings.yml
 
 lisp/bindings/wlr-bindings.lisp: $(ROOT)/lisp/bindings/wlr-bindings.yml
-	cl-bindgen b lisp/bindings/wlr-bindings.yml
+	PKG_CONFIG_PATH=$(BUILD_DIR)/lib/pkgconfig cl-bindgen b lisp/bindings/wlr-bindings.yml
 
 $(BUILD_DIR)/heart/lib64/libheart.so: $(CACHE)/wlroots-configured FORCE
 	ninja -C $(BUILD_DIR)/heart

--- a/lisp/bindings/hrt-bindings.yml
+++ b/lisp/bindings/hrt-bindings.yml
@@ -1,7 +1,7 @@
 output: lisp/bindings/hrt-bindings.lisp
 package: hrt
 pkg-config:
-  - wlroots
+  - wlroots-0.18
 arguments:
   - "-DWLR_USE_UNSTABLE"
   - "-Iheart/include"

--- a/lisp/bindings/wlr-bindings.yml
+++ b/lisp/bindings/wlr-bindings.yml
@@ -1,7 +1,7 @@
 output: lisp/bindings/wlr-bindings.lisp
 package: wlr
 pkg-config:
-  - wlroots
+  - wlroots-0.18
 arguments:
   - "-DWLR_USE_UNSTABLE"
   - "-Ibuild/include/wlroots-0.18/"


### PR DESCRIPTION
In order to find the wlroots.pc file, we need to specify it's path, as well as specify the wlroots version.

See #105.