### PR TITLE
WIP: Use Meson for coordinating entire build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,12 @@ jobs:
           && sbcl --noinform --load "$HOME/quicklisp/setup.lisp"  --eval "(progn (setf ql-util::*do-not-prompt* t)(ql:add-to-init-file))" \
           && sbcl --noinform --eval "(ql:quickload '("alexandria" "cl-ansi-text" "terminfo" "iterate" "cffi" "cffi-grovel" "closer-mop" "adopt"))" \
           && sbcl --noinform --eval "(ql:quickload '("fiasco"))"
-      - name: Build
-        run: make
+      - name: Setup
+        run: |
+          mkdir build
+          cd build
+          meson setup ..
       - name: Test
-        run: make test
+        run: |
+          cd build
+          ninja mahogany-test

--- a/build-mahogany.lisp
+++ b/build-mahogany.lisp
@@ -1,5 +1,0 @@
-(require 'asdf)
-
-(load "init-build-env.lisp")
-
-(asdf:make "mahogany/executable")

--- a/heart/meson.build
+++ b/heart/meson.build
@@ -1,14 +1,4 @@
-project(
-  'heart',
-  'c',
-  version: '0.1',
-  license: 'GPL',
-  default_options: [
-    'c_std=c11',
-    'warning_level=2',
-    'werror=true',
-  ],
-)
+heart_proj_name = 'heart'
 
 add_project_arguments(
   [
@@ -83,7 +73,7 @@ foreach name, have : features
 endforeach
 
 lib_hrt = library(
-  meson.project_name(), hrt_source_files,
+  heart_proj_name, hrt_source_files,
   dependencies: hrt_deps,
   include_directories: [hrt_inc, proto_inc],
   install: true
@@ -99,8 +89,8 @@ pkg = import('pkgconfig')
 pkg.generate(
   lib_hrt,
   version: meson.project_version(),
-  filebase: meson.project_name(),
-  name: meson.project_name(),
+  filebase: heart_proj_name,
+  name: heart_proj_name,
   description: 'Core package for mahogany wm',
   variables: hrt_vars,
 )

--- a/make-mahogany.lisp.in
+++ b/make-mahogany.lisp.in
@@ -6,14 +6,17 @@
 
 (let* ((task (first (uiop:command-line-arguments)))
        (root (pathname "@SOURCE_ROOT@/"))
-       (build-dir (pathname  "@BUILD_ROOT@/"))
-       (asdf-cache (make-pathname
-		    :directory (append
-				(pathname-directory build-dir)
-				(list
-				 "lisp"
-				 (uiop:implementation-identifier))))))
-  (format t "~%Using config:~% source root: ~S~%  cache-dir:~S~2%" root asdf-cache)
+       (build-dir (pathname "@BUILD_ROOT@/"))
+       (asdf-cache (merge-pathnames
+		    (make-pathname
+		     :directory (append
+				 (pathname-directory build-dir)
+				 (list
+				  "mahogany.p"
+				  (uiop:implementation-identifier))))
+		    build-dir)))
+  (format t "~%Using config:~%  source root: ~S~%  cache-dir:~S~%" root asdf-cache)
+  (finish-output)
   ;; See https://asdf.common-lisp.dev/asdf.html#Configuration-DSL-1
   ;; for what this is doing.
   ;; Basically, we want our local copies of dependencies in the dependencies folder

--- a/make-mahogany.lisp.in
+++ b/make-mahogany.lisp.in
@@ -2,8 +2,6 @@
 
 (declaim (optimize (debug 3)))
 
-(cl:pushnew :hrt-debug *features*)
-
 (let* ((task (first (uiop:command-line-arguments)))
        (root (pathname "@SOURCE_ROOT@/"))
        (build-dir (pathname "@BUILD_ROOT@/"))
@@ -14,9 +12,12 @@
 				 (list
 				  "mahogany.p"
 				  (uiop:implementation-identifier))))
-		    build-dir)))
-  (format t "~%Using config:~%  source root: ~S~%  cache-dir:~S~%" root asdf-cache)
+		    build-dir))
+       (lisp-features (list@LISP_FEATURES@)))
+  (format t "~%Using config:~%  source root: ~S~%  cache-dir: ~S~%  features: ~S~%"
+	  root asdf-cache lisp-features)
   (finish-output)
