### PR TITLE
Add ability to pass through key events

### DIFF
--- a/lisp/key-bindings.lisp
+++ b/lisp/key-bindings.lisp
@@ -101,4 +101,10 @@
   :top-binding *top-map*
   :prefix-binding *root-map*)
 
+(define-kmap-mode prefix-passthrough-mode
+  :documentation "Kmap mode that makes pressing the prefix key twice in a row
+send the prefix key to the focused client."
+  :prefix-binding *prefix-passthrough-kmap*)
+
 (base-mode t)
+(prefix-passthrough-mode t)

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -55,12 +55,14 @@
 	           (:file "group" :depends-on ("transaction" "objects" "bindings"))
 	           (:file "state" :depends-on ("objects" "transaction" "keyboard"))
 	           (:file "globals" :depends-on ("objects" "system"))
-	           (:file "kmap-modes" :depends-on ("objects" "globals" "keyboard"))
+	           (:file "kmap-modes"
+                :depends-on ("objects" "globals" "keyboard" "input" "command"))
 	           (:file "transaction" :depends-on ("globals"))
 	           (:file "output" :depends-on ("objects" "bindings" "state"))
 	           (:file "events" :depends-on ("globals" "state" "objects" "bindings"))
-	           (:file "input" :depends-on ("state" "keyboard" "bindings"))
-	           (:file "key-bindings" :depends-on ("kmap-modes" "state" "tree" "input" "command"))
+	           (:file "input" :depends-on ("state" "keyboard" "bindings" "command"))
+	           (:file "key-bindings"
+                :depends-on ("kmap-modes" "state" "tree" "input" "command"))
 	           (:file "main" :depends-on ("bindings" "keyboard" "input" "package"))))
 
 (asdf:defsystem #:mahogany/executable


### PR DESCRIPTION
Add `prefix-passthrough-mode`, which makes hitting the prefix key twice in a row send the key event to the focused client. Since this is in a different mode that is turned on after the default keymap mode, it overshadows any potential mappings make in that mode.

Fixes #136.