### PR TITLE
Remove hardcoded quit on `<ESC>`.

### DIFF
--- a/lisp/input.lisp
+++ b/lisp/input.lisp
@@ -39,10 +39,7 @@
   (let ((key-state (mahogany-state-key-state state)))
     (declare (type key-state key-state))
     (if (= event-state 1)
-	(or (check-and-run-keybinding key seat key-state)
-	    (when (eql 65307 (key-keysym key))
-	      (server-stop *compositor-state*)
-	      t))
+        (check-and-run-keybinding key seat key-state)
 	 (key-state-active-p key-state))))
 
 (defun %focus-frame-under-cursor (seat)


### PR DESCRIPTION
`<ESC>` is used in many scenarios, and should not be hardcoded as quitting.

For example,

1. To exit insert mode in vim, someone uses `<esc>`.
2. Someone likes to bind their capslock as `ctrl` and `<esc>`, depending on how long it's pressed.