### PR TITLE
Add a useful link in the note.

### DIFF
--- a/doc/devel/proposal/initial-plan.org
+++ b/doc/devel/proposal/initial-plan.org
@@ -94,13 +94,13 @@
     and sink selection.
 * Undecided
 ** Mode line
-   + see wlr-protocols and layer-shell
+   + see wlr-protocols and [[https://codeberg.org/dwl/dwl/src/branch/main/protocols/wlr-layer-shell-unstable-v1.xml#][layer-shell]]
 ** Menu windows
-   + see wlr-protocols and layer-shell
+   + see wlr-protocols and [[https://codeberg.org/dwl/dwl/src/branch/main/protocols/wlr-layer-shell-unstable-v1.xml#][layer-shell]]
    + Menu windows that the user interacts with could be implemented as
     a major mode that puts all input into the menu instead of
     re-directing it to the windows.
 ** Notification windows
    Dunst for wayland?
-   + see wlr-protocols and layer-shell
+   + see wlr-protocols and [[https://codeberg.org/dwl/dwl/src/branch/main/protocols/wlr-layer-shell-unstable-v1.xml#][layer-shell]] 
 ** IPC for modeline, testing


### PR DESCRIPTION
It shows how DWM for Wayland (DWL) implements layer shell, which is necessary for mode-line, `rofi` etc.

This is directly helpful for one goal in the 0.1.0 roadmap https://github.com/stumpwm/mahogany/issues/85