### PR TITLE
Create hrt_scene_root and hrt_scene_output and use them

### DIFF
--- a/heart/include/hrt/hrt_scene.h
+++ b/heart/include/hrt/hrt_scene.h
@@ -3,9 +3,31 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <hrt/hrt_output.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/types/wlr_scene.h>
 
+struct hrt_scene_root {
+    struct wlr_scene_tree *background;
+    struct wlr_scene_tree *bottom;
+    struct wlr_scene_tree *normal;
+    struct wlr_scene_tree *fullscreen;
+    struct wlr_scene_tree *top;
+    struct wlr_scene_tree *overlay;
+    // Should we store the outputs and groups associated with this?
+    struct {
+      struct wl_listener scene_destroy;
+    } listeners;
+};
+
+struct hrt_scene_output {
+    struct wlr_scene_tree *background;
+    struct wlr_scene_tree *bottom;
+
+    struct wlr_scene_tree *top;
+    struct wlr_scene_tree *overlay;
+};
 
 struct hrt_scene_group {
     struct wlr_scene_tree *normal;
@@ -19,7 +41,15 @@ struct hrt_scene_fullscreen_node {
     struct hrt_view *view;
 };
 
-struct hrt_scene_group *hrt_scene_group_create(struct wlr_scene_tree *parent);
+struct hrt_scene_root *hrt_scene_root_create(struct wlr_scene_tree *scene);
+
+void hrt_scene_root_destroy(struct hrt_scene_root *scene_root);
+
+struct hrt_scene_output *hrt_scene_output_create(struct hrt_scene_root *scene);
+
+void hrt_scene_output_destroy(struct hrt_scene_output *output);
+
+struct hrt_scene_group *hrt_scene_group_create(struct hrt_scene_root *parent);
 
 void hrt_scene_group_destroy(struct hrt_scene_group *group);
 
@@ -58,8 +88,8 @@ hrt_scene_fullscreen_node_destroy(struct hrt_scene_fullscreen_node *node);
 uint32_t hrt_scene_node_set_dimensions(struct hrt_scene_fullscreen_node *node,
                                        int width, int height);
 
-void hrt_scene_node_set_position(struct hrt_scene_fullscreen_node *node,
-				 int x, int y);
+void hrt_scene_node_set_position(struct hrt_scene_fullscreen_node *node, int x,
+                                 int y);
 
 uint32_t hrt_scene_fullscreen_configure(struct hrt_scene_fullscreen_node *group,
                                         struct hrt_output *output);

--- a/heart/src/output.c
+++ b/heart/src/output.c
@@ -150,7 +150,6 @@ bool hrt_output_init(struct hrt_server *server,
     wl_signal_add(&server->backend->events.new_output, &server->new_output);
 
     server->output_layout = wlr_output_layout_create(server->wl_display);
-    server->scene         = wlr_scene_create();
     server->scene_layout =
         wlr_scene_attach_output_layout(server->scene, server->output_layout);
 
@@ -180,10 +179,7 @@ bool hrt_output_init(struct hrt_server *server,
 }
 
 void hrt_output_destroy(struct hrt_server *server) {
-    wlr_scene_node_destroy(&server->scene->tree.node);
     wl_list_remove(&server->output_layout_changed.link);
-    // The output layout  gets destroyed when the display does:
-    // wlr_output_layout_destroy(server->output_layout);
-
+    // The output layout and scene root gets destroyed when the display does:
     wl_list_remove(&server->new_output.link);
 }

--- a/heart/src/server.c
+++ b/heart/src/server.c
@@ -65,6 +65,7 @@ bool hrt_server_init(struct hrt_server *server,
     wlr_data_control_manager_v1_create(server->wl_display);
     wlr_gamma_control_manager_v1_create(server->wl_display);
 
+    server->scene = wlr_scene_create();
     server->output_layout = wlr_output_layout_create(server->wl_display);
 
     server->view_callbacks = view_callbacks;
@@ -123,14 +124,15 @@ void hrt_server_finish(struct hrt_server *server) {
     // Some of these "destroy" calls should probably be hooked up to listen to the destroy
     // events of the wlr objects they attach listeners to instead of being cleaned
     // up here...
-    hrt_seat_destroy(&server->seat);
-    hrt_output_destroy(server);
     hrt_xdg_shell_destroy(server);
+    hrt_seat_destroy(&server->seat);
 
+    hrt_output_destroy(server);
     wlr_allocator_destroy(server->allocator);
     wlr_renderer_destroy(server->renderer);
     wlr_backend_destroy(server->backend);
     wl_display_destroy(server->wl_display);
+    wlr_scene_node_destroy(&server->scene->tree.node);
 }
 
 struct wlr_scene_tree *hrt_server_scene_tree(struct hrt_server *server) {

--- a/lisp/bindings/hrt-bindings.lisp
+++ b/lisp/bindings/hrt-bindings.lisp
@@ -276,6 +276,20 @@ set the width and height of views."
 
 ;; next section imported from file build/include/hrt/hrt_scene.h
 
+(cffi:defcstruct hrt-scene-root
+  (background :pointer #| (:struct wlr-scene-tree) |# )
+  (bottom :pointer #| (:struct wlr-scene-tree) |# )
+  (normal :pointer #| (:struct wlr-scene-tree) |# )
+  (fullscreen :pointer #| (:struct wlr-scene-tree) |# )
+  (top :pointer #| (:struct wlr-scene-tree) |# )
+  (overlay :pointer #| (:struct wlr-scene-tree) |# ))
+
+(cffi:defcstruct hrt-scene-output
+  (background :pointer #| (:struct wlr-scene-tree) |# )
+  (bottom :pointer #| (:struct wlr-scene-tree) |# )
+  (top :pointer #| (:struct wlr-scene-tree) |# )
+  (overlay :pointer #| (:struct wlr-scene-tree) |# ))
+
 (cffi:defcstruct hrt-scene-group
   (normal :pointer #| (:struct wlr-scene-tree) |# )
   (fullscreen :pointer #| (:struct wlr-scene-tree) |# ))
@@ -285,8 +299,20 @@ set the width and height of views."
   (background :pointer #| (:struct wlr-scene-rect) |# )
   (view (:pointer (:struct hrt-view))))
 
+(cffi:defcfun ("hrt_scene_root_create" hrt-scene-root-create) (:pointer (:struct hrt-scene-root))
+  (scene :pointer #| (:struct wlr-scene-tree) |# ))
+
+(cffi:defcfun ("hrt_scene_root_destroy" hrt-scene-root-destroy) :void
+  (scene-root (:pointer (:struct hrt-scene-root))))
+
+(cffi:defcfun ("hrt_scene_output_create" hrt-scene-output-create) (:pointer (:struct hrt-scene-output))
+  (scene (:pointer (:struct hrt-scene-root))))
+
+(cffi:defcfun ("hrt_scene_output_destroy" hrt-scene-output-destroy) :void
+  (output (:pointer (:struct hrt-scene-output))))
+
 (cffi:defcfun ("hrt_scene_group_create" hrt-scene-group-create) (:pointer (:struct hrt-scene-group))
-  (parent :pointer #| (:struct wlr-scene-tree) |# ))
+  (parent (:pointer (:struct hrt-scene-root))))
 
 (cffi:defcfun ("hrt_scene_group_destroy" hrt-scene-group-destroy) :void
   (group (:pointer (:struct hrt-scene-group))))

--- a/lisp/bindings/hrt-bindings.yml
+++ b/lisp/bindings/hrt-bindings.yml
@@ -2,9 +2,9 @@ output: lisp/bindings/hrt-bindings.lisp
 package: hrt
 pkg-config:
   - wlroots-0.19
+  - heart
 arguments:
   - "-DWLR_USE_UNSTABLE"
-  - "-Iheart/include"
 files:
   - build/include/hrt/hrt_input.h
   - build/include/hrt/hrt_view.h

--- a/lisp/bindings/package.lisp
+++ b/lisp/bindings/package.lisp
@@ -56,8 +56,12 @@
 	   #:keysyms-len
 	   #:wl-key-state
 	   ;; scene helpers:
+	   #:hrt-scene-root-create
+	   #:hrt-scene-root-destroy
 	   #:hrt-scene-group-create
 	   #:hrt-scene-group-destroy
+	   #:hrt-scene-output-create
+	   #:hrt-scene-output-destroy
 	   #:scene-group-add-view
 	   #:hrt-scene-group-set-enabled
 	   #:hrt-scene-group-transfer

--- a/lisp/events.lisp
+++ b/lisp/events.lisp
@@ -29,3 +29,12 @@
 	((view (:pointer (:struct hrt:hrt-view))))
   (log-string :trace "View maximize callback called!")
   (mahogany-state-view-maximize *compositor-state* view))
+
+(cffi:defcallback handle-new-output :void ((output (:pointer (:struct hrt:hrt-output))))
+  (mahogany-state-output-add *compositor-state* output))
+
+(cffi:defcallback handle-output-removed :void ((output (:pointer (:struct hrt:hrt-output))))
+  (mahogany-state-output-remove *compositor-state* output))
+
+(cffi:defcallback handle-output-layout-change :void ()
+  (mahogany-state-output-reconfigure *compositor-state*))

--- a/lisp/group.lisp
+++ b/lisp/group.lisp
@@ -1,7 +1,7 @@
 (in-package #:mahogany)
 
-(defun make-mahogany-group (name number scene-tree)
-  (let ((hrt-group (hrt:hrt-scene-group-create scene-tree)))
+(defun make-mahogany-group (name number hrt-scene)
+  (let ((hrt-group (hrt:hrt-scene-group-create hrt-scene)))
     (hrt:hrt-scene-group-set-enabled hrt-group nil)
     (log-string :debug "Created group ~A" name)
     (%make-mahogany-group name number hrt-group)))

--- a/lisp/objects.lisp
+++ b/lisp/objects.lisp
@@ -1,7 +1,9 @@
 (in-package #:mahogany)
 
-(defstruct (mahogany-output (:constructor %make-mahogany-output (hrt-output full-name)))
+(defstruct (mahogany-output (:constructor %make-mahogany-output
+					  (hrt-output hrt-scene full-name)))
   (hrt-output cffi:null-pointer :type cffi:foreign-pointer :read-only t)
+  (hrt-scene  cffi:null-pointer :type cffi:foreign-pointer :read-only t)
   (full-name "" :type string :read-only t))
 
 (defstruct (mahogany-group (:constructor %make-mahogany-group (name number hrt-group)))
@@ -18,6 +20,8 @@
   ((hrt-server :type hrt-server
 	       :initarg server
 	       :accessor mahogany-state-server)
+   (hrt-scene :type hrt-scene
+	      :accessor mahogany-state-scene)
    (key-state :type key-state
 	      :initform (make-key-state nil)
 	      :accessor mahogany-state-key-state)
@@ -26,7 +30,7 @@
    (keybindings :type list
 		:initform nil
 		:reader mahogany-state-keybindings)
-   (outputs :type vector
+   (outputs :type (vector mahogany-output *)
 	    :initform (make-array 0
 				  :element-type 'mahogany-output
 				  :adjustable t

--- a/lisp/output.lisp
+++ b/lisp/output.lisp
@@ -11,16 +11,10 @@
 		 (or model "")
 		 (or serial ""))))
 
-(defun make-mahogany-output (hrt-output)
-  (let ((name (%get-output-full-name hrt-output)))
-    (%make-mahogany-output hrt-output name)))
+(defun make-mahogany-output (hrt-output hrt-scene)
+  (let ((name (%get-output-full-name hrt-output))
+	(scene (hrt:hrt-scene-output-create hrt-scene)))
+    (%make-mahogany-output hrt-output scene name)))
 
-(cffi:defcallback handle-new-output :void ((output (:pointer (:struct hrt:hrt-output))))
-  (let ((mh-output (make-mahogany-output output)))
-    (mahogany-state-output-add *compositor-state* mh-output)))
-
-(cffi:defcallback handle-output-removed :void ((output (:pointer (:struct hrt:hrt-output))))
-  (mahogany-state-output-remove *compositor-state* output))
-
-(cffi:defcallback handle-output-layout-change :void ()
-  (mahogany-state-output-reconfigure *compositor-state*))
+(defun destroy-mahogany-output (mh-output)
+  (hrt:hrt-scene-output-destroy (mahogany-output-hrt-scene mh-output)))

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -55,7 +55,7 @@
 		   (:file "globals" :depends-on ("objects" "system"))
 		   (:file "transaction" :depends-on ("globals"))
 	       (:file "output" :depends-on ("objects" "bindings" "state"))
-	       (:file "view" :depends-on ("globals" "state" "objects" "bindings"))
+	       (:file "events" :depends-on ("globals" "state" "objects" "bindings"))
 	       (:file "input" :depends-on ("state" "keyboard" "bindings"))
 	       (:file "key-bindings" :depends-on ("globals" "state" "keyboard" "tree" "input"))
 	       (:file "main" :depends-on ("bindings" "keyboard" "input" "package"))))


### PR DESCRIPTION
This should make managing full screen and output layers easier. Contains a preliminary API for full screen groups.

+ With `mahogany-output`s needing information from the rest of the code, move their creation out of the callback handler.
  + Re-arrange events code into a single file, as it just contains handlers in an effort to make things a bit clearer
+ Change where the wlr_scene is initialized so we can destroy it later and still have initialization / destruction in the same file