### PR TITLE
lisp: Add group-current-output

### DIFF
--- a/lisp/tree/package.lisp
+++ b/lisp/tree/package.lisp
@@ -43,4 +43,5 @@
            #:frame-view
            #:frame-next
            #:frame-prev
-           #:leafs-in))
+           #:leafs-in
+           #:output-node-output))

--- a/lisp/tree/tree-interface.lisp
+++ b/lisp/tree/tree-interface.lisp
@@ -69,7 +69,10 @@ of an already existing frame with the `set-split-frame-type` function")
   ((parent :initarg :parent
            :initform nil
            :type (or null tree-container)
-           :accessor frame-parent)))
+           :accessor frame-parent)
+   (output :initarg :output
+           :type (not null)
+           :reader output-node-output)))
 
 (deftype split-frame-type ()
   '(member :vertical :horizontal))
@@ -165,10 +168,10 @@ a view assigned to it."))
   (do ((cur-frame frame (frame-parent cur-frame)))
       ((root-frame-p cur-frame) cur-frame)))
 
-(defun tree-container-add (tree-container &key (x 0) (y 0) (width 100) (height 100))
+(defun tree-container-add (tree-container output &key (x 0) (y 0) (width 100) (height 100))
   (declare (type tree-container tree-container))
   (with-accessors ((container-children tree-children)) tree-container
-    (let* ((new-output (make-instance 'output-node :parent tree-container))
+    (let* ((new-output (make-instance 'output-node :parent tree-container :output output))
            (new-tree (make-instance 'view-frame :x x :y y :width width :height height
                                     :parent new-output))
            (prev-output (first container-children)))

--- a/test/tree-tests.lisp
+++ b/test/tree-tests.lisp
@@ -8,7 +8,7 @@
 (defun make-tree-for-tests (&key (x 0) (y 0) (width 100) (height 100))
   (let ((container (make-instance 'tree:tree-container)))
     (multiple-value-bind (output-node frame)
-        (tree:tree-container-add container :x x :y y :width width :height height)
+        (tree:tree-container-add container t :x x :y y :width width :height height)
       (values frame output-node))))
 
 (defun make-tree-frame (children &key split-direction (x 0) (y 0) (width 100) (height 100))


### PR DESCRIPTION
This returns the output that contains the currently focused frame.

Accomplish this by associating the output-nodes with the outputs, so it's possible to climb the frame tree to find which output a frame is contained within.