### PR TITLE
hrt scene group abstraction

### DIFF
--- a/heart/include/hrt/hrt_scene.h
+++ b/heart/include/hrt/hrt_scene.h
@@ -1,0 +1,67 @@
+#ifndef HRT_HRT_SCENE
+#define HRT_HRT_SCENE
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <wlr/types/wlr_xdg_shell.h>
+#include <wlr/types/wlr_scene.h>
+
+
+struct hrt_scene_group {
+    struct wlr_scene_tree *normal;
+    struct wlr_scene_tree *fullscreen;
+};
+
+struct hrt_scene_fullscreen_node {
+    /// the tree holding the background node as well as the view:
+    struct wlr_scene_tree *tree;
+    struct wlr_scene_rect *background;
+    struct hrt_view *view;
+};
+
+struct hrt_scene_group *hrt_scene_group_create(struct wlr_scene_tree *parent);
+
+void hrt_scene_group_destroy(struct hrt_scene_group *group);
+
+void hrt_scene_group_add_view(struct hrt_scene_group *group,
+                              struct hrt_view *view);
+
+void hrt_scene_group_init_view(struct hrt_scene_group *group,
+                               struct hrt_view *view);
+
+void hrt_scene_group_set_enabled(struct hrt_scene_group *group, bool enabled);
+
+void hrt_scene_group_transfer(struct hrt_scene_group *source,
+                              struct hrt_scene_group *destination);
+
+struct wlr_scene_tree *hrt_scene_group_normal(struct hrt_scene_group *group);
+
+// It might make more sense for the cl frontend to pass in the x,y, width, and height
+// variables instead of the output, but's cleaner this way.
+/**
+ * Create a hrt_scene_fullscreen_node with a black bacground of the given size.
+ * Mode the hrt_view inside the node, removing it from where ever it was in the scene tree.
+ **/
+struct hrt_scene_fullscreen_node *
+hrt_scene_create_fullscreen_node(struct hrt_scene_group *group,
+                                 struct hrt_view *view,
+                                 struct hrt_output *output);
+
+/**
+ * Destroy the given background node, moving the struct hrt_view to the
+ * normral layer.
+ * Returns the view that was in the node.
+ */
+struct hrt_view *
+hrt_scene_fullscreen_node_destroy(struct hrt_scene_fullscreen_node *node);
+
+uint32_t hrt_scene_node_set_dimensions(struct hrt_scene_fullscreen_node *node,
+                                       int width, int height);
+
+void hrt_scene_node_set_position(struct hrt_scene_fullscreen_node *node,
+				 int x, int y);
+
+uint32_t hrt_scene_fullscreen_configure(struct hrt_scene_fullscreen_node *group,
+                                        struct hrt_output *output);
+
+#endif