+  (setf *features* (append lisp-features *features*))
   ;; See https://asdf.common-lisp.dev/asdf.html#Configuration-DSL-1
   ;; for what this is doing.
   ;; Basically, we want our local copies of dependencies in the dependencies folder

--- a/make-mahogany.lisp.in
+++ b/make-mahogany.lisp.in
@@ -1,15 +1,19 @@
+(require 'asdf)
+
 (declaim (optimize (debug 3)))
 
 (cl:pushnew :hrt-debug *features*)
 
-(let* ((root (uiop/os:getcwd))
+(let* ((task (first (uiop:command-line-arguments)))
+       (root (pathname "@SOURCE_ROOT@/"))
+       (build-dir (pathname  "@BUILD_ROOT@/"))
        (asdf-cache (make-pathname
 		    :directory (append
-				(pathname-directory root)
+				(pathname-directory build-dir)
 				(list
-				 "build"
-				 "asdf-cache"
+				 "lisp"
 				 (uiop:implementation-identifier))))))
+  (format t "~%Using config:~% source root: ~S~%  cache-dir:~S~2%" root asdf-cache)
   ;; See https://asdf.common-lisp.dev/asdf.html#Configuration-DSL-1
   ;; for what this is doing.
   ;; Basically, we want our local copies of dependencies in the dependencies folder
@@ -26,4 +30,7 @@
   (asdf:initialize-output-translations
    `(:output-translations
      :inherit-configuration
-     (,(namestring root) ,(namestring asdf-cache)))))
+     (,(namestring root) ,(namestring asdf-cache))))
+  (cond
+    ((string= "build" task) (asdf:make "mahogany/executable"))
+    ((string= "test" task) (asdf:test-system "mahogany"))))

--- a/meson.build
+++ b/meson.build
@@ -12,9 +12,22 @@ project(
 
 subdir('heart')
 
+lisp_features = []
+if get_option('debug_utils')
+  lisp_features += ':hrt-debug'
+endif
+if get_option('xwayland').enabled()
+  lisp_features += ':hrt-xwayland'
+endif
+feature_str = ''
+foreach f : lisp_features
+  feature_str += ' ' +  f
+endforeach
+
 lisp_conf_data = configuration_data()
 lisp_conf_data.set('SOURCE_ROOT', meson.source_root())
 lisp_conf_data.set('BUILD_ROOT', meson.build_root())
+lisp_conf_data.set('LISP_FEATURES', feature_str)
 
 lisp_make_file = configure_file(
   input: 'make-mahogany.lisp.in',

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,69 @@
+project(
+  'mahogany',
+  'c',
+  version: '0.1',
+  license: 'GPL',
+  default_options: [
+    'c_std=c11',
+    'warning_level=2',
+    'werror=true',
+  ],
+)
+
+subdir('heart')
+
+lisp_conf_data = configuration_data()
+lisp_conf_data.set('SOURCE_ROOT', meson.source_root())
+lisp_conf_data.set('BUILD_ROOT', meson.build_root())
+
+lisp_make_file = configure_file(
+  input: 'make-mahogany.lisp.in',
+  output: 'make-mahogany.lisp',
+  configuration: lisp_conf_data,
+)
+
+lisp_inputs = [
+  lib_hrt,
+]
+
+lisp_c = get_option('lisp')
+
+lisp = find_program(lisp_c)
+
+if lisp_c == 'sbcl'
+  execute_lisp = [lisp, '--non-interactive', '--load', lisp_make_file]
+elif lisp_c == 'ccl'
+  sh = find_program('sh')
+  execute_lisp = [lisp, '-b', '--load', lisp_make_file, '--']
+else
+  error('Don\'t know how to  build using lisp implementation ' + lisp_c)
+endif
+
+mahogany_target = custom_target(
+  'mahogany',
+  command: execute_lisp + 'build',
+  build_always_stale: true,
+  build_by_default: true,
+  install: true,
+  output: 'mahogany',
+  input: lisp_inputs,
+  install_dir: get_option('bindir'),
+)
+
+libhrt_path = lib_hrt.full_path()
+
+mahogany_run_env = {
+  'LD_LIBRARY_PATH': libhrt_path.substring(0, -11)
+}
+
+run_target(
+  'run',
+  command: mahogany_target,
+  env: mahogany_run_env,
+)
+
+run_target(
+  'mahogany-test',
+  command: execute_lisp + 'test',
+  depends: [lib_hrt],
+)

--- a/meson.build
+++ b/meson.build
@@ -33,21 +33,24 @@ lisp = find_program(lisp_c)
 if lisp_c == 'sbcl'
   execute_lisp = [lisp, '--non-interactive', '--load', lisp_make_file]
 elif lisp_c == 'ccl'
-  sh = find_program('sh')
   execute_lisp = [lisp, '-b', '--load', lisp_make_file, '--']
+# Sadly, this won't even compile when using clasp:
+# elif lisp_c  == 'clasp'
+#   execute_lisp = [lisp, '--non-interactive', '--load', lisp_make_file, '--']
 else
   error('Don\'t know how to  build using lisp implementation ' + lisp_c)
 endif
 
 mahogany_target = custom_target(
   'mahogany',
-  command: execute_lisp + 'build',
-  build_always_stale: true,
+  command: execute_lisp + ['build'],
   build_by_default: true,
   install: true,
-  output: 'mahogany',
+  build_always_stale: true,
+  output: ['mahogany', 'mahogany.p'],
   input: lisp_inputs,
-  install_dir: get_option('bindir'),
+  install_dir: [get_option('bindir'), false],
+  console: true,
 )
 
 libhrt_path = lib_hrt.full_path()
@@ -58,12 +61,11 @@ mahogany_run_env = {
 
 run_target(
   'run',
-  command: mahogany_target,
+  command: mahogany_target[0],
   env: mahogany_run_env,
 )
 
 run_target(
   'mahogany-test',
-  command: execute_lisp + 'test',
-  depends: [lib_hrt],
+  command: execute_lisp + ['test']
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('xwayland', type: 'feature', value: 'auto', description: 'Enable support for X11 applications')
 option('example', type: 'boolean', value: true, description: 'Build example C application')
 option('debug_utils', type: 'boolean', value: true, description: 'Include utilities to add new outputs when running under wayland or X11')
+option('lisp', type: 'string', value: 'sbcl', description: 'Lisp compiler to use')

--- a/run-tests.lisp
+++ b/run-tests.lisp
@@ -1,5 +1,0 @@
-(require 'asdf)
-
-(load "init-build-env.lisp")
-
-(asdf:test-system "mahogany")


### PR DESCRIPTION
This allows us to use its configuration ability and makes the project easier to install

Pros:
+ We use one build tool for everything
+ We don't need to "install" the heart libraries to get them to run
+ We get install and configure functionality for (almost free)
+ It's a tiny bit faster

Cons:
+ Building Mahogany is a bit of a hack, but it works great
+ There doesn't seem to be a good way to set `LD_LIBRARY_PATH` for running mahogany without installing it, especially if you are using subprojects to pull in dependencies; this works in the Makefile setup because we install them locally.

TODO:
+ [ ] Add targets for generating bindings files
+ [ ] Find a better way to set LD_LIBRARY_PATH when running the executable
+ [ ] Update instructions
+ [ ] Add a target that cleans the lisp artifacts after every reconfigure.
