### PR TITLE
Add support for fullscreen XDG shell views

### DIFF
--- a/doc/devel/frame-tree.org
+++ b/doc/devel/frame-tree.org
@@ -1,11 +1,16 @@
-* Frame Tree
+* Tiling and the Frame Tree
+
+Tiling is accomplished via an n-ary tree, which is defined in the
+=mahogany/tree= package.
 
 There are three general types of nodes in the frame tree:
 
-+ Parent trees, represented by the =tree-frame= class
-+ Leaf frames, represented by the =view-frame= class. These nodes
++ *Output Nodes*, represented by the =output-node= class. These tie
+  the nodes below to an output and handle showing full screen windows.
++ *Leaf Frames*, represented by the =view-frame= class. These nodes
   contain application windows.
-+ Output nodes, represented by the =output-node= class.
++ *Tree Frames*, which represent splits in the frame tree. These
+  objects have a supertype of =frame-tree=.
 
 =tree-frame= objects are broken into two further categories:
 + =binary-tree-frame=, which represents a tree frame that always has
@@ -13,13 +18,54 @@ There are three general types of nodes in the frame tree:
 + =poly-tree-frame=, which represents a tree frame that has two or
   more children.
 
-Each complete tree is grouped into a =tree-container=, which contains
+Each complete tree is grouped into a =layer-container=, which contains
 one tree for each output that is currently visible.
 
+** Common Properties / Operations
+
++ Frame Navigation :: Each node in the frame tree has =frame-next= and
+  =frame-prev= attributes, which allow for iteration over the leafs in
+  the tree. In addition, they have =frame-parent= attribute to get the
+  node's parent.
++ Focus :: Each node in the frame tree can be marked as focused. What
+  exactly this does changes for each node type, but it provides a
+  mechanism to tell the compositor which frames have focus.
+
+** Classes
+
+*** Layer Container (=layer-container=)
+
+This class is not considered a part of the frame tree, but rather
+contains rendering information for the trees it contains. It also
+allows the root node in each tree to have a parent object. When used
+in a tiling layer, this class holds the list of visible output nodes.
+
+*** Output Nodes (=output-node=)
+
 The =output-node= class is the root of a frame tree, and has exactly
-one child, which is the actual tree graph. This class is here so that
-there is a fixed object that we can refer to when looking at the trees
-in the =tree-container= class; otherwise, operations like
-=replace-frame= and output manipulation become much more difficult to
-implement; without this, there is no fixed node to refer to instead of
-one that may be deleted or moved elsewhere in the tree.
+one child, which is the actual tree graph. This node contains the
+frame tree for the output and handles full screen views on the output.
+
+**** Fullscreen view handling
+
+When a view is fullscreened on an output node, the node starts to
+behave similarly to a view frame, although it keeps its children
+intact so that they can be restored when the view is no longer full
+screened.
+
+To full screen a view, the node places the view in an =hrt_scene_fullscreen_node=
+object provided by the backend. This node is only used for displaying
+the view; when the view no longer attached to the node, this object
+gets destroyed.
+
+*** Leaf Frames (=view-frame=)
+
+These frames hold application windows and manage their size and focus state.
+
+*** Tree Frames (=tree-frame=)
+
+~tree-frame~ objects represent split points in the layout tree, where
+space is partitioned into child frames.
+
+Tree frames can be split horizontally or vertically, and can have 2 or
+more children depending on the type.

--- a/heart/include/hrt/hrt_scene.h
+++ b/heart/include/hrt/hrt_scene.h
@@ -83,6 +83,10 @@ hrt_scene_create_fullscreen_node(struct hrt_scene_layer *layer,
                                  struct hrt_view *view,
                                  struct hrt_output *output);
 
