### PR TITLE
Introduce output-usable-area

### DIFF
--- a/heart/include/hrt/hrt_output.h
+++ b/heart/include/hrt/hrt_output.h
@@ -4,12 +4,15 @@
 #include <wayland-server.h>
 
 #include <wlr/types/wlr_output.h>
+#include <wlr/util/box.h>
 
 #include <hrt/hrt_server.h>
 
 struct hrt_output {
     struct wlr_output *wlr_output;
     struct hrt_server *server;
+
+    struct wlr_box usable_area;
 
     struct wl_listener request_state;
     struct wl_listener frame;

--- a/lisp/bindings/hrt-bindings.lisp
+++ b/lisp/bindings/hrt-bindings.lisp
@@ -191,6 +191,7 @@ well behaved ones should."
 (cffi:defcstruct hrt-output
   (wlr-output :pointer #| (:struct wlr-output) |# )
   (server (:pointer (:struct hrt-server)))
+  (usable-area (:struct wlr:wlr-box))
   (request-state (:struct wl-listener))
   (frame (:struct wl-listener))
   (destroy (:struct wl-listener))

--- a/lisp/bindings/package.lisp
+++ b/lisp/bindings/package.lisp
@@ -1,5 +1,15 @@
+(defpackage #:wlr
+  (:use :cl #:wayland-server-core)
+  (:export
+   ;; Symbols for wlr-box:
+   #:wlr-box
+   #:x
+   #:y
+   #:width
+   #:height))
+
 (defpackage #:mahogany/core
-  (:use :cl #:wayland-server-core #:xkb)
+  (:use :cl #:wayland-server-core #:xkb #:wlr)
   (:local-nicknames (#:mh/interface #:mahogany/wm-interface))
   (:nicknames #:hrt)
   (:export #:hrt-output-callbacks
@@ -21,6 +31,7 @@
            #:hrt-seat-cursor-lx
            #:hrt-seat-cursor-ly
            #:hrt-seat-set-keymap
+           ;; output symbols:
            #:hrt-output
            #:hrt-output-name
            #:hrt-output-make
@@ -34,6 +45,7 @@
            ;; output methods:
            #:output-resolution
            #:output-position
+           #:output-usable-area
            ;; view-methods
            #:view
            #:view-reparent
@@ -75,14 +87,3 @@
            #:hrt-scene-fullscreen-configure
            #:scene-init-view
            #:load-foreign-libraries))
-
-(defpackage #:wlr
-  (:use :cl #:wayland-server-core)
-  (:export
-   #:scene-tree-create
-   #:scene-node-destroy
-   #:scene-node-set-position
-   #:scene-node-reparent
-   #:scene-node-set-enabled
-   ;; scene node slot:
-   #:node))

--- a/lisp/bindings/wrappers.lisp
+++ b/lisp/bindings/wrappers.lisp
@@ -15,3 +15,10 @@
   (declare (type cffi:foreign-pointer output))
   (with-return-by-value ((x :int) (y :int))
     (hrt-output-position output x y)))
+
+(defun output-usable-area (output)
+  (declare (type cffi:foreign-pointer output))
+  (let ((box (cffi:foreign-slot-pointer output '(:struct hrt-output)
+                                      'usable-area)))
+    (cffi:with-foreign-slots ((x y width height) box (:struct wlr-box))
+      (values x y width height))))

--- a/lisp/tree/output-node.lisp
+++ b/lisp/tree/output-node.lisp
@@ -3,9 +3,8 @@
 (defun reconfigure-node (node hrt-output)
   (declare (type output-node node)
            (type cffi:foreign-pointer hrt-output))
-  (multiple-value-bind (x y) (hrt:output-position hrt-output)
-    (set-position node x y))
-  (multiple-value-bind (width height) (hrt:output-resolution hrt-output)
+  (multiple-value-bind (x y width height) (hrt:output-usable-area hrt-output)
+    (set-position node x y)
     (set-dimensions node width height)))
 
 (defmethod set-position ((frame output-node) new-x new-y)


### PR DESCRIPTION
This defines where on the screen we can place tiled and floating frames, as the views using the layers shell protocol can get exclusive access to parts of it.
+ Use a dummy implementation until we figure out how that will work.

See #113, #85.