### PR TITLE
Implement command system using cl-interactive system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,8 @@ build/
 .ccls-cache
 .cache
 
-compile_commands.json# OCICL Package management
+compile_commands.json
+
+# Package management
 ocicl/
+/.qlot/

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "dependencies/cl-xkbcommon"]
 	path = dependencies/cl-xkbcommon
 	url = https://github.com/sdilts/cl-xkbcommon.git
+[submodule "dependencies/cl-interactive"]
+	path = dependencies/cl-interactive
+	url = https://github.com/sdilts/cl-interactive.git

--- a/lisp/command.lisp
+++ b/lisp/command.lisp
@@ -16,6 +16,12 @@
   (declare (ignore com arg))
   (cl-interactive:input-method-read im prompt :require-match nil))
 
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defun read-command-name (command input-method arg prompt)
+    (declare (ignore command arg))
+    (cl-interactive:completing-read input-method prompt
+                                    :completions cl-interactive:*default-command-database*)))
+
 (defmacro defcommand (name args &body impl)
   "Define a command that can be invoked interactively via a keybinding.
 
@@ -66,6 +72,14 @@ See the documentation for cl-interactive:define-command for more details.
                     (toast-message *compositor-state* (condition-text condition)
                                    :theme *message-error-theme*))))))))))))
 
