### PR TITLE
hrt: Add fallbackout output

### DIFF
--- a/heart/include/hrt/hrt_output.h
+++ b/heart/include/hrt/hrt_output.h
@@ -28,6 +28,10 @@ struct hrt_output_callbacks {
 bool hrt_output_init(struct hrt_server *server,
                      const struct hrt_output_callbacks *callbacks);
 void hrt_output_destroy(struct hrt_server *server);
+
+struct hrt_output *hrt_output_create(struct hrt_server *server,
+                                     struct wlr_output *wlr_output);
+
 /**
  * Get the effective output resolution of the output that can be used to
  * set the width and height of views.

--- a/heart/include/hrt/hrt_scene.h
+++ b/heart/include/hrt/hrt_scene.h
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/types/wlr_scene.h>
+#include "hrt/hrt_output.h"
 
 
 struct hrt_scene_group {

--- a/heart/include/hrt/hrt_server.h
+++ b/heart/include/hrt/hrt_server.h
@@ -1,6 +1,7 @@
 #ifndef HRT_HRT_SERVER_H
 #define HRT_HRT_SERVER_H
 
+#include "hrt/hrt_output.h"
 #include "wlr/backend/session.h"
 #include <stdbool.h>
 
@@ -20,6 +21,7 @@ struct hrt_server {
     struct wl_display *wl_display;
     struct wlr_backend *backend;
     struct wl_listener backend_destroy;
+    struct wlr_backend *headless_backend;
     struct wlr_session *session;
     struct wlr_renderer *renderer;
     struct wlr_compositor *compositor;
@@ -36,6 +38,7 @@ struct hrt_server {
     struct wl_listener output_manager_destroy;
 
     struct hrt_seat seat;
+    struct hrt_output *fallback_output;
 
     struct wlr_xdg_shell *xdg_shell;
     struct wl_listener new_xdg_toplevel;

--- a/heart/src/output.c
+++ b/heart/src/output.c
@@ -7,6 +7,7 @@
 #include <wayland-server-core.h>
 #include <wayland-util.h>
 #include <wlr/render/wlr_renderer.h>
+#include <wlr/backend/headless.h>
 
 #include <hrt/hrt_output.h>
 
@@ -32,10 +33,13 @@ static void handle_frame_notify(struct wl_listener *listener, void *data) {
 }
 
 static void handle_output_destroy(struct wl_listener *listener, void *data) {
-    wlr_log(WLR_DEBUG, "Output destroyed");
     struct hrt_output *output = wl_container_of(listener, output, destroy);
     struct hrt_server *server = output->server;
-    server->output_callback->output_removed(output);
+    wlr_log(WLR_DEBUG, "Output destroyed %s", output->wlr_output->name);
+
+    if (!wlr_output_is_headless(output->wlr_output)) {
+        server->output_callback->output_removed(output);
+    }
 
     wl_list_remove(&output->frame.link);
     wl_list_remove(&output->request_state.link);
@@ -53,8 +57,8 @@ static float float_rand() {
     return (float)(rand() / (double)RAND_MAX); /* [0, 1.0] */
 }
 
-static struct hrt_output *hrt_output_create(struct hrt_server *server,
-                                            struct wlr_output *wlr_output) {
+struct hrt_output *hrt_output_create(struct hrt_server *server,
+                                     struct wlr_output *wlr_output) {
     struct hrt_output *output = calloc(1, sizeof(struct hrt_output));
     output->wlr_output        = wlr_output;
     output->server            = server;
@@ -63,6 +67,9 @@ static struct hrt_output *hrt_output_create(struct hrt_server *server,
     wl_signal_add(&wlr_output->events.frame, &output->frame);
     output->request_state.notify = handle_request_state;
     wl_signal_add(&wlr_output->events.request_state, &output->request_state);
+
+    output->destroy.notify = handle_output_destroy;
+    wl_signal_add(&wlr_output->events.destroy, &output->destroy);
 
     // temp background color:
     // {0.730473, 0.554736, 0.665036, 1.000000} is really pretty.
@@ -74,14 +81,16 @@ static struct hrt_output *hrt_output_create(struct hrt_server *server,
     printf("Output color: {%f, %f, %f, %f}\n", output->color[0],
            output->color[1], output->color[2], output->color[3]);
 
+    wlr_output->data = output;
+
     return output;
 }
 
 static void handle_new_output(struct wl_listener *listener, void *data) {
-    wlr_log(WLR_DEBUG, "New output detected");
     struct hrt_server *server = wl_container_of(listener, server, new_output);
 
     struct wlr_output *wlr_output = data;
+    wlr_log(WLR_DEBUG, "New output detected: %s", wlr_output->name);
 
     wlr_output_init_render(wlr_output, server->allocator, server->renderer);
 
@@ -109,11 +118,11 @@ static void handle_new_output(struct wl_listener *listener, void *data) {
 
     struct hrt_output *output = hrt_output_create(server, wlr_output);
 
-    output->destroy.notify = handle_output_destroy;
-    wl_signal_add(&wlr_output->events.destroy, &output->destroy);
-
-    wlr_output->data = output;
-    server->output_callback->output_added(output);
+    // I'm not sure how to handle headless outputs, but they certainly shouldn't
+    // go through mahogany's normal code paths:
+    if (!wlr_output_is_headless(wlr_output)) {
+        server->output_callback->output_added(output);
+    }
 }
 
 static void handle_output_manager_destroy(struct wl_listener *listener,

--- a/lisp/bindings/hrt-bindings.lisp
+++ b/lisp/bindings/hrt-bindings.lisp
@@ -200,6 +200,10 @@ well behaved ones should."
 (cffi:defcfun ("hrt_output_destroy" hrt-output-destroy) :void
   (server (:pointer (:struct hrt-server))))
 
+(cffi:defcfun ("hrt_output_create" hrt-output-create) (:pointer (:struct hrt-output))
+  (server (:pointer (:struct hrt-server)))
+  (wlr-output :pointer #| (:struct wlr-output) |# ))
+
 (cffi:defcfun ("hrt_output_resolution" hrt-output-resolution) :void
   "Get the effective output resolution of the output that can be used to
 set the width and height of views."
@@ -230,6 +234,7 @@ set the width and height of views."
   (wl-display :pointer #| (:struct wl-display) |# )
   (backend :pointer #| (:struct wlr-backend) |# )
   (backend-destroy (:struct wl-listener))
+  (headless-backend :pointer #| (:struct wlr-backend) |# )
   (session :pointer #| (:struct wlr-session) |# )
   (renderer :pointer #| (:struct wlr-renderer) |# )
   (compositor :pointer #| (:struct wlr-compositor) |# )
@@ -244,6 +249,7 @@ set the width and height of views."
   (output-manager-test (:struct wl-listener))
   (output-manager-destroy (:struct wl-listener))
   (seat (:struct hrt-seat))
+  (fallback-output (:pointer (:struct hrt-output)))
   (xdg-shell :pointer #| (:struct wlr-xdg-shell) |# )
   (new-xdg-toplevel (:struct wl-listener))
   (new-xdg-popup (:struct wl-listener))

--- a/lisp/bindings/hrt-bindings.yml
+++ b/lisp/bindings/hrt-bindings.yml
@@ -5,6 +5,7 @@ pkg-config:
 arguments:
   - "-DWLR_USE_UNSTABLE"
   - "-Iheart/include"
+  - "-Ibuild/heart/protocols"
 files:
   - build/include/hrt/hrt_input.h
   - build/include/hrt/hrt_view.h


### PR DESCRIPTION
For the layer shell implementation, we need an output regardless of if any actual outputs are connected.