+struct hrt_view *hrt_scene_fullscreen_swap(struct hrt_scene_fullscreen_node *node,
+                               struct hrt_view *view);
+
+
 /**
  * Destroy the given background node, moving the struct hrt_view to the
  * normral layer.

--- a/heart/include/hrt/hrt_view.h
+++ b/heart/include/hrt/hrt_view.h
@@ -66,6 +66,10 @@ void hrt_view_init(struct hrt_view *view, struct wlr_scene_tree *tree);
 
 void hrt_view_info(struct hrt_view *view);
 
+uint32_t hrt_view_fullscreen(struct hrt_view *view, bool fullscreen);
+
+bool hrt_view_fullscreened(struct hrt_view *view);
+
 /**
  * Request that this view be the given size. Returns the associated configure
  *serial.

--- a/heart/src/scene.c
+++ b/heart/src/scene.c
@@ -161,8 +161,20 @@ hrt_scene_create_fullscreen_node(struct hrt_scene_layer *layer,
 
     hrt_view_reparent(view, root);
     hrt_view_set_relative(view, 0, 0);
+    hrt_view_set_size(view, width, height);
 
     return new_node;
+}
+
+struct hrt_view *hrt_scene_fullscreen_swap(struct hrt_scene_fullscreen_node *node,
+			       struct hrt_view *view) {
+  struct hrt_view *v = node->view;
+  struct wlr_scene_tree *p = view->scene_tree->node.parent;
+  hrt_view_reparent(view, node->layer.tree);
+  hrt_view_reparent(node->view, p);
+  node->view = view;
+  hrt_view_fullscreen(view, true);
+  return v;
 }
 
 struct hrt_view *

--- a/heart/src/view.c
+++ b/heart/src/view.c
@@ -86,6 +86,11 @@ void hrt_view_unfocus(struct hrt_view *view, struct hrt_seat *seat) {
     wlr_seat_keyboard_notify_clear_focus(seat->seat);
 }
 
+bool hrt_view_focused(struct hrt_view *view) {
+  // FIXME: Should we be checking the pending or current state here?
+  return view->xdg_toplevel->current.activated;
+}
+
 void hrt_view_set_hidden(struct hrt_view *view, bool hidden) {
     wlr_scene_node_set_enabled(&view->scene_tree->node, !hidden);
 }
@@ -102,4 +107,12 @@ void hrt_view_send_configure(struct hrt_view *view) {
     if (view->xdg_toplevel->base->initialized) {
         wlr_xdg_surface_schedule_configure(view->xdg_toplevel->base);
     }
+}
+
+uint32_t hrt_view_fullscreen(struct hrt_view *view, bool fullscreen) {
+  return wlr_xdg_toplevel_set_fullscreen(view->xdg_toplevel, fullscreen);
+}
+
+bool hrt_view_fullscreened(struct hrt_view *view) {
+  return view->xdg_toplevel->current.fullscreen;
 }

--- a/lisp/events.lisp
+++ b/lisp/events.lisp
@@ -46,8 +46,7 @@
     ((view (:pointer (:struct hrt:hrt-view)))
      (output (:pointer (:struct hrt:hrt-output)))
      (fullscreen :bool))
-    ()
-  (log-string :trace "fullscreen requested: view ~S on output ~S" view output)
+    (:error-val nil)
   (mahogany-state-view-fullscreen *compositor-state* view output fullscreen))
 
 (hrt:define-hrt-callback handle-new-output :void

--- a/lisp/group.lisp
+++ b/lisp/group.lisp
@@ -133,11 +133,14 @@ to match."
       (declare (ignore found key))
       value)))
 
+(defun %group-current-output-node (group)
+  (let* ((cur-frame (mahogany-group-current-frame group))
+         (output-node (tree:find-root-frame cur-frame)))
+    output-node))
+
 (defun group-current-output (group)
   "Return the output that contains the group's currently focused frame"
-  (let* ((cur-frame (mahogany-group-current-frame group))
-         (output-node (tree:frame-parent (tree:find-root-frame cur-frame))))
-    (tree:output-node-output output-node)))
+  (tree:output-node-output (%group-current-output-node group)))
 
 (defun group-remove-output (group output seat)
   (declare (type hrt:output output)
@@ -167,9 +170,9 @@ to match."
     (push view (mahogany-group-views group))
     ;; We need to send a configure event, so we might as well
     ;; guess the size of the window:
-    (with-accessors ((focused-frame mahogany-group-current-frame))
-        group
-      (if focused-frame
+    (let ((focused-frame (mahogany-group-current-frame group)))
+      ;; TODO: Try to guess when there is a full screen view visible:
+      (if (and focused-frame (not (typep focused-frame 'tree:output-node)))
           (set-dimensions view (tree:frame-width focused-frame) (tree:frame-height focused-frame))
           (set-dimensions view 0 0)))
     view))
@@ -182,42 +185,54 @@ to match."
 		   (hidden mahogany-group-hidden-views))
       group
     (alexandria:when-let ((current-frame (mahogany-group-current-frame group)))
-      (alexandria:when-let ((view (tree:frame-view current-frame)))
-        (%add-hidden hidden view))
-      ;; we should be on the right layer already, but if we add frame rules
-      ;; or floating frames, we need to make sure the view goes in the right layer.
-      ;; I don't want to put this in the frame code until we had the layer shell code,
-      ;; as I don't think it will actually work there.
-      (let* ((layer (tree:frame-find-layer current-frame))
+      ;; By default, add new views to the tiled layer:
+      (let* ((layer (mahogany-group-tiled-container group))
              (hrt-layer (tree:layer-container-layer layer)))
         (hrt:scene-layer-add-view hrt-layer view))
-      ;; Adding a view to a frame dirties the view transaction:
-      (setf (tree:frame-view current-frame) view))))
+      (alexandria:when-let ((to-hide (tree:frame-view current-frame)))
+        (%add-hidden hidden to-hide))
+      (%swap-view-into-frame group current-frame view))))
 
 (declaim (inline %find-view-frame))
 (defun %find-view-frame (group view fn)
   (dolist (tree (tree:tree-children (mahogany-group-tiled-container group)))
+    ;; TODO: use foreach-leaf here:
     (dolist (f (mahogany/tree:get-populated-frames tree))
       (when (equalp (tree:frame-view f) view)
         (funcall fn f)))))
 
-(defun %group-remove-view (group view)
+(defun group-unmap-view (group view)
   (declare (type mahogany-group group))
   (with-accessors ((view-list mahogany-group-views)
                    (output-map mahogany-group-output-map)
                    (hidden mahogany-group-hidden-views))
       group
-    (hrt:with-view-transaction ()
-      (flet ((remove-and-populate (f)
-               (setf (tree:frame-view f) nil)
-               (alexandria:when-let ((new-view (%pop-hidden-item hidden)))
-                 (setf (tree:frame-view f) new-view))))
-        (%find-view-frame group view #'remove-and-populate))
-      (ring-list:remove-item hidden view)
-      (hrt:dirty-view-transaction))))
-
-(defun group-unmap-view (group view)
-  (%group-remove-view group view))
+    (log-string :trace "unmapping view ~S" view)
+    (alexandria:if-let ((f (tree:find-view-frame (mahogany-group-tiled-container group) view)))
+      (hrt:with-view-transaction ()
+        (etypecase f
+          (tree:output-node
+           (log-string :trace "unmapping fullscreen view ~S" view)
+           (let ((to-replace (ring-list:peek-item hidden)))
+             (cond
+               ((and to-replace (hrt:view-fullscreen-p to-replace))
+                (tree:set-fullscreen f (%pop-hidden-item hidden)))
+               (t
+                (%clear-fullscreen-state group f)
+                ;; reset the current frame:
+                (let ((to-focus (tree:find-focused-frame f)))
+                  ;; Don't pull from the hidden list unless we land on an empty frame:
+                  (when (and to-replace
+                             (not (tree:frame-view to-focus)))
+                    (setf (tree:frame-view to-focus) (%pop-hidden-item hidden)))
+                  (setf (mahogany-group-current-frame group) to-focus)
+                  (tree:mark-frame-focused to-focus (server-seat *compositor-state*)))))))
+          (tree:view-frame
+           (setf (tree:frame-view f) nil)
+           (when (> (ring-list:ring-list-size hidden) 0)
+             (%swap-view-into-frame group f (%pop-hidden-item hidden)))))
+        (hrt:dirty-view-transaction))
+      (ring-list:remove-item hidden view))))
 
 (defun group-remove-view (group view)
   (declare (type mahogany-group group))
@@ -239,11 +254,11 @@ to match."
 
 (defun %maximize-frame (group frame)
   (declare (type mahogany-group group))
-  (let ((tree-root (mahogany/tree:find-root-frame frame)))
+  (let ((topmost-frame (mahogany/tree:find-topmost-frame frame)))
     (flet ((hide-and-disable (view-frame)
              (alexandria:when-let ((view (tree:frame-view view-frame)))
                (%add-hidden (mahogany-group-hidden-views group) view))))
-      (tree:replace-frame tree-root frame #'hide-and-disable)))
+      (tree:replace-frame topmost-frame frame #'hide-and-disable)))
   (hrt:dirty-view-transaction))
 
 (defun group-maximize-current-frame (group)
@@ -253,10 +268,145 @@ currently focused frame"
   (let ((current-frame (mahogany-group-current-frame group)))
     (%maximize-frame group current-frame)))
 
+(defstruct (%hidden-view-info (:constructor %make-hidden-view-info (output frame)))
+  (output nil :type tree:output-node :read-only t)
+  (frame nil :type tree:view-frame :read-only t))
+
+(defun %hide-views-under-fullscreen (group output-node &optional (add-fun #'ring-list:add-item-prev))
+  (declare (optimize (speed 3))
+           (type mahogany-group group)
+           (type tree:output-node output-node)
+           (type (function (ring-list:ring-list T) (values fixnum)) add-fun))
+  (let ((hidden-views (mahogany-group-hidden-views group)))
+    (dolist (f (tree:get-populated-frames output-node))
+      (let ((v (tree:frame-view f)))
+        (unless (ring-list:contains-item hidden-views v)
+          (funcall add-fun hidden-views v)
+          (hrt:view-set-hidden v t))
+        (setf (gethash v (mahogany-group-hidden-view-map group))
+              (%make-hidden-view-info output-node f))))))
+
+(defun %group-make-fullscreen (group view output)
+  (declare (type (or null hrt:output) output)
+           (type hrt:view view)
+           (type mahogany-group group))
+  (hrt:view-set-fullscreen view t)
+  (alexandria:if-let ((frame (tree:find-view-frame
+			      (mahogany-group-tiled-container group)
+			      view)))
+    ;; The frame is visible, immediately fullscreen it:
+    (let ((output-node (if output
+			   (gethash (hrt:output-full-name output)
+                                    (mahogany-group-output-map group))
+			   (%group-current-output-node group))))
+      (unless output-node
+        (mahogany/log:log-string :warn "Could not find output when making view fullscreen")
+        (return-from %group-make-fullscreen nil))
+      (setf (tree:frame-view frame) nil)
+      (let ((prev-fullscreen (tree:set-fullscreen output-node view)))
+        (cond
+          (prev-fullscreen
+           (%add-hidden (mahogany-group-hidden-views group) prev-fullscreen))
+          (t
+           ;; Since there wasn't a fullscreen node here previously, mark all the views
+           ;; that it hides as hidden:
+           (%hide-views-under-fullscreen group output-node))))
+      ;; When a frame on the current output is focused, move the focus to the fullscreen
+      ;; view:
+      (when (eq (%group-current-output-node group)
+                output-node)
+        (tree:mark-frame-focused output-node (server-seat *compositor-state*))
+        (setf (mahogany-group-current-frame group) output-node)))
+    ;; Frame isn't visible; allow the view to be fullscreened and we will deal with it
+    ;; when it becomes visible:
+    (progn
+      (log-string :trace "Allowing hidden view to become fullscreen: ~S" view)))
+  ;; We always fulfull the request:
+  t)
+
+(defun %clear-fullscreen-state (group frame)
+  "Unmark the output node frame and make the views that are under it visible.
+After this function is ran, the current frame needs to be set and focused."
+  (declare (type tree:output-node frame)
+           (type mahogany-group group))
+  (let ((hidden-map (mahogany-group-hidden-view-map group)))
+    (loop :for hidden-view :being :the :hash-key
+            :of hidden-map
+              :using (hash-value data)
+          :when (eql frame (%hidden-view-info-output data))
+            :do (remhash hidden-view hidden-map)
+                (hrt:view-set-hidden hidden-view nil)
+                (ring-list:remove-item (mahogany-group-hidden-views group)
+                                       hidden-view
+                                       :test #'eql)))
+  (tree:unmark-frame-focused frame (server-seat *compositor-state*))
+  (tree:clear-fullscreen frame))
+
+(defun %group-unfullscreen (group view)
+  (declare (type mahogany-group group)
+           (type hrt:view view))
+  (hrt:view-set-fullscreen view nil)
+  (alexandria:if-let ((frame (tree:find-view-frame
+                              (mahogany-group-tiled-container group)
+                              view)))
+    ;; The frame is visible, we need to do some cleanup:
+    (cond
+      ((typep frame 'tree:output-node)
+       (%clear-fullscreen-state group frame)
+       (let ((to-focus (tree:find-focused-frame frame)))
+         (setf (mahogany-group-current-frame group) to-focus)
+         (alexandria:when-let ((prev (tree:frame-view to-focus)))
+           (%add-hidden (mahogany-group-hidden-views group) prev))
+         (setf (tree:frame-view to-focus) view)))
+      (t
+       ;; We aren't doing anything; communicate that to the calling code
+       nil))
+    (progn
+      (log-string :trace "Make hidden view not fullscreen: ~S" view))))
+
 (defun group-set-fullscreen (group view output set-fullscreen)
-  ;; TODO: implement me!
-  nil ; return nil to show no action was taken
-  )
+  (if set-fullscreen
+      (%group-make-fullscreen group view output)
+      (%group-unfullscreen group view)))
+
+(defun %swap-view-into-frame (group current-frame view)
+  (declare (type mahogany-group group)
+           (type (or null hrt:view) view))
+  (cond
+    ((hrt:view-fullscreen-p view)
+     (let* ((cur-output (%group-current-output-node group))
+            (prev-fullscreen (tree:set-fullscreen cur-output view)))
+       (unless prev-fullscreen
+         (%hide-views-under-fullscreen group cur-output #'ring-list:add-item))
+       (tree:mark-frame-focused cur-output (server-seat *compositor-state*))
+       (setf (mahogany-group-current-frame group) cur-output)))
+    (t
+     (let ((hidden-data (gethash view (mahogany-group-hidden-view-map group))))
+       (declare (type (or null %hidden-view-info) hidden-data))
+       (etypecase current-frame
+         (tree:output-node
+          (%clear-fullscreen-state group current-frame)
+          (cond
+            ((and hidden-data
+                  (eql (%hidden-view-info-output hidden-data) current-frame))
+             (log-string :trace "Hidden view is visible under fullscreen view")
+             ;; The view should be visible, focus its frame:
+             (let ((to-focus (%hidden-view-info-frame hidden-data)))
+               (setf (mahogany-group-current-frame group) to-focus)
+               (tree:mark-frame-focused to-focus (server-seat *compositor-state*))))
+            (t
+             (let ((to-focus (tree:find-focused-frame current-frame)))
+               (setf (mahogany-group-current-frame group) to-focus)
+               (alexandria:when-let ((prev (tree:frame-view to-focus)))
+                 (%add-hidden (mahogany-group-hidden-views group) prev))
+               (setf (tree:frame-view to-focus) view)))))
+         (tree:view-frame
+          (when hidden-data
+            (setf (tree:frame-view (%hidden-view-info-frame hidden-data))
+                  nil)
+            (remhash view (mahogany-group-hidden-view-map group)))
+          (setf (tree:frame-view current-frame) view))))))
+  (hrt:dirty-view-transaction))
 
 (defun group-next-hidden (group)
   (declare (type mahogany-group group))
@@ -267,8 +417,7 @@ currently focused frame"
       (alexandria:if-let ((view (tree:frame-view current-frame)))
         (setf next-view (%swap-next-hidden hidden-views view))
         (setf next-view (%pop-hidden-item hidden-views)))
-      (setf (tree:frame-view current-frame) next-view)
-      (hrt:dirty-view-transaction))))
+      (%swap-view-into-frame group current-frame next-view))))
 
 (defun group-previous-hidden (group)
   (declare (type mahogany-group group))
@@ -279,8 +428,7 @@ currently focused frame"
       (alexandria:if-let ((view (tree:frame-view current-frame)))
         (setf next-view (%swap-prev-hidden hidden-views view))
         (setf next-view (%pop-hidden-item hidden-views)))
-      (setf (tree:frame-view current-frame) next-view)
-      (hrt:dirty-view-transaction))))
+      (%swap-view-into-frame group current-frame next-view))))
 
 (defun group-next-frame (group seat)
   (declare (type mahogany-group group))

--- a/lisp/group.lisp
+++ b/lisp/group.lisp
@@ -272,6 +272,9 @@ currently focused frame"
   (output nil :type tree:output-node :read-only t)
   (frame nil :type tree:view-frame :read-only t))
 
+;; In order to swap between hidden views, we need to record which views are under
+;; a fullscreen view so that we can remove the view from its frame if it gets placed
+;; in a different one.
 (defun %hide-views-under-fullscreen (group output-node &optional (add-fun #'ring-list:add-item-prev))
   (declare (optimize (speed 3))
            (type mahogany-group group)

--- a/lisp/heart/hrt-bindings.lisp
+++ b/lisp/heart/hrt-bindings.lisp
@@ -135,6 +135,15 @@ names."
 (cffi:defcfun ("hrt_view_info" hrt-view-info) :void
   (view (:pointer (:struct hrt-view))))
 
+(declaim (inline hrt-view-fullscreen))
+(cffi:defcfun ("hrt_view_fullscreen" hrt-view-fullscreen) :uint32
+  (view (:pointer (:struct hrt-view)))
+  (fullscreen :bool))
+
+(declaim (inline hrt-view-fullscreened))
+(cffi:defcfun ("hrt_view_fullscreened" hrt-view-fullscreened) :bool
+  (view (:pointer (:struct hrt-view))))
+
 (declaim (inline hrt-view-set-size))
 (cffi:defcfun ("hrt_view_set_size" hrt-view-set-size) :uint32
   "Request that this view be the given size. Returns the associated configure
@@ -262,8 +271,7 @@ set the width and height of views."
   (overlay :pointer #| (:struct wlr-scene-tree) |#))
 
 (cffi:defcstruct hrt-scene-group
-  (layers :pointer #| (:struct wlr-scene-tree) |#)
-  (fullscreens :pointer #| (:struct wlr-scene-tree) |#))
+  (layers :pointer #| (:struct wlr-scene-tree) |#))
 
 (cffi:defcstruct hrt-scene-layer
   (tree :pointer #| (:struct wlr-scene-tree) |#))
@@ -318,16 +326,21 @@ destination layer"
 (cffi:defcfun ("hrt_scene_group_layers" hrt-scene-group-layers) :pointer #| (:struct wlr-scene-tree) |#
   (group (:pointer (:struct hrt-scene-group))))
 
-(declaim (inline hrt-scene-create-fullscreen-layer))
-(cffi:defcfun ("hrt_scene_create_fullscreen_layer" hrt-scene-create-fullscreen-layer) (:pointer (:struct hrt-scene-fullscreen-node))
+(declaim (inline hrt-scene-create-fullscreen-node))
+(cffi:defcfun ("hrt_scene_create_fullscreen_node" hrt-scene-create-fullscreen-node) (:pointer (:struct hrt-scene-fullscreen-node))
   "Create a hrt_scene_fullscreen_layer with a black bacground of the given size.
 Mode the hrt_view inside the node, removing it from where ever it was in the scene tree."
-  (group (:pointer (:struct hrt-scene-group)))
+  (layer (:pointer (:struct hrt-scene-layer)))
   (view (:pointer (:struct hrt-view)))
   (output (:pointer (:struct hrt-output))))
 
-(declaim (inline hrt-scene-fullscreen-layer-destroy))
-(cffi:defcfun ("hrt_scene_fullscreen_layer_destroy" hrt-scene-fullscreen-layer-destroy) (:pointer (:struct hrt-view))
+(declaim (inline hrt-scene-fullscreen-swap))
+(cffi:defcfun ("hrt_scene_fullscreen_swap" hrt-scene-fullscreen-swap) (:pointer (:struct hrt-view))
+  (node (:pointer (:struct hrt-scene-fullscreen-node)))
+  (view (:pointer (:struct hrt-view))))
+
+(declaim (inline hrt-scene-fullscreen-node-destroy))
+(cffi:defcfun ("hrt_scene_fullscreen_node_destroy" hrt-scene-fullscreen-node-destroy) (:pointer (:struct hrt-view))
   "Destroy the given background node, moving the struct hrt_view to the
 normral layer.
 Returns the view that was in the node."

--- a/lisp/heart/output.lisp
+++ b/lisp/heart/output.lisp
@@ -24,6 +24,7 @@
 (defun destroy-output (mh-output)
   (declare (ignore mh-output)))
 
+(declaim (inline output-resolution output-position))
 (defun output-resolution (output)
   (declare (type output output))
   (with-return-by-value ((width :int) (height :int))

--- a/lisp/heart/package.lisp
+++ b/lisp/heart/package.lisp
@@ -23,6 +23,8 @@
            #:hrt-view
            #:view-mapped
            #:view-unmapped
+           #:view-set-fullscreen
+           #:view-fullscreen-p
            #:request-minimize
            #:request-maximize
            #:request-fullscreen
@@ -109,6 +111,7 @@
            #:hrt-scene-group-set-position
            ;; #:hrt-scene-group-layers
            #:scene-create-fullscreen-node
-           #:hrt-scene-fullscreen-layer-destroy
-           #:hrt-scene-fullscreen-configure
+           #:hrt-scene-fullscreen-node-destroy
+           #:scene-fullscreen-configure
+           #:scene-fullscreen-swap
            #:load-foreign-libraries))

--- a/lisp/heart/scene-group.lisp
+++ b/lisp/heart/scene-group.lisp
@@ -7,12 +7,22 @@
   (hrt-scene-layer-add-view scene-layer (view-hrt-view view)))
 
 (declaim (inline scene-create-fullscreen-node))
-(defun scene-create-fullscreen-node (hrt-layer view hrt-output)
+(defun scene-create-fullscreen-node (hrt-layer view output)
   (declare (type view view)
-           (type cffi:foreign-pointer hrt-group hrt-output))
-  (let ((node (hrt-scene-create-fullscreen-node hrt-group
+           (type output output)
+           (type cffi:foreign-pointer hrt-layer))
+  (let ((node (hrt-scene-create-fullscreen-node hrt-layer
                                                  (view-hrt-view view)
-                                                 hrt-output)))
+                                                 (output-hrt-output output))))
     (if (not (cffi:null-pointer-p node))
         node
         (error "Could not allocate fullscreen node."))))
+
+(declaim (inline scene-fullscreen-swap))
+(defun scene-fullscreen-swap (hrt-node view)
+  (hrt-scene-fullscreen-swap hrt-node (view-hrt-view view)))
+
+(defun scene-fullscreen-configure (hrt-node output)
+  (declare (type output output)
+           (type cffi:foreign-pointer hrt-node))
+  (hrt-scene-fullscreen-configure hrt-node (output-hrt-output output)))

--- a/lisp/heart/view.lisp
+++ b/lisp/heart/view.lisp
@@ -18,6 +18,11 @@
   (declare (type view view))
   (hrt-view-unfocus (view-hrt-view view) seat))
 
+(declaim (inline view-focused-p))
+(defun view-focused-p (view)
+  (declare (type view view))
+  (hrt-view-focused (view-hrt-view view)))
+
 (declaim (inline view-mapped-p))
 (defun view-mapped-p (view)
   (declare (type view view))
@@ -43,7 +48,12 @@
 (declaim (inline view-set-fullscreen))
 (defun view-set-fullscreen (view fullscreen)
   (declare (type view view))
-  (hrt-view-set-fullscreen (view-hrt-view view) fullscreen))
+  (hrt-view-fullscreen (view-hrt-view view) fullscreen))
+
+(declaim (inline view-fullscreen-p))
+(defun view-fullscreen-p (view)
+  (declare (type view view))
+  (hrt-view-fullscreened (view-hrt-view view)))
 
 (declaim (inline view-configure))
 (defun view-configure (view)

--- a/lisp/key-bindings.lisp
+++ b/lisp/key-bindings.lisp
@@ -7,11 +7,13 @@
   (mh-sys:open-terminal))
 
 (defcommand split-frame-h ()
+  "Split the current frame horizontally"
   (let ((frame (mahogany-current-frame *compositor-state*)))
     (when frame
       (tree:split-frame-h frame :direction :right))))
 
 (defcommand split-frame-v ()
+  "Split the current frame horizontally"
   (let ((frame (mahogany-current-frame *compositor-state*)))
     (when frame
       (tree:split-frame-v frame :direction :bottom))))

--- a/lisp/objects.lisp
+++ b/lisp/objects.lisp
@@ -8,8 +8,11 @@
   (hrt-group (cffi:null-pointer) :type cffi:foreign-pointer :read-only t)
   (tiled-container nil :type tree:layer-container :read-only t)
   (output-map (make-hash-table :test 'equal) :type hash-table :read-only t)
-  (current-frame nil :type (or tree:frame null))
+  (current-frame nil :type (or tree:frame tree:output-node null))
   (hidden-views (ring-list:make-ring-list) :type ring-list:ring-list)
+  ;; Map that contains views hidden by fullscreen windows.
+  ;; view -> %hidden-view-info
+  (hidden-view-map (make-hash-table) :type hash-table)
   (views nil :type list))
 
 (defclass mahogany-state ()

--- a/lisp/ring-list/ring-list.lisp
+++ b/lisp/ring-list/ring-list.lisp
@@ -10,6 +10,7 @@
    #:pop-item
    #:pop-item-prev
    #:peek-item
+   #:contains-item
    #:swap-next
    #:swap-previous
    #:swap-next-find
@@ -176,6 +177,12 @@ Reverses the action that swap-next performs"
       (setf (ring-item-item prev) item
             head prev)
       prev-item)))
+
+(defun contains-item (ring-list item &key (test #'equalp))
+  (declare (type ring-list ring-list))
+  (let ((found (%find-item ring-list item test)))
+    (when found
+      (ring-item-item found))))
 
 ;; We need to re-define print-object to prevent infinite recursion
 ;; when chasing the next and previous pointers:

--- a/lisp/state.lisp
+++ b/lisp/state.lisp
@@ -201,6 +201,9 @@
   (let ((output (%find-output output-ptr (mahogany-state-outputs state))))
     (%with-found-view state (view view-ptr)
       (%with-found-group state (group view)
+        (log-string :debug
+                    "~@<Fullscreen requested (~:[no~;yes~]):~I ~:_view ~S ~:_on output ~S~:>"
+                    set-fullscreen view output)
 	(group-set-fullscreen group view output set-fullscreen)))))
 
 (defun mahogany-state-view-map (state view-ptr)

--- a/lisp/tree/frame.lisp
+++ b/lisp/tree/frame.lisp
@@ -140,7 +140,7 @@
 of FRAME to those of ROOT."
   ;; check to see if we are replacing the topmost node in a tree
   ;; and the output node we are associated with has no siblings
-  (if (and (root-frame-p root) (not (cdr (tree-children (frame-parent (frame-parent root))))))
+  (if (and (topmost-frame-p root) (not (cdr (tree-children (frame-parent (frame-parent root))))))
       (setf (%frame-next frame) frame
             (%frame-prev frame) frame)
       (psetf (%frame-next (frame-prev root)) frame
@@ -536,7 +536,7 @@ REMOVE-FUNC is called with one argument: the view that was removed."
       (return-from find-empty-frame empty)))
   nil)
 
-(defmethod find-view-frame ((root frame) view)
+(defmethod find-view-frame ((root tree-parent) view)
   (foreach-leaf (frame root)
     (alexandria:if-let ((f (find-view-frame frame view)))
       (return-from find-view-frame f)))

--- a/lisp/tree/output-node.lisp
+++ b/lisp/tree/output-node.lisp
@@ -4,14 +4,14 @@
   (declare (type output-node node)
            (type hrt:output output))
   (multiple-value-bind (x y width height) (hrt:output-usable-area output)
-    (set-position node x y)
-    (set-dimensions node width height)))
+    (set-position (first (tree-children node)) x y)
+    (set-dimensions (first (tree-children node)) width height))
+  (alexandria:when-let ((fullscreen-node (output-node-fullscreen node)))
+    (hrt:scene-fullscreen-configure (%fullscreen-data-node fullscreen-node) output)))
 
-(defmethod set-position ((frame output-node) new-x new-y)
-  (set-position (first (tree-children frame)) new-x new-y))
-
-(defmethod set-dimensions ((frame output-node) width height)
-  (set-dimensions (first (tree-children frame)) width height))
+;; Don't implement set-position and set-dimensions, as there are two differen
+;;  dimensions we need to worry about; the usable area for the tilted layers
+;;  and the full area for the fullscreen windows. These methods don't differentiate.
 
 (defmethod frame-prev ((frame output-node))
   (with-slots (children) frame
@@ -31,19 +31,107 @@
   (with-slots (children) frame
     (frame-next (car (last children)))))
 
-;; This is really awkward, as we don't want to
-;; declare an in-frame-p method for the tree-parent class,
-;; as we would overshadow the implementation for the `tree-frame`
-;; type, which needs to use the regular `frame` implementation:
+(defun set-fullscreen (output-node view)
+  "Set the given view to fullscreen on this output and return the previously fullscreened
+view, if there was one."
+  (declare (type output-node output-node))
+  ;; Re-arrange the next and prev pointers to point to this node instead of one its children:
+  (let ((prev (frame-prev output-node))
+        (next (frame-next output-node)))
+    (setf (%frame-next prev) output-node
+          (%frame-prev next) output-node))
+  (log-string :trace "~@<Making output node fullscreen:~I ~:_~S ~:_on layer ~S~:>"
+              output-node (layer-container-layer (frame-parent output-node)))
+  (let ((output (output-node-output output-node))
+        (fullscreen (output-node-fullscreen output-node)))
+    (alexandria:if-let ((fullscreen-data fullscreen))
+      ;; There's already a fullscreen item, swap the new one in:
+      (let ((fullscreen-node (%fullscreen-data-node fullscreen-data))
+            (other-view (%fullscreen-data-view fullscreen-data)))
+        (hrt:scene-fullscreen-swap fullscreen-node view)
+        (hrt:scene-fullscreen-configure fullscreen-node output)
+        (setf (%fullscreen-data-view fullscreen-data) view)
+        other-view)
+      (let* ((hrt-layer (layer-container-layer (frame-parent output-node)))
+             (fullscreen-node (hrt:scene-create-fullscreen-node hrt-layer view output)))
+        (log-string :trace "Created new fullscreen node for output")
+        (setf (output-node-fullscreen output-node) (%make-fullscreen-data view fullscreen-node))
+        nil))))
+
+(defun %find-first-child (frame)
+  (declare (type tree-parent frame))
+  (let ((f frame))
+    (loop :until (typep f 'view-frame)
+          :do (setf f (first (tree-children f))))
+    f))
+
+(defun %find-last-child (frame)
+  (declare (type tree-parent frame))
+  (let ((f frame))
+    (loop :until (typep f 'view-frame)
+          :do (setf f (car (last (tree-children f)))))
+    f))
+
+(defun clear-fullscreen (output-node)
+  (declare (type output-node output-node))
+  ;; reset the next and prev pointers to point to a child frame:
+  (let ((prev (frame-prev output-node))
+        (next (frame-next output-node)))
+    (setf (%frame-next prev) (%find-first-child output-node)
+	  (%frame-prev next) (%find-last-child output-node)))
+  (alexandria:when-let ((data (output-node-fullscreen output-node)))
+    (let ((node (%fullscreen-data-node data))
+          (view (%fullscreen-data-view data)))
+      (hrt:hrt-scene-fullscreen-node-destroy node)
+      (setf (output-node-fullscreen output-node) nil)
+      view)))
+
+(defmethod mark-frame-focused :after ((frame output-node) seat)
+  (alexandria:when-let ((data (output-node-fullscreen frame)))
+    (log-string :trace "fullscreen frame focused ~S" frame)
+    (hrt:focus-view (%fullscreen-data-view data) seat)))
+
+(defmethod unmark-frame-focused :after ((frame output-node) seat)
+  (alexandria:when-let ((data (output-node-fullscreen frame)))
+    (log-string :trace "fullscreen frame unfocused ~S" frame)
+    (hrt:unfocus-view (%fullscreen-data-view data) seat)))
+
+(defmethod frame-view ((frame output-node))
+  (alexandria:when-let ((data (output-node-fullscreen frame)))
+    (%fullscreen-data-view data)))
+
 (defmethod in-frame-p ((parent output-node) x y)
-  ;; output nodes have exactly 1 child:
-  (let ((f (car (tree-children parent))))
-    (in-frame-p f x y)))
+  ;; Use the dimensions and position of the output:
+  (declare (type real x y))
+  (let ((output (output-node-output parent)))
+    (multiple-value-bind (frame-width frame-height) (hrt:output-resolution output)
+      (multiple-value-bind (frame-x frame-y) (hrt:output-position output)
+        (and (<= frame-x x)
+             (<  x (+ frame-x frame-width))
+             (<= frame-y y)
+             (<  y (+ frame-y frame-height)))))))
 
 (defmethod frame-at ((parent output-node) x y)
-  ;; output nodes have exactly 1 child:
-  (let ((f (car (tree-children parent))))
-    (frame-at f x y)))
+  ;; If there is a fullscreen window, return this node:
+  (if (output-node-fullscreen parent)
+      parent
+      ;; output nodes have exactly 1 child:
+      (let ((f (car (tree-children parent))))
+        (frame-at f x y))))
+
+(defmethod find-view-frame ((node output-node) view)
+  (alexandria:if-let ((data (output-node-fullscreen node)))
+    (when (equal (%fullscreen-data-view data) view)
+      node)
+    (call-next-method)))
 
 (defmethod frame-anchor-p ((frame output-node))
   t)
+
+(defmethod print-object ((object output-node) stream)
+  (print-unreadable-object (object stream :type t)
+    (with-slots (children output fullscreen)
+        object
+      (format stream
+              "~:_:output ~S ~:_:fullscreen ~S ~:_:children ~S"
+              output fullscreen children))))

--- a/lisp/tree/package.lisp
+++ b/lisp/tree/package.lisp
@@ -33,10 +33,12 @@
            #:remove-frame
            #:swap-positions
            #:find-empty-frame
+           #:find-focused-frame
            #:find-view-frame
            #:get-populated-frames
            #:root-frame-p
            #:find-root-frame
+           #:find-topmost-frame
            #:find-first-leaf
            #:mark-frame-focused
            #:unmark-frame-focused
@@ -48,5 +50,8 @@
            #:frame-next
            #:frame-prev
            #:frame-find-layer
-           #:leafs-in
-           #:output-node-output))
+           #:find-frame-if
+           #:output-node
+           #:output-node-output
+           #:set-fullscreen
+           #:clear-fullscreen))

--- a/lisp/tree/tree-interface.lisp
+++ b/lisp/tree/tree-interface.lisp
@@ -82,6 +82,10 @@ should not be directly instantiated; inherit from it instead."))
         (dest-layer (layer-container-layer destination)))
     (hrt:hrt-scene-layer-transfer source-layer dest-layer)))
 
+(defstruct (%fullscreen-data (:constructor %make-fullscreen-data (view node)))
+  (view nil :type hrt:view)
+  (node nil :type cffi:foreign-pointer))
+
 (defclass output-node (tree-parent)
   ((parent :initarg :parent
            :initform nil
@@ -89,7 +93,14 @@ should not be directly instantiated; inherit from it instead."))
            :accessor frame-parent)
    (output :initarg :output
            :type (not null)
-           :reader output-node-output))
+           :reader output-node-output)
+   (fullscreen :initform nil
+               :type (or null %fullscreen-data)
+               :accessor output-node-fullscreen)
+   (focused :initarg :focused
+         :reader frame-focused
+         :initform nil
+         :type boolean))
   (:documentation
    "A node in the frame tree that contains the tiled frames tied to
 a specific output."))
@@ -116,6 +127,9 @@ a specific output."))
   ()
   (:documentation "An inner node of a frame-tree that can have more than two children"))
 
+(deftype tree-node ()
+  `(or frame output-node))
+
 ;; frame-tree interface
 (defgeneric set-split-frame-type (frame type)
   (:documentation "Sets the split frame type. Note that this may change the
@@ -127,14 +141,18 @@ See *new-split-type* for more details"))
 The parent tree is modified appropriately.
    RATIO: the size of newly created frame compared to the given frame. If not given, then
      the the size is split evenly between the other child frame(s)
-   DIRECTION: where the new frame is placed. Either :left or :right"))
+   DIRECTION: where the new frame is placed. Either :left or :right")
+  (:method ((node output-node) &key &allow-other-keys)
+    (error 'mahogany/util:invalid-operation :text "Cannot split output node frames!")))
 
 (defgeneric split-frame-h (frame &key ratio direction)
   (:documentation "Split the frame horizontally. Returns a tree of the split frames.
 The parent tree is modified appropriately.
    RATIO: the size of newly created frame compared to the given frame. If not given, then
      the the size is split evenly between the other child frame(s)
-   DIRECTION: where the new frame is placed. Either :top or :bottom"))
+   DIRECTION: where the new frame is placed. Either :top or :bottom")
+  (:method ((node output-node) &key &allow-other-keys)
+    (error 'mahogany/util:invalid-operation :text "Cannot split output node frames!")))
 
 (defgeneric remove-frame-from-parent (parent frame cleanup-func)
   (:documentation "Remove the frame from the tree. Parent must be the direct parent of frame."))
@@ -166,11 +184,19 @@ a view assigned to it."))
   (:method ((frame frame) seat)
     (declare (ignore seat))
     (log-string :trace "frame focused")
+    (setf (slot-value frame 'focused) t))
+  (:method ((frame output-node) seat)
+    (declare (ignore seat))
+    (log-string :trace "frame focused")
     (setf (slot-value frame 'focused) t)))
 
 (defgeneric unmark-frame-focused (frame seat)
   (:documentation "Mark the frame as being focused")
   (:method ((frame frame) seat)
+    (declare (ignore seat))
+    (log-string :trace "frame unfocused")
+    (setf (slot-value frame 'focused) nil))
+  (:method ((frame output-node) seat)
     (declare (ignore seat))
     (log-string :trace "frame unfocused")
     (setf (slot-value frame 'focused) nil)))
@@ -183,18 +209,26 @@ a view assigned to it."))
     nil))
 
 (defun root-frame-p (frame)
-  "Return T if FRAME is the topmost frame in a frame tree"
-  (let ((parent (frame-parent frame)))
-    (frame-anchor-p parent)))
+  "Return T if FRAME is the topmost node in a frame tree"
+  (frame-anchor-p frame))
+
+(defun topmost-frame-p (frame)
+  (root-frame-p (frame-parent frame)))
+
+(defun find-topmost-frame (frame)
+  "Find the root node for this frame tree"
+  (declare (type tree-node frame))
+  (do ((cur-frame frame (frame-parent cur-frame)))
+      ((topmost-frame-p cur-frame) cur-frame)))
 
 (defun find-root-frame (frame)
   "Find the root node for this frame tree"
-  (declare (type frame frame))
+  (declare (type tree-node frame))
   (do ((cur-frame frame (frame-parent cur-frame)))
       ((root-frame-p cur-frame) cur-frame)))
 
 (defun frame-find-layer (frame)
-  (declare (type frame frame))
+  (declare (type tree-node frame frame))
   (do ((cur-frame frame (frame-parent cur-frame)))
     ((typep cur-frame 'layer-container) cur-frame)))
 
@@ -226,8 +260,7 @@ a view assigned to it."))
   (let ((stack-var (gensym "stack"))
         (frame-var (gensym "frame")))
     `(let* ((,frame-var ,frame)
-            (,stack-var (if (or (typep ,frame-var 'tree-frame)
-                                (typep ,frame-var 'output-node))
+            (,stack-var (if (typep ,frame-var 'tree-parent)
                             (tree-children ,frame-var)
                             (list ,frame-var))))
        (iter (for ,var = (pop ,stack-var))
@@ -235,3 +268,9 @@ a view assigned to it."))
              (if (typep ,var 'tree-frame)
                  (appendf ,stack-var (tree-children ,var))
                  (progn ,@body))))))
+
+(defun find-focused-frame (frame)
+  (foreach-leaf (f frame)
+    (when (frame-focused f)
+      (return-from find-focused-frame f)))
+  nil)

--- a/lisp/tree/tree-interface.lisp
+++ b/lisp/tree/tree-interface.lisp
@@ -209,14 +209,15 @@ a view assigned to it."))
     nil))
 
 (defun root-frame-p (frame)
-  "Return T if FRAME is the topmost node in a frame tree"
+  "Return T if FRAME is the root node in a frame tree"
   (frame-anchor-p frame))
 
 (defun topmost-frame-p (frame)
+  "Return T if the frame is a child of a root node."
   (root-frame-p (frame-parent frame)))
 
 (defun find-topmost-frame (frame)
-  "Find the root node for this frame tree"
+  "Find the topmost node for this frame tree"
   (declare (type tree-node frame))
   (do ((cur-frame frame (frame-parent cur-frame)))
       ((topmost-frame-p cur-frame) cur-frame)))

--- a/lisp/tree/view.lisp
+++ b/lisp/tree/view.lisp
@@ -8,11 +8,11 @@
          :documentation "The client of the frame")
    (next :initarg next-frame
          :initform nil
-         :type (or view-frame null)
+         :type (or tree-node null)
          :reader frame-next)
    (prev :initarg prev-frame
          :initform nil
-         :type (or view-frame null)
+         :type (or tree-node null)
          :reader frame-prev)
    (seat :initform nil)))
 

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -70,8 +70,8 @@
                (:file "command")
                (:file "objects" :depends-on ("package" "ring-list"))
                (:file "message" :depends-on ("heart"))
-               (:file "group" :depends-on ("objects" "heart"))
-               (:file "state" :depends-on ("objects" "keyboard" "heart"))
+               (:file "group" :depends-on ("objects" "heart" "globals"))
+               (:file "state" :depends-on ("objects" "keyboard" "heart" "group"))
                (:file "globals" :depends-on ("objects" "system"))
                (:file "kmap-modes"
                       :depends-on ("objects" "globals" "keyboard" "input" "command"))


### PR DESCRIPTION
Support full screen XDG shell views by connecting them to an `output-node` of the frame tree such that it the full screen view gets displayed instead of the output node's children.

This is done by implementing some of the `view-frame` methods to work with `output-node` instances and special casing various operations to deal with when an output node is focused instead of a normal frame.

Todo:
+ [x] Appropriately handle full screen requests (both to enable and disable full screen status)
+ [X] Handle unmapping a full screen view  
+ [x] Documentation, especially  about behavior
+ [x] Add ability to navigate away from full screen views by navigating using `group-next-hidden` and `group-previous-hidden`
+ [x] Ensure that fullscreens work with multiple outputs


See #94.