### PR TITLE
Implement kmap-modes and setting the prefix key

### DIFF
--- a/doc/kmap-modes.org
+++ b/doc/kmap-modes.org
@@ -1,0 +1,35 @@
+#+TITLE: Keymap modes
+
+It's possbile to bundle keymaps into =kmap-modes=, which allow those
+keymaps to be enabled or disabled by calling a function. To define a
+keymap mode, use the =define-kmap-mode= macro:
+
+#+BEGIN_SRC lisp
+  (define-kmap-mode example-mode
+    :documentation "An example keymap mode"
+    :top-binding (define-kmap
+  				 (kbd "s-e") #'do-foo)
+    :prefix-binding (define-kmap
+  					(kbd "e") #'do-bar))
+#+END_SRC
+
+The macro takes the name of the mode, as well as three optional
+keyword arguments:
++ =documentation= :: The documentatoin associated with this mode
++ =top-binding= :: The keymap the gets bound to the top level when
+  the mode is activated
++ =prefix-binding= :: The keymap that gets bound behind the prefix key
+  when the mode is activated
+
+This macro generates a function with the same name as the mode that
+allows you to activate or deactivate the mode:
+
+#+BEGIN_SRC lisp
+  ;; activate the mode
+  (example-mode)
+  ;; deactivate the mode
+  (example-mode nil)
+#+END_SRC
+
+If the argument to this function is a truthy value, the mode is
+activated; otherwise, the the mode is deactivated.

--- a/lisp/key-bindings.lisp
+++ b/lisp/key-bindings.lisp
@@ -100,11 +100,17 @@
 		     (kbd "p") #'previous-view
 		     (kbd "g") *group-map*))
 
-(defvar *top-map* (define-kmap
-		    (kbd "C-t") *root-map*))
+(defvar *top-map* (define-kmap))
+
 #+:hrt-debug
 (progn
   (define-key *root-map* (kbd "d") *debug-map*))
 
-(setf (mahogany-state-keybindings *compositor-state*)
-      (list *top-map*))
+;; Instead of using the macro, maybe we should define this manually
+;; so users can't deactivate it?
+(define-kmap-mode base-mode
+  :documentation "Base mode for mahogany that contains the default keybindings"
+  :top-binding *top-map*
+  :prefix-binding *root-map*)
+
+(base-mode t)

--- a/lisp/keyboard/package.lisp
+++ b/lisp/keyboard/package.lisp
@@ -17,6 +17,7 @@
 	   #:define-key
 	   #:kmap-p
 	   #:kmap
+	   #:make-kmap
 	   #:kmap-lookup
 	   #:key-state
 	   #:make-key-state

--- a/lisp/kmap-modes.lisp
+++ b/lisp/kmap-modes.lisp
@@ -1,0 +1,93 @@
+(in-package #:mahogany)
+
+(defstruct (kmap-mode (:constructor make-kmap-mode
+						  (name top-binding prefix-binding doc)))
+  (name nil :type symbol :read-only t)
+  (doc "" :type (or null string) :read-only t)
+  (top-binding (make-kmap) :type kmap :read-only t)
+  (prefix-binding (make-kmap) :type kmap :read-only t)
+  (top-kmap nil :type (or null kmap)))
+
+(defun kmap-mode-deactivate (state kmap-mode)
+  (declare (type kmap-mode kmap-mode)
+		   (mahogany-state state))
+  (with-accessors ((active-bindings mahogany-state-keybindings)
+				   (active-modes mahogany-active-kmap-modes))
+	  state
+	(labels ((relevant-kmap-p (kmap)
+			   (declare (type kmap kmap))
+			   (or (eq (kmap-mode-top-kmap kmap-mode) kmap)
+				   (eq (kmap-mode-top-binding kmap-mode) kmap))))
+	  (setf active-bindings (delete-if #'relevant-kmap-p active-bindings)))
+	(setf (kmap-mode-top-kmap kmap-mode) nil)
+	(setf active-modes (delete kmap-mode active-modes))))
+
+(defun %kmap-mode-active-in-state (state kmap-mode)
+  (declare (type kmap-mode kmap-mode)
+		   (type mahogany-state state))
+  (member kmap-mode (mahogany-active-kmap-modes state) :test #'eq))
+
+(defun kmap-mode-activate (state kmap-mode)
+  (declare (type kmap-mode kmap-mode)
+		   (type mahogany-state state))
+  ;; if it already appears to be active, do nothing:
+  (when (%kmap-mode-active-in-state state kmap-mode)
+	(assert (not (null (kmap-mode-top-kmap kmap-mode))))
+	(return-from kmap-mode-activate))
+  (with-accessors ((keybindings mahogany-state-keybindings)
+				   (active-kmap-modes mahogany-active-kmap-modes)
+				   (prefix-key mahogany-state-prefix-key))
+	  state
+	(let ((top-kmap (define-kmap
+					  prefix-key (kmap-mode-prefix-binding kmap-mode))))
+	  (setf (kmap-mode-top-kmap kmap-mode) top-kmap)
+	  (push top-kmap keybindings)
+	  (push (kmap-mode-top-binding kmap-mode) keybindings)
+	  (push kmap-mode active-kmap-modes)))
+  (values))
+
+(defparameter *kmap-modes* nil
+  "List of defined kmap modes")
+
+(defun %validate-mode-symbol (symbol)
+  (let* ((name (symbol-name symbol))
+		 (len (length name)))
+	(cond
+	  ((<= len 5)
+	   (error "Mode symbol cannot be named \"-mode\""))
+	  ((not (string-equal "-mode" (subseq name (- len 5))))
+	   (error "Mode symbol name must end in \"-mode\"")))))
+
+;; TODO: Make it possible to redefine kmap-modes,
+;;  get a list of available kmap modes
+(defmacro define-kmap-mode (name &key
+								   documentation
+								   (top-binding (make-kmap))
+								   (prefix-binding (make-kmap)))
+
+  (%validate-mode-symbol name)
+  `(let ((kmap-mode (make-kmap-mode (quote ,name)
+									  ,top-binding
+									  ,prefix-binding
+									  ,documentation)))
+	 (pushnew kmap-mode *kmap-modes* :key #'kmap-mode-name)
+	 (defun ,name (&optional (activate t))
+	   (if activate
+		   (kmap-mode-activate *compositor-state* kmap-mode)
+		   (kmap-mode-deactivate *compositor-state* kmap-mode)))))
+
+(defun (setf mahogany-state-prefix-key) (key state)
+  (declare (type key key)
+		   (type mahogany-state state))
+  (with-accessors ((active-modes mahogany-active-kmap-modes))
+	  state
+	(let ((new-bindings nil))
+	  ;; go backwards so pushing gets us the same order:
+	  (dolist (mode active-modes)
+		(let ((new-top-kmap (define-kmap
+							  key (kmap-mode-prefix-binding mode))))
+		  (setf (kmap-mode-top-kmap mode) new-top-kmap)
+		  (push new-top-kmap new-bindings)
+		  (push (kmap-mode-top-binding mode) new-bindings)))
+	  (setf (mahogany-state-keybindings state) new-bindings
+			(slot-value state 'prefix-key) key))))

--- a/lisp/objects.lisp
+++ b/lisp/objects.lisp
@@ -29,7 +29,14 @@
 		  :accessor mahogany-current-group)
    (keybindings :type list
 		:initform nil
-		:reader mahogany-state-keybindings)
+				:reader mahogany-state-keybindings)
+   (active-kmap-modes :type list
+					  :initform nil
+					  :accessor mahogany-active-kmap-modes)
+   (prefix-key :type key
+			   :initform (kbd "C-t")
+			   :reader mahogany-state-prefix-key
+			   :documentation "The prefix key used for prefix-bound kmaps.")
    (outputs :type (vector mahogany-output *)
 	    :initform (make-array 0
 				  :element-type 'mahogany-output

--- a/mahogany-test.asd
+++ b/mahogany-test.asd
@@ -11,7 +11,8 @@ This file is a part of mahogany.
   :components ((:file "util")
 	       (:file "ring-list")
 	       (:file "tree-tests" :depends-on ("util"))
-	       (:file "keyboard-tests")
+		   (:file "keyboard-tests")
+		   (:file "kmap-modes")
 	       (:file "config-system-tests")
 	       (:file "log-tests"))
   :description "Test System for mahogany."

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -54,11 +54,12 @@
 	       (:file "group" :depends-on ("transaction" "objects" "bindings"))
 	       (:file "state" :depends-on ("objects" "transaction" "keyboard"))
 		   (:file "globals" :depends-on ("objects" "system"))
+		   (:file "kmap-modes" :depends-on ("objects" "globals" "keyboard"))
 		   (:file "transaction" :depends-on ("globals"))
 	       (:file "output" :depends-on ("objects" "bindings" "state"))
 	       (:file "events" :depends-on ("globals" "state" "objects" "bindings"))
 	       (:file "input" :depends-on ("state" "keyboard" "bindings"))
-	       (:file "key-bindings" :depends-on ("globals" "state" "keyboard" "tree" "input"))
+	       (:file "key-bindings" :depends-on ("kmap-modes" "state" "tree" "input"))
 	       (:file "main" :depends-on ("bindings" "keyboard" "input" "package"))))
 
 (asdf:defsystem #:mahogany/executable

--- a/test/kmap-modes.lisp
+++ b/test/kmap-modes.lisp
@@ -1,0 +1,8 @@
+(fiasco:define-test-package #:mahogany-tests/kmap-modes
+  (:use #:mahogany))
+
+(in-package #:mahogany-tests/kmap-modes)
+
+(fiasco:deftest define-kmap-mode-signals-when-name-wrong ()
+  (signals simple-error (macroexpand `(mahogany::define-kmap-mode foo)))
+  (signals simple-error (macroexpand '(mahogany::define-kmap-mode -mode))))


### PR DESCRIPTION
kmap-modes are similar to emacs's global minor modes, where activating them adds keybindings and deactivating them removes them.
+ Add `active-kmap-modes` and `prefix-key` slots to mahogany state.
+ New functions `kmap-mode-deactivate`, `kmap-mode-activate`, which are intended to be internal functions

Closes #52.