### PR TITLE
gimme-key: trying a popup for key hints

### DIFF
--- a/lisp/keyboard/gimme-key.lisp
+++ b/lisp/keyboard/gimme-key.lisp
@@ -1,0 +1,40 @@
+(in-package #:mahogany/keyboard)
+
+(defun sort-keymap-bindings (key-bindings)
+  "Sort the `key-BINDINGS' vector of a keymap based on their keys."
+  ;; NOTE this might be too costly on top-level keymaps, and it doesn't help
+  ;; that it will be called _every_ time you advance the state...
+  ;;
+  ;; ... doing the naive thing for now.
+  (sort key-bindings
+        #'(lambda (s1 s2)
+            (string-lessp (string-upcase s1) (string-upcase s2)))
+        :key #'(lambda (k)
+                 (with-output-to-string (s)
+                   (pprint-key (binding-key k) s)))))
+
+(defun gimme-key-pprint (map &optional (stream *standard-output*))
+  "just like `pprint-kmap`, but even prettier."
+  (declare (type kmap map) (type stream stream)
+           (optimize (safety 1)))
+  (pprint-logical-block (stream nil)
+    (pprint-indent :current 2 stream)
+    (princ "⤵" stream)
+    (loop :for binding :across (sort-keymap-bindings (kmap-bindings map))
+          :for key := (binding-key binding)
+          :for command := (binding-command binding)
+          :do (pprint-newline :mandatory stream)
+              (pprint-key key stream)
+              (write-string " : " stream)
+              (if (kmap-p command)
+                  (gimme-key-pprint command stream)
+                  (write
+                   (nth-value 2 (function-lambda-expression command)) ;NOTE not portable...
+                   :stream stream)))))
+
+(defun gimme-key-format (key-state)
+  (with-output-to-string (s)
+    (when-let ((themaplist (key-state-kmaps key-state)))
+      (dolist (kmap themaplist)
+        (gimme-key-pprint kmap s)
+        (format s "~%")))))

--- a/lisp/keyboard/package.lisp
+++ b/lisp/keyboard/package.lisp
@@ -7,6 +7,7 @@
            #:make-key
            #:print-key
            #:pprint-key
+           #:gimme-key-format
            #:key-keysym
            #:key-modifier-mask
            #:key-modifier-key-p

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -44,7 +44,8 @@
                         :components ((:file "package")
                                      (:file "keytrans")
                                      (:file "key")
-                                     (:file "kmap")))
+                                     (:file "kmap")
+                                     (:file "gimme-key")))
                (:module tree
                         :depends-on ("log" "util" "interfaces" "bindings")
                         :components ((:file "package")


### PR DESCRIPTION
A first attempt at this https://github.com/stumpwm/mahogany/issues/214#issuecomment-3857519823

Same basic code, hooking into `check-and-run-keybinding` and showing a toast with the pretty-printed keymap tree. Again, not quite intended for merging, but already some code to point at and perhaps use eventually.

Some issues:

- This naively sorts the keybindings before iterating, which can get costly, but could be optimized later in the PR.
- To figure out the function name, I used `function-lambda-expression`, despite warnings found online while searching for a solution. One idea here could be the `binding` struct having a "name" or "description" field... I wonder if the default could be populated automatically from the symbol passed to `define-key`.
- Not sure where the `defconfig`s should go (or the whole `gimme-...` "package", for that matter...), and decided against burying them under `mahogany/keyboard`.
- Moving the code that kills the popup to the `reset-state` function overwrites the "keybinding undefined" warning, so I kept it where it was in the original patch.

The popup looks like this:
<img width="803" height="648" alt="2026-02-15-174228_803x648_scrot" src="https://github.com/user-attachments/assets/1421ca07-d341-400b-8512-57b49c9403cf" />

To address the issue of this popup taking over the screen, I was thinking of which-key's "dispatch menu" (by default at `C-h`), which implements paging. I think it could be a special test inside `check-and-run-keybinding`'s `cond` form, updating the toast and (somehow) keeping the state consistent. I might try that next unless you suggest something else.

Cheers