### PR TITLE
Eval defconfig forms during load time

### DIFF
--- a/lisp/config/config-system.lisp
+++ b/lisp/config/config-system.lisp
@@ -133,7 +133,7 @@ type specifier, and documentation"
   (check-type documentation string)
   (check-type name symbol)
   (with-gensyms (default-value)
-    `(progn
+    `(eval-when (:compile-toplevel :load-toplevel :execute)
        (let* ((,default-value ,default))
          (if (typep ,default-value (quote ,type-specifier))
              (progn


### PR DESCRIPTION
This fixes undefined variable warnings.