--- a/heart/src/meson.build
+++ b/heart/src/meson.build
@@ -5,6 +5,7 @@ hrt_source_files += files(
   'output.c',
   'output_methods.c',
   'seat.c',
+  'scene.c',
   'server.c',
   'view.c',
   'xdg_shell.c',

--- a/heart/src/scene.c
+++ b/heart/src/scene.c
@@ -1,0 +1,146 @@
+#include "hrt/hrt_output.h"
+#include "hrt/hrt_scene.h"
+#include "hrt/hrt_server.h"
+#include "hrt/hrt_view.h"
+#include "wlr/util/log.h"
+#include <stdlib.h>
+#include <time.h>
+#include <wayland-util.h>
+
+static struct wlr_scene_tree *create_place_above(struct wlr_scene_tree *parent,
+                                                 struct wlr_scene_tree *below) {
+    struct wlr_scene_tree *tree = wlr_scene_tree_create(parent);
+    wlr_scene_node_place_above(&tree->node, &below->node);
+    return tree;
+}
+
+struct hrt_scene_group *hrt_scene_group_create(struct wlr_scene_tree *parent) {
+    struct hrt_scene_group *layers = calloc(1, sizeof(*layers));
+    if (!layers) {
+        wlr_log(WLR_ERROR, "Could not allocate hrt_scene_layers");
+        return NULL;
+    }
+    layers->normal     = wlr_scene_tree_create(parent);
+    layers->fullscreen = create_place_above(parent, layers->normal);
+
+    return layers;
+}
+
+void hrt_scene_group_destroy(struct hrt_scene_group *layers) {
+    wlr_scene_node_destroy(&layers->fullscreen->node);
+    wlr_scene_node_destroy(&layers->normal->node);
+    free(layers);
+}
+
+void hrt_scene_group_add_view(struct hrt_scene_group *group,
+                              struct hrt_view *view) {
+    hrt_view_reparent(view, group->normal);
+}
+
+void hrt_scene_group_init_view(struct hrt_scene_group *group,
+                               struct hrt_view *view) {
+    hrt_view_init(view, group->normal);
+}
+
+void hrt_scene_group_set_enabled(struct hrt_scene_group *group, bool enabled) {
+    wlr_scene_node_set_enabled(&group->fullscreen->node, enabled);
+    wlr_scene_node_set_enabled(&group->normal->node, enabled);
+}
+
+static void reparent_children(struct wlr_scene_tree *source,
+                              struct wlr_scene_tree *dest) {
+    struct wlr_scene_node *child, *child_tmp;
+    wl_list_for_each_safe(child, child_tmp, &source->children, link) {
+        wlr_scene_node_reparent(child, dest);
+    }
+}
+
+void hrt_scene_group_transfer(struct hrt_scene_group *source,
+                              struct hrt_scene_group *destination) {
+    reparent_children(source->fullscreen, destination->fullscreen);
+    reparent_children(source->normal, destination->normal);
+}
+
+struct wlr_scene_tree *hrt_scene_group_normal(struct hrt_scene_group *group) {
+    return group->normal;
+}
+
+struct hrt_scene_fullscreen_node *
+hrt_scene_create_fullscreen_node(struct hrt_scene_group *layers,
+                                 struct hrt_view *view,
+                                 struct hrt_output *output) {
+    struct hrt_scene_fullscreen_node *new_node = calloc(1, sizeof(*new_node));
+
+    if (!new_node) {
+        wlr_log(WLR_ERROR, "Failed to allocate hrt_scene_fullscreen_node");
+        return NULL;
+    }
+
+    struct wlr_scene_tree *root = wlr_scene_tree_create(layers->fullscreen);
+    if (!root) {
+        wlr_log(WLR_ERROR, "Failed to allocate wlr_scene_tree");
+        return NULL;
+    }
+    int x, y;
+    hrt_output_position(output, &x, &y);
+    wlr_scene_node_set_position(&root->node, x, y);
+
+    const float color[4] = {
+        0,
+        0,
+        0,
+        0,
+    };
+    int width, height;
+    hrt_output_resolution(output, &width, &height);
+    struct wlr_scene_rect *rect =
+        wlr_scene_rect_create(root, width, height, color);
+    if (!rect) {
+        wlr_log(WLR_ERROR, "Failed to allocate hrt_scene_rect");
+        return NULL;
+    }
+
+    new_node->tree       = root;
+    new_node->background = rect;
+    new_node->view       = view;
+    root->node.data      = new_node;
+
+    hrt_view_reparent(view, root);
+    hrt_view_set_relative(view, 0, 0);
+
+    return new_node;
+}
+
+struct hrt_view *
+hrt_scene_fullscreen_node_destroy(struct hrt_scene_fullscreen_node *node) {
+    struct hrt_view *view = node->view;
+    hrt_view_reparent(view, node->background->node.parent->node.parent);
+    // We don't need to free the background, as it's destroyed by
+    // destroying its parent:
+    wlr_scene_node_destroy(&node->tree->node);
+    free(node);
+
+    return view;
+}
+
+uint32_t hrt_scene_node_set_dimensions(struct hrt_scene_fullscreen_node *node,
+                                       int width, int height) {
+    wlr_scene_rect_set_size(node->background, width, height);
+    return hrt_view_set_size(node->view, width, height);
+}
+
+void hrt_scene_node_set_position(struct hrt_scene_fullscreen_node *node, int x,
+                                 int y) {
+    wlr_scene_node_set_position(&node->tree->node, x, y);
+}
+
+uint32_t hrt_scene_fullscreen_configure(struct hrt_scene_fullscreen_node *node,
+                                        struct hrt_output *output) {
+    int x, y;
+    hrt_output_position(output, &x, &y);
+    wlr_scene_node_set_position(&node->tree->node, x, y);
+
+    int width, height;
+    hrt_output_resolution(output, &width, &height);
+    return hrt_scene_node_set_dimensions(node, width, height);
+}

--- a/lisp/bindings/hrt-bindings.yml
+++ b/lisp/bindings/hrt-bindings.yml
@@ -10,6 +10,7 @@ files:
   - build/include/hrt/hrt_view.h
   - build/include/hrt/hrt_output.h
   - build/include/hrt/hrt_server.h
+  - build/include/hrt/hrt_scene.h
 pointer-expansion:
   include:
     match: "hrt.*"

--- a/lisp/bindings/package.lisp
+++ b/lisp/bindings/package.lisp
@@ -52,6 +52,19 @@
 	   #:modifiers
 	   #:keysyms-len
 	   #:wl-key-state
+	   ;; scene helpers:
+	   #:hrt-scene-group-create
+	   #:hrt-scene-group-destroy
+	   #:scene-group-add-view
+	   #:hrt-scene-group-set-enabled
+	   #:hrt-scene-group-transfer
+	   #:hrt-scene-group-set-dimensions
+	   #:hrt-scene-group-set-position
+	   ;; #:hrt-scene-group-normal
+	   #:scene-create-fullscreen-node
+	   #:hrt-scene-fullscreen-node-destroy
+	   #:hrt-scene-fullscreen-configure
+	   #:scene-init-view
 	   #:load-foreign-libraries))
 
 (defpackage #:wlr

--- a/lisp/bindings/package.lisp
+++ b/lisp/bindings/package.lisp
@@ -31,7 +31,6 @@
 	   #:output-position
 	   ;; view-methods
 	   #:view
-	   #:view-init
 	   #:view-reparent
 	   #:view-request-close
 	   #:view-hrt-view

--- a/lisp/bindings/scene-group.lisp
+++ b/lisp/bindings/scene-group.lisp
@@ -1,0 +1,24 @@
+(in-package #:hrt)
+
+(declaim (inline scene-group-add-view))
+(defun scene-group-add-view (scene-group view)
+  (declare (type view view)
+	   (type cffi:foreign-pointer scene-group))
+  (hrt-scene-group-add-view scene-group (view-hrt-view view)))
+
+(declaim (inline scene-create-fullscreen-node))
+(defun scene-create-fullscreen-node (hrt-group view hrt-output)
+  (declare (type view view)
+	   (type cffi:foreign-pointer hrt-group hrt-output))
+  (alexandria:if-let ((node (hrt-scene-create-fullscreen-node hrt-group
+							      (view-hrt-view view)
+							      hrt-output)))
+    node
+    (error "Could not allocate fullscreen node.")))
+
+
+(declaim (inline scene-init-view))
+(defun scene-init-view (hrt-group hrt-view)
+  (declare (type cffi:foreign-pointer hrt-group hrt-view))
+  (hrt-scene-group-init-view hrt-group hrt-view)
+  (%make-view hrt-view))

--- a/lisp/bindings/view.lisp
+++ b/lisp/bindings/view.lisp
@@ -3,10 +3,10 @@
 (defstruct (view (:constructor %make-view (hrt-view)))
   (hrt-view (cffi:null-pointer) :type cffi:foreign-pointer :read-only t))
 
-(defun view-init (hrt-view scene-tree)
-  (let ((view (%make-view hrt-view)))
-    (hrt-view-init hrt-view scene-tree)
-    (the view view)))
+;; (defun view-init (hrt-view scene-tree)
+;;   (let ((view (%make-view hrt-view)))
+;;     (hrt-view-init hrt-view scene-tree)
+;;     (the view view)))
 
 (declaim (inline focus-view))
 (defun focus-view (view seat)
@@ -38,6 +38,11 @@
 (defun view-request-close (view)
   (declare (type view view))
   (hrt-view-request-close (view-hrt-view view)))
+
+(declaim (inline view-set-fullscreen))
+(defun view-set-fullscreen (view fullscreen)
+  (declare (type view view))
+  (hrt-view-set-fullscreen (view-hrt-view view) fullscreen))
 
 (defmethod mh/interface:set-dimensions ((view view) width height)
   (hrt-view-set-size (view-hrt-view view) width height))

--- a/lisp/bindings/view.lisp
+++ b/lisp/bindings/view.lisp
@@ -3,11 +3,6 @@
 (defstruct (view (:constructor %make-view (hrt-view)))
   (hrt-view (cffi:null-pointer) :type cffi:foreign-pointer :read-only t))
 
-;; (defun view-init (hrt-view scene-tree)
-;;   (let ((view (%make-view hrt-view)))
-;;     (hrt-view-init hrt-view scene-tree)
-;;     (the view view)))
-
 (declaim (inline focus-view))
 (defun focus-view (view seat)
   (declare (type view view))

--- a/lisp/objects.lisp
+++ b/lisp/objects.lisp
@@ -4,10 +4,10 @@
   (hrt-output cffi:null-pointer :type cffi:foreign-pointer :read-only t)
   (full-name "" :type string :read-only t))
 
-(defstruct (mahogany-group (:constructor %make-mahogany-group (name number scene-tree)))
+(defstruct (mahogany-group (:constructor %make-mahogany-group (name number hrt-group)))
   (name "" :type string)
   (number 1 :type fixnum :read-only t)
-  (scene-tree (cffi:null-pointer) :type cffi:foreign-pointer :read-only t)
+  (hrt-group (cffi:null-pointer) :type cffi:foreign-pointer :read-only t)
   (tree-container (make-instance 'tree:tree-container) :type tree:tree-container :read-only t)
   (output-map (make-hash-table :test 'equal) :type hash-table :read-only t)
   (current-frame nil :type (or tree:frame null))

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -34,7 +34,8 @@
 				     (:file "hrt-libs")
 				     (:file "hrt-bindings")
 				     (:file "wrappers")
-				     (:file "view")))
+				     (:file "view")
+				     (:file "scene-group")))
 	       (:module keyboard
 			:depends-on ("util")
 		        :components ((:file "package")


### PR DESCRIPTION
Introduce hrt_scene_group, which abstracts over the concept of layers, which is needed for implementing both full screen windows and the layer shell protocol.

I'm not sure if it's actually the right way to do this, but it's a start. At the very least, it reduces the usage of wlroots functions on the lisp side, which is usually a good thing.

See #94 and #85.