-(defcommand colon ((cmd-line (:function #'read-command-name ": ")))
-  (:method ((exec string))
-    (toast-message *compositor-state* exec)))
+(defcommand colon (sequence
+                   seat
+                   (cmd-line (:function read-command-name ": ")))
+  (:method (sequence seat (exec string))
+    (let ((cmd (cl-interactive:find-command cl-interactive:*default-command-database*
+                                            exec)))
+      (if cmd
+          (execute-command cmd sequence seat)
+          (toast-message *compositor-state*
+                         (format nil "Command not found: ~A" exec)
+                         :theme *message-error-theme*)))))

--- a/lisp/command.lisp
+++ b/lisp/command.lisp
@@ -1,12 +1,71 @@
 (in-package #:mahogany)
 
-(defmacro defcommand (name (&key sequence seat) &body body)
-  (let ((seat-var (or seat (gensym "seat")))
-        (sequence-var (or sequence (gensym "sequence"))))
-  `(defun ,name (,sequence-var ,seat-var)
-     ,@(when (or (not sequence) (not seat))
-         `((declare ,@(when (not sequence)
-                       `((ignore ,sequence-var)))
-                   ,@(when (not seat)
-                       `((ignore ,seat-var))))))
-     ,@body)))
+(setf cl-interactive:*default-input-method*
+      #+sbcl
+      (make-instance 'foot-input-method)
+      #-sbcl
+      (make-instance 'rofi-input-method))
+
+(defparameter *input-methods-available*
+  (list
+   'rofi-input-method
+   #+sbcl
+   'foot-input-method))
+
+(defun interactively-read-string (com im arg prompt)
+  (declare (ignore com arg))
+  (cl-interactive:input-method-read im prompt :require-match nil))
+
+(defmacro defcommand (name args &body impl)
+  "Define a command that can be invoked interactively via a keybinding.
+
+ARGS defines the interactive and non-interactive arguments to the function;
+Interactive functions are denoted with (ARG-NAME ARG-SPEC), where ARG-SPEC
+describes how the argument is obtained interactively.
+
+Non-interactive arguments are injected from the surrounding context. Currently,
+two symbols are supported:
++ mahogany::seat, which is the seat that triggered the keybinding
++ mahogany::sequence, which is the sequence of keys pressed to trigger the
+  keybinding.
+If these symbols appear in the argument list, those args will
+be given the described values.
+
+BODY is the set of valid options for defgeneric.
+
+See the documentation for cl-interactive:define-command for more details.
+"
+  `(cl-interactive:define-command ,name ,args
+     ,@impl))
+
+(defun execute-command (function key-sequence seat)
+  ;; If there are no interactive arguments,
+  ;; we could just execute the command directly, but
+  ;; doing it in another thread allows for interactive
+  ;; error handling and keeps the behavior consistent between
+  ;; commands with and without interactive arguments.
+  (bt2:make-thread
+   (lambda ()
+     (cl-interactive:with-gathered-args
+           ((sequence key-sequence)
+            (seat seat))
+         gathered
+       (multiple-value-bind (func arg-list)
+           (cl-interactive:gather-args-interactively
+            function
+            :already-gathered gathered)
+         (when func
+           (hrt:run-in-main-thread
+            (lambda ()
+              (log-string :debug "Calling command ~S with args:~%~4T~S"
+                          func arg-list)
+              (hrt:with-view-transaction ()
+                (handler-case
+                    (cl-interactive:call-command-with-argument-list func arg-list)
+                  (invalid-operation (condition)
+                    (toast-message *compositor-state* (condition-text condition)
+                                   :theme *message-error-theme*))))))))))))
+
+(defcommand colon ((cmd-line (:function #'read-command-name ": ")))
+  (:method ((exec string))
+    (toast-message *compositor-state* exec)))

--- a/lisp/input-methods/foot-input-method.lisp
+++ b/lisp/input-methods/foot-input-method.lisp
@@ -1,0 +1,63 @@
+(in-package #:mahogany)
+
+(defclass foot-input-method (cl-interactive:input-method) ()
+  (:documentation "Input method that uses foot and fzf for interactive input"))
+
+(defmethod cl-interactive:prepare-completions-for-input-method
+    ((im foot-input-method) (completions cl-interactive:database))
+  (cl-interactive:database-strings completions))
+
+(defmethod cl-interactive:prepare-completions-for-input-method
+    ((im foot-input-method) (completions list))
+  (if (every #'stringp completions)
+      completions
+      (error 'cl-interactive:unknown-completions-error
+	     :input-method im
+	     :completions completions)))
+
+(defmethod cl-interactive:input-method-read ((im foot-input-method)
+					     (prompt string)
+					     &key completions require-match
+					       initial-input history)
+  (declare (ignore initial-input history))
+  (multiple-value-bind (read-fd write-fd)
+      (sb-unix:unix-pipe)
+    (unwind-protect
+	 (let ((curpid (sb-unix:unix-getpid))
+	       (read (sb-sys:make-fd-stream read-fd :input t))
+	       (write (sb-sys:make-fd-stream write-fd :output t)))
+	   (flet ((fzf-foot ()
+		        (multiple-value-bind (subrfd subwfd)
+			        (sb-unix:unix-pipe)
+		          (let ((write (sb-sys:make-fd-stream subwfd :output t)))
+			        (loop for comp in completions
+			              do (write-line comp write)
+				             (write-line comp))
+			        (force-output write)
+			        (sb-unix:unix-close subwfd)
+                    (let ((cmd (list "foot" "--" "sh" "-c"
+			                         (format nil "fzf --print-query --prompt=~S < /proc/~D/fd/~D | tail -1 > /proc/~D/fd/~D"
+				                             prompt curpid subrfd curpid write-fd))))
+			          (log-string :debug "Launching ~A" cmd)
+			          (uiop:launch-program cmd)))
+		          (unwind-protect (read-line read)
+			        (sb-unix:unix-close subrfd)))))
+	     (let ((pset nil)
+		       (res (fzf-foot)))
+	       (tagbody
+		    start
+		      (if require-match
+		          (if (find res completions :test #'string=)
+			          (return-from cl-interactive:input-method-read res)
+			          (progn
+			            (psetf pset t
+				               prompt (if pset
+					                      prompt
+					                      (concatenate 'string
+							                           "[Invalid Entry] "
+							                           prompt)))
+			            (setf res (fzf-foot))
+			            (go start)))
+		          (return-from cl-interactive:input-method-read res))))))
+      (sb-unix:unix-close write-fd)
+      (sb-unix:unix-close read-fd))))

--- a/lisp/input-methods/rofi-input-method.lisp
+++ b/lisp/input-methods/rofi-input-method.lisp
@@ -1,0 +1,58 @@
+(in-package #:mahogany)
+
+(defclass rofi-input-method (input-method) ())
+
+(defmethod prepare-completions-for-input-method
+    ((im rofi-input-method)
+     (completions cl-interactive:database))
+  (cl-interactive:database-strings completions))
+
+(defmethod input-method-read
+    ((im rofi-input-method) (prompt string)
+     &key completions require-match initial-input
+       history
+       &allow-other-keys)
+  (declare (ignore initial-input history))
+  (let ((pset nil))
+    (tagbody
+     start
+       (let ((res (run-simple-rofi prompt completions nil)))
+         (cond ((find res completions :test #'string=)
+                (return-from input-method-read res))
+               (require-match
+                (psetf pset t
+                       prompt (if pset
+                                  prompt
+                                  (concatenate 'string "[Invalid entry] "
+                                               prompt)))
+                (go start))
+               (t (return-from input-method-read res)))))))
+
+(defun run-rofi (arguments input)
+  "Run rofi syncronously."
+  (multiple-value-bind (o e s)
+      (uiop:run-program (cons "rofi" arguments)
+                        :output '(:string :stripped t)
+                        :input (make-string-input-stream
+                                (typecase input
+                                  (string input)
+                                  ((or (cons string cons)
+                                       (cons string null))
+                                   (format nil "~{~A~^~%~}" input))
+                                  (null "")
+                                  (otherwise
+                                   (error "invalid input to rofi"))))
+                        :ignore-error-status t
+                        :force-shell nil)
+    (if (= s 0)
+        (values o e s)
+        (error "rofi exited badly with status ~D" s))))
+
+(defun run-simple-rofi (prompt input &optional lines)
+  "Run rofi instead. whoops"
+  (multiple-value-bind (output error status)
+      (run-rofi (list* "-dmenu" "-p" prompt (when lines (list "-l" "10")))
+                input)
+    (cond ((= status 0)
+           (values output nil 0 nil))
+          (t (values nil error status output)))))

--- a/lisp/input.lisp
+++ b/lisp/input.lisp
@@ -48,14 +48,6 @@ Values:
                ((= *keyboard-focus-bits* 0)
                 :ignore)))))
 
-(defun execute-command (function key-sequence seat)
-  (hrt:with-view-transaction ()
-    (handler-case
-        (funcall function key-sequence seat)
-      (invalid-operation (condition)
-        (toast-message *compositor-state* (condition-text condition)
-                       :theme *message-error-theme*)))))
-
 (defun %unkown-keybinding-message (key-state last)
   (declare (optimize (speed 3) (safety 0))
            (type key-state key-state)

--- a/lisp/key-bindings.lisp
+++ b/lisp/key-bindings.lisp
@@ -99,6 +99,7 @@
 (defvar *root-map*
   (define-kmap
     (kbd "!") #'run-shell-command
+    (kbd ";") #'colon
     (kbd "o") #'next-frame
     (kbd "O") #'prev-frame
     (kbd "q") #'handle-server-stop

--- a/lisp/key-bindings.lisp
+++ b/lisp/key-bindings.lisp
@@ -1,68 +1,88 @@
 (in-package #:mahogany)
 
+(defcommand run-shell-command
+    ((shell-command (:function interactively-read-string "Exec: ")))
+  (:method ((exec string))
+    (uiop:launch-program exec)))
+
 (defcommand handle-server-stop ()
-  (server-stop *compositor-state*))
+  (:method ()
+    (server-stop *compositor-state*)))
 
 (defcommand open-terminal ()
-  (mh-sys:open-terminal))
+  (:method ()
+    (mh-sys:open-terminal)))
 
 (defcommand split-frame-h ()
-  "Split the current frame horizontally"
-  (let ((frame (mahogany-current-frame *compositor-state*)))
-    (when frame
-      (tree:split-frame-h frame :direction :right))))
+  (:documentation "Split the current frame horizontally")
+  (:method ()
+    (let ((frame (mahogany-current-frame *compositor-state*)))
+      (when frame
+        (tree:split-frame-h frame :direction :right)))))
 
 (defcommand split-frame-v ()
-  "Split the current frame horizontally"
-  (let ((frame (mahogany-current-frame *compositor-state*)))
-    (when frame
-      (tree:split-frame-v frame :direction :bottom))))
+  (:documentation "Split the current frame horizontally")
+  (:method ()
+    (let ((frame (mahogany-current-frame *compositor-state*)))
+      (when frame
+        (tree:split-frame-v frame :direction :bottom)))))
 
 (defcommand maximize-current-frame ()
-  (let ((group (state-current-group *compositor-state*)))
-    (group-maximize-current-frame group)))
+  (:method ()
+    (let ((group (state-current-group *compositor-state*)))
+      (group-maximize-current-frame group))))
 
 (defcommand close-current-view ()
-  (let ((frame (mahogany-current-frame *compositor-state*)))
-    (alexandria:when-let ((view (mahogany/tree:frame-view frame)))
-      (hrt:view-request-close view))))
+  (:method ()
+    (let ((frame (mahogany-current-frame *compositor-state*)))
+      (alexandria:when-let ((view (mahogany/tree:frame-view frame)))
+        (hrt:view-request-close view)))))
 
 (defcommand next-view ()
-  "Raise the next hidden view in the current group"
-  (let ((group (state-current-group *compositor-state*)))
-    (group-next-hidden group)))
+  (:documentation "Raise the next hidden view in the current group")
+  (:method ()
+    (let ((group (state-current-group *compositor-state*)))
+      (group-next-hidden group))))
 
 (defcommand previous-view ()
-  "Raise the next hidden view in the current group"
-  (let ((group (state-current-group *compositor-state*)))
-    (group-previous-hidden group)))
+  (:documentation "Raise the next hidden view in the current group")
+  (:method ()
+    (let ((group (state-current-group *compositor-state*)))
+      (group-previous-hidden group))))
 
-(defcommand next-frame (:seat seat)
-  (let ((group (state-current-group *compositor-state*)))
-    (group-next-frame group seat)))
+(defcommand next-frame (seat)
+  (:method (seat)
+    (let ((group (state-current-group *compositor-state*)))
+      (group-next-frame group seat))))
 
-(defcommand prev-frame (:seat seat)
-  (let ((group (state-current-group *compositor-state*)))
-    (group-prev-frame group seat)))
+(defcommand prev-frame (seat)
+  (:method (seat)
+    (let ((group (state-current-group *compositor-state*)))
+      (group-prev-frame group seat))))
 
 (defcommand gnew ()
-  (mahogany-state-group-add *compositor-state*))
+  (:method ()
+    (mahogany-state-group-add *compositor-state*)))
 
 (defcommand gkill ()
-  (let ((current-group (state-current-group *compositor-state*)))
-    (mahogany-state-group-remove *compositor-state* current-group)))
+  (:method ()
+    (let ((current-group (state-current-group *compositor-state*)))
+      (mahogany-state-group-remove *compositor-state* current-group))))
 
 (defcommand gnext ()
-  (state-next-hidden-group *compositor-state*))
+  (:method ()
+    (state-next-hidden-group *compositor-state*)))
 
 (defcommand gprev ()
-  (state-next-hidden-group *compositor-state*))
+  (:method ()
+    (state-next-hidden-group *compositor-state*)))
 
 #+:hrt-debug
 (defcommand add-output ()
-  (if (hrt:hrt-add-output (state-server *compositor-state*))
-      (log-string :info "Output not added")
-      (log-string :info "Output added")))
+  (:method ()
+    (if (hrt:hrt-add-output (state-server *compositor-state*))
+        (log-string :info "Output not added")
+        (log-string :info "Output added"))))
 
 #+:hrt-debug
 (defvar *debug-map*
@@ -78,6 +98,7 @@
 
 (defvar *root-map*
   (define-kmap
+    (kbd "!") #'run-shell-command
     (kbd "o") #'next-frame
     (kbd "O") #'prev-frame
     (kbd "q") #'handle-server-stop

--- a/lisp/kmap-modes.lisp
+++ b/lisp/kmap-modes.lisp
@@ -90,7 +90,8 @@ the KEYBINDINGS list."
            (kmap-mode-deactivate *compositor-state* kmap-mode)))))
 
 (defcommand passthrough-key-event ()
-  :pass-through)
+  (:method ()
+    :pass-through))
 
 (defvar *prefix-passthrough-kmap*
   (define-kmap

--- a/lisp/package.lisp
+++ b/lisp/package.lisp
@@ -5,6 +5,10 @@
         #:mahogany/wm-interface
         #:mahogany/util
         #:mahogany/keyboard)
+  (:import-from #:cl-interactive/input-method
+                #:input-method
+                #:prepare-completions-for-input-method
+                #:input-method-read)
   (:local-nicknames (#:tree #:mahogany/tree)
                     (#:colors #:cl-colors2)
                     (#:config #:config-system))

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -21,6 +21,7 @@
                #:fset
                #:bordeaux-threads
                #:float-features
+               #:cl-interactive
                #:cffi)
   :in-order-to ((test-op (test-op mahogany-test)))
   :pathname #p"lisp/"
@@ -69,8 +70,16 @@
                                      (:file "output-node" :depends-on ("tree-interface"))
                                      (:file "frame" :depends-on ("tree-interface"))
                                      (:file "view" :depends-on ("tree-interface"))))
+               (:module input-methods
+                :depends-on ("package")
+                ;; It would be cool to figure out module loading
+                ;; so that we could have a bunch of input methods
+                ;; but not have them loaded until needed:
+                :components ((:file "rofi-input-method")
+                             #+sbcl
+                             (:file "foot-input-method")))
                (:file "package")
-               (:file "command")
+               (:file "command" :depends-on ("input-methods"))
                (:file "objects" :depends-on ("package" "ring-list"))
                (:file "output-config" :depends-on ("heart"))
                (:file "message" :depends-on ("heart"))

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -79,10 +79,10 @@
                              #+sbcl
                              (:file "foot-input-method")))
                (:file "package")
-               (:file "command" :depends-on ("input-methods"))
+               (:file "command" :depends-on ("input-methods" "globals" "message"))
                (:file "objects" :depends-on ("package" "ring-list"))
                (:file "output-config" :depends-on ("heart"))
-               (:file "message" :depends-on ("heart"))
+               (:file "message" :depends-on ("heart" "config"))
                (:file "group" :depends-on ("objects" "heart" "globals"))
                (:file "state" :depends-on ("objects" "keyboard" "heart" "group"))
                (:file "globals" :depends-on ("objects" "system"))


### PR DESCRIPTION
## TODO:
+ [x] There needs to be a way to specify the current seat and key sequence
  arguments to interactive functions instead of using dynamic
  variables. cl-interactive doesn't have a documented way of doing
  this.
+ [ ] Implement a portable input method; the foot one that was added
  relies on SBCL.
+ [x] Don't use internal cl-interactive symbols
+ [x] Figure out what the license is for `cl-interactive` so we can actually use it.
+ [x] Import the `define-command` symbol into the `mahogany` package or add our own wrapper around the macro.

See #35.