### PR TITLE
hrt: Add fallbackout output

### DIFF
--- a/heart/include/hrt/hrt_scene.h
+++ b/heart/include/hrt/hrt_scene.h
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/types/wlr_scene.h>
+#include "hrt/hrt_output.h"
 
 
 struct hrt_scene_group {

--- a/lisp/bindings/hrt-bindings.lisp
+++ b/lisp/bindings/hrt-bindings.lisp
@@ -97,14 +97,11 @@ names."
 
 (cffi:defctype view-mapped-handler :pointer #| function ptr void (struct hrt_view *) |#)
 
-(cffi:defctype view-request-fullscreen :pointer #| function ptr _Bool (struct hrt_view *, struct hrt_output *, _Bool) |#)
-
 (cffi:defcstruct hrt-view-callbacks
   (new-view new-view-handler)
   (view-mapped view-mapped-handler)
   (view-unmapped view-mapped-handler)
-  (view-destroyed view-destroy-handler)
-  (request-fullscreen view-request-fullscreen))
+  (view-destroyed view-destroy-handler))
 
 (cffi:defcstruct hrt-view
   (width :int)
@@ -134,10 +131,6 @@ serial."
   (view (:pointer (:struct hrt-view)))
   (width :int)
   (height :int))
-
-(cffi:defcfun ("hrt_view_set_fullscreen" hrt-view-set-fullscreen) :uint32
-  (view (:pointer (:struct hrt-view)))
-  (fullscreen :bool))
 
 (cffi:defcfun ("hrt_view_mapped" hrt-view-mapped) :bool
   (view (:pointer (:struct hrt-view))))
@@ -197,6 +190,10 @@ well behaved ones should."
 (cffi:defcfun ("hrt_output_destroy" hrt-output-destroy) :void
   (server (:pointer (:struct hrt-server))))
 
+(cffi:defcfun ("hrt_output_create" hrt-output-create) (:pointer (:struct hrt-output))
+  (server (:pointer (:struct hrt-server)))
+  (wlr-output :pointer #| (:struct wlr-output) |# ))
+
 (cffi:defcfun ("hrt_output_resolution" hrt-output-resolution) :void
   "Get the effective output resolution of the output that can be used to
 set the width and height of views."
@@ -227,6 +224,7 @@ set the width and height of views."
   (wl-display :pointer #| (:struct wl-display) |# )
   (backend :pointer #| (:struct wlr-backend) |# )
   (backend-destroy (:struct wl-listener))
+  (headless-backend :pointer #| (:struct wlr-backend) |# )
   (session :pointer #| (:struct wlr-session) |# )
   (renderer :pointer #| (:struct wlr-renderer) |# )
   (compositor :pointer #| (:struct wlr-compositor) |# )
@@ -241,6 +239,7 @@ set the width and height of views."
   (output-manager-test (:struct wl-listener))
   (output-manager-destroy (:struct wl-listener))
   (seat (:struct hrt-seat))
+  (fallback-output (:pointer (:struct hrt-output)))
   (xdg-shell :pointer #| (:struct wlr-xdg-shell) |# )
   (new-xdg-toplevel (:struct wl-listener))
   (new-xdg-popup (:struct wl-listener))

--- a/lisp/bindings/hrt-bindings.yml
+++ b/lisp/bindings/hrt-bindings.yml
@@ -5,6 +5,7 @@ pkg-config:
 arguments:
   - "-DWLR_USE_UNSTABLE"
   - "-Iheart/include"
+  - "-Ibuild/heart/protocols"
 files:
   - build/include/hrt/hrt_input.h
   - build/include/hrt/hrt_view.h


### PR DESCRIPTION
For the layer shell implementation, we need an output regardless of if any actual outputs are connected.