### PR TITLE
Fix message window scaling

### DIFF
--- a/heart/src/message.c
+++ b/heart/src/message.c
@@ -328,7 +328,18 @@ bool hrt_toast_message(struct hrt_server *server,
         return false;
     }
 
+    /* apply nearest scaling if output has an integer scale factor, linear otherwise */
+    enum wlr_scale_filter_mode scale_filter = (ceilf(scale) == scale) ?
+        WLR_SCALE_FILTER_NEAREST :
+        WLR_SCALE_FILTER_BILINEAR;
+    if (message_box.width < message->base.width &&
+        message_box.height < message->base.height)
+        /* if we are scaling down, we should always choose linear */
+        scale_filter = WLR_SCALE_FILTER_BILINEAR;
+
+    wlr_scene_buffer_set_filter_mode(scene_buffer, scale_filter);
     wlr_scene_buffer_set_dest_size(scene_buffer, message_box.width, message_box.height);
+
     wlr_scene_node_set_position(&scene_buffer->node, message_box.x, message_box.y);
     wlr_scene_node_set_enabled(&scene_buffer->node, true);
 


### PR DESCRIPTION
fix message window coordinates calculation with mixed output scales

- change the default hardcoded message font size to 15 instead of 20
- apply scaling at the font rendering stage (pango) instead of cairo to avoid blurry text when upscaling
- use a cleaner way than #206 to get a specific output's base coordinates
- clean up and simplifiy message window coordinates calculations
- apply a scale filter on rendered scene_buffer