### PR TITLE
hrt: Add ability to customize message themes

### DIFF
--- a/heart/example/main.c
+++ b/heart/example/main.c
@@ -93,6 +93,33 @@ static const char *gravity_names[] = {
     "center"
 };
 
+static struct hrt_message_theme theme = {
+    .font             = "monospace 15",
+    .font_color       = {1, 1, 1, 1},
+    .background_color = {0, 0, 0, 1},
+    .border_color     = {1, 1, 1, 1},
+    .message_border_width = 1,
+    .message_padding      = 5,
+    .margin_x             = 15,
+    .margin_y             = 15,
+};
+
+static void show_message() {
+    char text[64];
+    snprintf(text, sizeof(text) - 1, "test message %u\ngravity: %s",
+             server.message_counter, gravity_names[server.message_gravity]);
+    bool shown =
+        hrt_toast_message(&server.server, server.current_output->output, text,
+                          server.message_gravity, &theme, 5000);
+    if (shown) {
+        server.message_counter++;
+        server.message_gravity++;
+        if (server.message_gravity > GRAVITY_MAX) {
+            server.message_gravity = 0;
+        }
+    }
+}
+
 static bool keyboard_callback(struct hrt_seat *seat,
                               struct hrt_keypress_info *info) {
     puts("Keyboard callback called");
@@ -111,17 +138,7 @@ static bool keyboard_callback(struct hrt_seat *seat,
                 seat, showNormalCursor ? "crossed_circle" : "left_ptr");
             showNormalCursor = !showNormalCursor;
         } else if (strcmp(buffer, "m") == 0 && server.current_output != NULL) {
-            char text[64];
-            snprintf(text, sizeof(text) - 1, "test message %u\ngravity: %s",
-                     server.message_counter,
-                     gravity_names[server.message_gravity]);
-            if (hrt_toast_message(&server.server, server.current_output->output,
-                                  text, server.message_gravity, 15, 15, 5000)) {
-                server.message_counter++;
-                server.message_gravity++;
-                if (server.message_gravity > GRAVITY_MAX)
-                    server.message_gravity = 0;
-            }
+            show_message();
         } else if (strcmp(buffer, "o") == 0 &&
                    wl_list_length(&server.outputs) > 1) {
             server.current_output =

--- a/heart/include/hrt/hrt_message.h
+++ b/heart/include/hrt/hrt_message.h
@@ -20,12 +20,22 @@ enum window_gravity {
     GRAVITY_MAX = GRAVITY_CENTER,
 };
 
+struct hrt_message_theme {
+    char *font;
+    float font_color[4];
+    float background_color[4];
+    float border_color[4];
+    int message_padding;
+    int message_border_width;
+    int margin_x;
+    int margin_y;
+};
+
 bool hrt_toast_message(struct hrt_server *server,
                        struct hrt_output *output,
                        const char *text,
                        enum window_gravity gravity,
-                       int margin_x,
-                       int margin_y,
+                       struct hrt_message_theme *theme,
                        int ms_delay);
 
 #endif

--- a/lisp/bindings/hrt-bindings.lisp
+++ b/lisp/bindings/hrt-bindings.lisp
@@ -349,14 +349,23 @@ Returns the view that was in the node."
   (:gravity-center 8)
   (:gravity-max 8))
 
+(cffi:defcstruct hrt-message-theme
+  (font (:pointer :char))
+  (font-color :float :count 4)
+  (background-color :float :count 4)
+  (border-color :float :count 4)
+  (message-padding :int)
+  (message-border-width :int)
+  (margin-x :int)
+  (margin-y :int))
+
 (declaim (inline hrt-toast-message))
 (cffi:defcfun ("hrt_toast_message" hrt-toast-message) :bool
   (server (:pointer (:struct hrt-server)))
   (output (:pointer (:struct hrt-output)))
   (text (:pointer :char))
-  (gravity window-gravity)
-  (margin-x :int)
-  (margin-y :int)
+  (gravity :int #| enum window-gravity |#)
+  (theme (:pointer (:struct hrt-message-theme)))
   (ms-delay :int))
 
 ;; next section imported from file build/include/hrt/hrt_server.h
@@ -409,7 +418,7 @@ Returns the view that was in the node."
   (server (:pointer (:struct hrt-server))))
 
 (declaim (inline hrt-server-scene-tree))
-(cffi:defcfun ("hrt_server_scene_tree" hrt-server-scene-tree) :pointer #| (:struct wlr-scene-tree) |#
+(cffi:defcfun ("hrt_server_scene_tree" hrt-server-scene-tree) :pointer #| (:struct wlr-scene-tree) |# 
   (server (:pointer (:struct hrt-server))))
 
 (declaim (inline hrt-server-seat))


### PR DESCRIPTION
Add the hrt_message_theme struct, which allows the following fields to be specified:
+ font
+ font_color
+ background_color
+ border_color
+ message_padding
+ message_border_width
+ margin_x
+ margin_y

See #192.