### PR TITLE
lisp: Change how key passthrough works

### DIFF
--- a/doc/manual/kmap-keybindings.org
+++ b/doc/manual/kmap-keybindings.org
@@ -95,3 +95,22 @@ Only keys that can be represented in a key can be valid prefix keys;
 Modifiers by themselves cannot be set to the prefix key. This stops
 keys like =Super= from being used as the prefix key. If this is a
 problem, create an issue and we may be able to find a workaround.
+
+** Passing Through key events
+
+Some applications may accept a keyboard shortcut that is shadowed by
+Mahogany. For example, =C-t= will open a new tab in most browsers, but
+since that combination is the start of the default key sequence, it is
+impossible to use. To get around this, a binding can "pass through" to
+the underlying application. Instead of assigning a function to the
+kmap, specify `:pass-through` instead:
+
+#+BEGIN_SRC lisp
+  (add-to-kmap *top-map*
+    (kbd "C") :pass-through)
+#+END_SRC
+
+By default, Mahogany activates the =prefix-passthrough-mode=
+[[kmap-modes.org][kmap mode]], which has a binding so that passing the prefix binding
+twice will cause the second one to be passed through to the underlying
+application.

--- a/lisp/input.lisp
+++ b/lisp/input.lisp
@@ -77,13 +77,14 @@ Values:
              matched
              (when result
                (reset-state)
-               ;; Only consume the pressed key if the command doesn't
-               ;; return `:pass-through`
-               (not (eql (execute-command result
-                                          (key-state-sequence key-state) seat)
-                         :pass-through)))
-             ;; Consume the pressed key
-             t)
+               ;; Only consume the pressed key if we have a command
+               ;; and not a special keyword:
+               (if (eq :pass-through result)
+                   (return-from check-and-run-keybinding nil)
+                   (execute-command result
+		                    (key-state-sequence key-state) seat)))
+             ;; Consume the pressed key)
+	         t)
             (;; No keybinding was pressed but we were expecting one.
              handling-keybinding
              (toast-message *compositor-state* (%unkown-keybinding-message key-state key))

--- a/lisp/kmap-modes.lisp
+++ b/lisp/kmap-modes.lisp
@@ -89,13 +89,9 @@ the KEYBINDINGS list."
            (kmap-mode-activate *compositor-state* kmap-mode)
            (kmap-mode-deactivate *compositor-state* kmap-mode)))))
 
-(defcommand passthrough-key-event ()
-  (:method ()
-    :pass-through))
-
 (defvar *prefix-passthrough-kmap*
   (define-kmap
-    (state-prefix-key *compositor-state*) #'passthrough-key-event))
+    (state-prefix-key *compositor-state*) :pass-through))
 
 (defun (setf state-prefix-key) (key state)
   (declare (type key key)


### PR DESCRIPTION
Instead of having a command return whether or not the key event should pass through, specify that behavior in place of a command. This allows us to return immediately instead of needing to wait for interactive arguments to be gathered.

This fixes how keyboard pass through works with #233.