### PR TITLE
Use adopt for arg parsing instead of cl-argparse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN dnf -y builddep wlroots
 RUN curl -O https://beta.quicklisp.org/quicklisp.lisp \
     && sbcl --noinform --load quicklisp.lisp --eval "(quicklisp-quickstart:install)" \
     && sbcl --noinform --load "/root/quicklisp/setup.lisp"  --eval "(progn (setf ql-util::*do-not-prompt* t)(ql:add-to-init-file))" \
-    && sbcl --noinform --eval "(ql:quickload '("alexandria" "cl-ansi-text" "terminfo" "snakes" "iterate" "cffi" "cffi-grovel" "closer-mop" "cl-argparse"))" \
+    && sbcl --noinform --eval "(ql:quickload '("alexandria" "cl-ansi-text" "terminfo" "snakes" "iterate" "cffi" "cffi-grovel" "closer-mop" "adopt"))" \
     && sbcl --noinform --eval "(ql:quickload '("fiasco"))"
 
 COPY . .

--- a/README.org
+++ b/README.org
@@ -20,7 +20,7 @@
 
 ** Contributing / Hacking
 
-Mahogany is still in an early stage of development. See the 
+Mahogany is still in an early stage of development. See the
 [[https://github.com/stumpwm/mahogany/milestones][list of milestones]]
 for features or work that is ready to be started. You can also browse the
 issue list for labels marked with
@@ -46,7 +46,7 @@ Before writing code, please look at [[CONTRIBUTING.md][CONTRIBUTING.md]]
    git submodule update --init
    #+END_SRC
 
-To see a full example of this process, see the 
+To see a full example of this process, see the
 [[https://github.com/stumpwm/mahogany/blob/master/Dockerfile][CI's Dockerfile]]
 
 *** Backend Library Dependencies
@@ -70,7 +70,7 @@ install it.
 
 Once downloaded, install the dependencies:
 #+BEGIN_SRC lisp
-  (ql:quickload '("alexandria" "cl-ansi-text" "terminfo" "cl-argparse"
+  (ql:quickload '("alexandria" "cl-ansi-text" "terminfo" "adopt"
 		  "snakes" "iterate" "cffi" "cffi-grovel" "closer-mop"))
 #+END_SRC
 

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -9,7 +9,7 @@
 	       #:alexandria
 	       #:cl-ansi-text
 	       #:terminfo
-		   #:cl-argparse
+	       #:adopt
 	       #:xkbcommon
 	       #:cl-wayland
 	       #:snakes


### PR DESCRIPTION
adopt has fewer features and is a bit less ergonomic to use, but:
+ It produces prettier help text
+ It can produce man pages
+ Has a published version with a version number
+ It's already packaged in guix
+ This project shouldn't need cl-argparse's additional features