### PR TITLE
Handle view mapping correctly

### DIFF
--- a/heart/include/hrt/hrt_view.h
+++ b/heart/include/hrt/hrt_view.h
@@ -10,6 +10,18 @@ struct hrt_view;
 
 typedef void (*view_destroy_handler)(struct hrt_view *view);
 typedef void (*new_view_handler)(struct hrt_view *view);
+typedef void (*view_mapped_handler)(struct hrt_view *view);
+
+struct hrt_view_callbacks {
+    /**
+     * A new view has been created. Must call `hrt_view_init` for the
+     * view to be displayed.
+     **/
+    new_view_handler new_view;
+    view_mapped_handler view_mapped;
+    view_mapped_handler view_unmapped;
+    view_destroy_handler view_destroyed;
+};
 
 struct hrt_view {
     int width, height;
@@ -30,17 +42,7 @@ struct hrt_view {
     struct wl_listener request_maximize;
     struct wl_listener request_fullscreen;
 
-    new_view_handler new_view_handler;
-    view_destroy_handler destroy_handler;
-};
-
-struct hrt_view_callbacks {
-    /**
-     * A new view has been created. Must call `hrt_view_init` for the
-     * view to be displayed.
-     **/
-    new_view_handler new_view;
-    view_destroy_handler view_destroyed;
+    const struct hrt_view_callbacks *callbacks;
 };
 
 /**
@@ -55,6 +57,8 @@ void hrt_view_info(struct hrt_view *view);
  *serial.
  **/
 uint32_t hrt_view_set_size(struct hrt_view *view, int width, int height);
+
+bool hrt_view_mapped(struct hrt_view *view);
 
 /**
  * Sets the view to the given coordinates relative to its parent.

--- a/heart/src/view.c
+++ b/heart/src/view.c
@@ -46,6 +46,14 @@ uint32_t hrt_view_set_size(struct hrt_view *view, int width, int height) {
     return 0;
 }
 
+bool hrt_view_mapped(struct hrt_view *view) {
+  if(view->xdg_surface && view->xdg_surface->surface) {
+      return view->xdg_surface->surface->mapped;
+  } else {
+      return false;
+  }
+}
+
 void hrt_view_set_relative(struct hrt_view *view, int x, int y) {
     wlr_scene_node_set_position(&view->scene_tree->node, x, y);
 }

--- a/lisp/bindings/hrt-bindings.lisp
+++ b/lisp/bindings/hrt-bindings.lisp
@@ -95,6 +95,14 @@ names."
 
 (cffi:defctype new-view-handler :pointer #| function ptr void (struct hrt_view *) |#)
 
+(cffi:defctype view-mapped-handler :pointer #| function ptr void (struct hrt_view *) |#)
+
+(cffi:defcstruct hrt-view-callbacks
+  (new-view new-view-handler)
+  (view-mapped view-mapped-handler)
+  (view-unmapped view-mapped-handler)
+  (view-destroyed view-destroy-handler))
+
 (cffi:defcstruct hrt-view
   (width :int)
   (height :int)
@@ -107,12 +115,7 @@ names."
   (destroy (:struct wl-listener))
   (request-maximize (:struct wl-listener))
   (request-fullscreen (:struct wl-listener))
-  (new-view-handler new-view-handler)
-  (destroy-handler view-destroy-handler))
-
-(cffi:defcstruct hrt-view-callbacks
-  (new-view new-view-handler)
-  (view-destroyed view-destroy-handler))
+  (callbacks (:pointer (:struct hrt-view-callbacks))))
 
 (cffi:defcfun ("hrt_view_init" hrt-view-init) :void
   "Fully initialize the view and place it in the given scene tree."
@@ -128,6 +131,9 @@ serial."
   (view (:pointer (:struct hrt-view)))
   (width :int)
   (height :int))
+
+(cffi:defcfun ("hrt_view_mapped" hrt-view-mapped) :bool
+  (view (:pointer (:struct hrt-view))))
 
 (cffi:defcfun ("hrt_view_set_relative" hrt-view-set-relative) :void
   "Sets the view to the given coordinates relative to its parent."

--- a/lisp/bindings/package.lisp
+++ b/lisp/bindings/package.lisp
@@ -7,7 +7,10 @@
 	   #:hrt-view-callbacks
 	   #:new-view
 	   #:hrt-view
+	   #:view-mapped
+	   #:view-unmapped
 	   #:view-destroyed
+	   #:view-mapped-p
 	   #:hrt-seat
 	   #:hrt-seat-notify-button
 	   #:hrt-seat-notify-axis

--- a/lisp/bindings/wrappers.lisp
+++ b/lisp/bindings/wrappers.lisp
@@ -34,6 +34,11 @@
   (declare (type view view))
   (hrt-view-unfocus (view-hrt-view view) seat))
 
+(declaim (inline view-mapped-p))
+(defun view-mapped-p (view)
+  (declare (type view view))
+  (hrt-view-mapped (view-hrt-view view)))
+
 (declaim (inline view-set-hidden))
 (defun view-set-hidden (view hidden)
   (declare (type view view)

--- a/lisp/main.lisp
+++ b/lisp/main.lisp
@@ -32,8 +32,10 @@ further up. "
 
 (defun init-view-callbacks (view-callbacks)
   (init-callback-struct view-callbacks (:struct hrt:hrt-view-callbacks)
-	(hrt:new-view handle-new-view-event)
-	(hrt:view-destroyed handle-view-destroyed-event)))
+    (hrt:new-view handle-new-view-event)
+    (hrt:view-mapped handle-view-mapped)
+    (hrt:view-unmapped handle-view-unmapped)
+    (hrt:view-destroyed handle-view-destroyed-event)))
 
 (defun run-server (args)
   (disable-fpu-exceptions)

--- a/lisp/view.lisp
+++ b/lisp/view.lisp
@@ -5,6 +5,16 @@
   (log-string :trace "New view callback called!")
   (mahogany-state-view-add *compositor-state* view))
 
+(cffi:defcallback handle-view-mapped :void
+    ((view (:pointer (:struct hrt:hrt-view))))
+  (log-string :trace "View Mapped!")
+  (mahogany-state-view-map *compositor-state* view))
+
+(cffi:defcallback handle-view-unmapped :void
+    ((view (:pointer (:struct hrt:hrt-view))))
+  (log-string :trace "View unmapped!")
+  (mahogany-state-view-unmap *compositor-state* view))
+
 (cffi:defcallback handle-view-destroyed-event :void
     ((view (:pointer (:struct hrt:hrt-view))))
   (log-string :trace "View destroyed callback called!")


### PR DESCRIPTION
Instead of immediately trying to place new views into the frame tree, wait until they are mapped to actually place them.

We still need to at least set their size before they can be mapped, so stil add them to the group's scene tree and set their size to the currently focused frame as a guess.
+ Store the whole view callback struct instead of pointers to individual members.