### PR TITLE
hrt: fix message when output not at (0,0)

### DIFF
--- a/heart/include/hrt/hrt_output.h
+++ b/heart/include/hrt/hrt_output.h
@@ -13,6 +13,7 @@ struct hrt_output {
     struct wlr_output *wlr_output;
     struct hrt_server *server;
     struct hrt_scene_output *scene;
+    struct wlr_scene_output *wlr_scene;
 
     struct wlr_box usable_area;
 

--- a/heart/src/message.c
+++ b/heart/src/message.c
@@ -168,6 +168,7 @@ out:
 
 static bool gravity_coords(enum window_gravity gravity,
                            int width, int height,
+                           int x, int y,
                            int min_x, int min_y,
                            int max_x, int max_y,
                            int *pos_x, int *pos_y) {
@@ -182,26 +183,23 @@ static bool gravity_coords(enum window_gravity gravity,
     if (width > container_width || height > container_height)
         return false;
 
-    int x = 0;
-    int y = 0;
-
     switch (gravity) {
         case GRAVITY_TOP_LEFT:
         case GRAVITY_BOTTOM_LEFT:
         case GRAVITY_LEFT:
-            x = min_x;
+            x += min_x;
             break;
 
         case GRAVITY_TOP_RIGHT:
         case GRAVITY_BOTTOM_RIGHT:
         case GRAVITY_RIGHT:
-            x = max_x - width;
+            x += max_x - width;
             break;
 
         case GRAVITY_TOP:
         case GRAVITY_BOTTOM:
         case GRAVITY_CENTER:
-            x = min_x + (container_width - width) / 2;
+            x += min_x + (container_width - width) / 2;
             break;
 
         default:
@@ -212,19 +210,19 @@ static bool gravity_coords(enum window_gravity gravity,
         case GRAVITY_TOP_LEFT:
         case GRAVITY_TOP_RIGHT:
         case GRAVITY_TOP:
-            y = min_y;
+            y += min_y;
             break;
 
         case GRAVITY_BOTTOM_LEFT:
         case GRAVITY_BOTTOM_RIGHT:
         case GRAVITY_BOTTOM:
-            y = max_y - height;
+            y += max_y - height;
             break;
 
         case GRAVITY_LEFT:
         case GRAVITY_RIGHT:
         case GRAVITY_CENTER:
-            y = min_y + (container_height - height) / 2;
+            y += min_y + (container_height - height) / 2;
             break;
 
         default:
@@ -273,6 +271,8 @@ bool hrt_toast_message(struct hrt_server *server,
     if (!gravity_coords(gravity,
                         scene_buffer->buffer->width,
                         scene_buffer->buffer->height,
+                        output->wlr_scene->x,
+                        output->wlr_scene->y,
                         margin_x * 2, margin_y * 2,
                         output->wlr_output->width - (margin_x * 2),
                         output->wlr_output->height - (margin_y * 2),

--- a/heart/src/output.c
+++ b/heart/src/output.c
@@ -115,6 +115,7 @@ static void handle_new_output(struct wl_listener *listener, void *data) {
         wlr_scene_output_create(server->scene, wlr_output);
     wlr_scene_output_layout_add_output(server->scene_layout, l_output,
                                        scene_output);
+    output->wlr_scene = scene_output;
 
     output->destroy.notify = handle_output_destroy;
     wl_signal_add(&wlr_output->events.destroy, &output->destroy);

--- a/lisp/bindings/hrt-bindings.lisp
+++ b/lisp/bindings/hrt-bindings.lisp
@@ -192,6 +192,7 @@ well behaved ones should."
   (wlr-output :pointer #| (:struct wlr-output) |# )
   (server (:pointer (:struct hrt-server)))
   (scene :pointer #| (:struct hrt-scene-output) |#)
+  (wlr-scene :pointer #| (:struct wlr-scene-output) |# )
   (usable-area (:struct wlr-box))
   (request-state (:struct wl-listener))
   (frame (:struct wl-listener))
@@ -262,10 +263,6 @@ set the width and height of views."
   (background :pointer #| (:struct wlr-scene-rect) |# )
   (view (:pointer (:struct hrt-view))))
 
-(declaim (inline hrt-scene-root-create))
-(cffi:defcfun ("hrt_scene_root_create" hrt-scene-root-create) (:pointer (:struct hrt-scene-root))
-  (scene :pointer #| (:struct wlr-scene-tree) |# ))
-
 (declaim (inline hrt-scene-root-destroy))
 (cffi:defcfun ("hrt_scene_root_destroy" hrt-scene-root-destroy) :void
   (scene-root (:pointer (:struct hrt-scene-root))))
@@ -277,10 +274,6 @@ set the width and height of views."
 (declaim (inline hrt-scene-output-destroy))
 (cffi:defcfun ("hrt_scene_output_destroy" hrt-scene-output-destroy) :void
   (output (:pointer (:struct hrt-scene-output))))
-
-(declaim (inline hrt-scene-group-create))
-(cffi:defcfun ("hrt_scene_group_create" hrt-scene-group-create) (:pointer (:struct hrt-scene-group))
-  (parent (:pointer (:struct hrt-scene-root))))
 
 (declaim (inline hrt-scene-group-destroy))
 (cffi:defcfun ("hrt_scene_group_destroy" hrt-scene-group-destroy) :void


### PR DESCRIPTION
Take into account the position of the output in layout coordinates when placing the message windows.

Another way this could have been solved is by using a wlr_scene_tree that has coordinates at the output's location, and setting the message window as its child. Since a children's coordinates are relative to its parent, we could keep the origin at (0,0). I choose not to do this because this feature isn't used elsewhere in the code base, and am afraid of introducing confusion.