### PR TITLE
Place lisp build artifacts in build directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ clean: FORCE
 	rm -rf $(BUILD_DIR)/lib64
 	rm -rf $(BUILD_DIR)/include
 	rm -rf $(BUILD_DIR)/install_output.txt
+	rm -rf $(BUILD_DIR)/asdf-cache/*
 
 test: $(BUILD_DIR)/heart/lib64/libheart.so
 	$(call $(LISP),run-tests.lisp)

--- a/build-mahogany.lisp
+++ b/build-mahogany.lisp
@@ -1,19 +1,9 @@
 (require 'asdf)
 
-;; See https://asdf.common-lisp.dev/asdf.html#Configuration-DSL-1
-;; for what this is doing.
-;; Basically, we want our local copies of dependencies in the dependencies folder
-;; to be used instead of anything that asdf can find in our environment
-(asdf:initialize-source-registry
- `(:source-registry
-   (:directory ,(uiop/os:getcwd))
-   (:tree ,(merge-pathnames (uiop/os:getcwd) #P"dependencies"))
-   ;; Use whatever the user has configured in their environment to find the rest.
-   :inherit-configuration))
-
-;; (asdf:find-system "mahogany/executable")
-;; (asdf:clear-configuration)
+(load "init-build-env.lisp")
 
 (declaim (optimize (debug 3)))
+
+(cl:pushnew :hrt-debug *features*)
 
 (asdf:make "mahogany/executable")

--- a/init-build-env.lisp
+++ b/init-build-env.lisp
@@ -1,0 +1,25 @@
+(let* ((root (uiop/os:getcwd))
+       (asdf-cache (make-pathname
+		    :directory (append
+				(pathname-directory root)
+				(list
+				 "build"
+				 "asdf-cache"
+				 (uiop:implementation-identifier))))))
+  ;; See https://asdf.common-lisp.dev/asdf.html#Configuration-DSL-1
+  ;; for what this is doing.
+  ;; Basically, we want our local copies of dependencies in the dependencies folder
+  ;; to be used instead of anything that asdf can find in our environment
+  (asdf:initialize-source-registry
+   `(:source-registry
+     (:directory ,root)
+     (:tree ,(merge-pathnames root #P"dependencies"))
+     ;; Use whatever the user has configured in their environment to find the rest.
+     :inherit-configuration))
+
+  ;; This puts all of the compiled fasl files into the build directory so that
+  ;; a `make clean` will clear them out.
+  (asdf:initialize-output-translations
+   `(:output-translations
+     :inherit-configuration
+     (,(namestring root) ,(namestring asdf-cache)))))

--- a/run-tests.lisp
+++ b/run-tests.lisp
@@ -1,14 +1,5 @@
 (require 'asdf)
 
-;; See https://asdf.common-lisp.dev/asdf.html#Configuration-DSL-1
-;; for what this is doing.
-;; Basically, we want our local copies of dependencies in the dependencies folder
-;; to be used instead of anything that asdf can find in our environment
-(asdf:initialize-source-registry
- `(:source-registry
-   (:directory ,(uiop/os:getcwd))
-   (:tree ,(merge-pathnames (uiop/os:getcwd) #P"dependencies"))
-   ;; Use whatever the user has configured in their environment to find the rest.
-   :inherit-configuration))
+(load "init-build-env.lisp")
 
 (asdf:test-system "mahogany")


### PR DESCRIPTION
Put the fasl files in the build directory so that `make clean` actually removes them.