### PR TITLE
Start implementing output management

### DIFF
--- a/doc/output-configuration.org
+++ b/doc/output-configuration.org
@@ -1,0 +1,42 @@
+#+TITLE: Output Configuration
+
+* Configuring individual Outputs
+
+To configure the position, scale, resolution and refresh rate of an
+output, you can use the =define-output-config= macro:
+
+#+BEGIN_SRC lisp
+  (define-output-config "default"
+    "WL-1"
+    (:scale 2))
+#+END_SRC
+
+The first argument is the name of the configuration, which allows it
+to be referenced in other contexts. Configuration names must be
+unique; defining a second configuration with the same name will
+overwrite the  first. The next argument is the name of the output or
+a list specifying the name, make, model or serial of the output. The
+rest of the arguments allow you to define the output's scale,
+resolution and position.
+
+** Grammar
+
+The grammar for this macro is as follows:
+
+#+BEGIN_SRC text
+(define-output-config NAME OUTPUT-CLAUSE)
+
+NAME : name
+
+OUTPUT-CLAUSE : NAME-OR-DETAILS OUTPUT-PROPERTIES
+
+NAME-OR-DETAILS : output-name | (&key name make model serial)
+
+OUTPUT-PROPERTIES :
+     (:scale scale)
+   | (:mode width height &key refresh custom)
+   | (:position x y)
+   | (:mirror NAME-OR-DETAILS)
+#+END_SRC
+
+Note that screen mirroring is not supported yet.

--- a/heart/example/main.c
+++ b/heart/example/main.c
@@ -46,6 +46,8 @@ static void cursor_wheel_callback(struct hrt_seat *seat,
 static void output_added_callback(struct hrt_output *output) {
     printf("Output added callback called, scale=%f\n",
            output->wlr_output->scale);
+    hrt_output_init(output, nullptr);
+
     struct example_output *o = calloc(1, sizeof(*o));
     o->output                = output;
     wl_list_insert(&server.outputs, &o->link);

--- a/heart/include/hrt/hrt_output.h
+++ b/heart/include/hrt/hrt_output.h
@@ -11,6 +11,19 @@
 
 struct hrt_scene_output;
 
+struct hrt_output_config {
+    double scale;
+    // Use the exact settings instead of the closest supported match:
+    bool custom_mode;
+    int width, height;
+    float refresh_rate;
+    // Place the output in a specific spot in the layout based on the
+    // given X,Y coordinates:
+    bool custom_position;
+    // These are in layout coordinates, not pixel coordinates:
+    int x, y;
+};
+
 struct hrt_output {
     struct wlr_output *wlr_output;
     struct hrt_server *server;
@@ -32,6 +45,16 @@ struct hrt_output_callbacks {
     void (*output_removed)(struct hrt_output *output);
     void (*output_layout_changed)();
 };
+
+/**
+ * Initialize the output with the given config. Without this call,
+ * the output will not be displayed.
+ * @param output the output to initalized
+ * @param config the configuration to use. To pick the default values,
+ *   pass nullptr.
+ **/
+bool hrt_output_init(struct hrt_output *output,
+                     struct hrt_output_config *config);
 
 /**
  * Get the effective output resolution of the output that can be used to

--- a/heart/include/output_impl.h
+++ b/heart/include/output_impl.h
@@ -2,6 +2,6 @@
 
 #include "hrt/hrt_server.h"
 
-bool hrt_output_init(struct hrt_server *server,
+bool hrt_server_output_init(struct hrt_server *server,
 		     const struct hrt_output_callbacks *callbacks);
 void hrt_output_destroy(struct hrt_server *server);

--- a/heart/src/output.c
+++ b/heart/src/output.c
@@ -2,6 +2,7 @@
 #include "hrt/hrt_server.h"
 #include "wlr/util/log.h"
 #include <assert.h>
+#include <limits.h>
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -82,6 +83,8 @@ static struct hrt_output *hrt_output_create(struct hrt_server *server,
     output->destroy.notify = handle_output_destroy;
     wl_signal_add(&wlr_output->events.destroy, &output->destroy);
 
+    wlr_output_init_render(wlr_output, server->allocator, server->renderer);
+
     return output;
 }
 
@@ -161,27 +164,99 @@ static void set_transform(struct wlr_output_state *state) {
 #endif
 }
 
-static void output_configure(struct hrt_output *output) {
+static void set_mode(struct wlr_output *output,
+                     struct wlr_output_state *pending, int width, int height,
+                     float refresh_rate, bool custom) {
+    // Not all floating point integers can be represented exactly
+    // as (int)(1000 * mHz / 1000.f)
+    // round() the result to avoid any error
+    int mhz = (int)roundf(refresh_rate * 1000);
+    // If no target refresh rate is given, match highest available
+    mhz = mhz <= 0 ? INT_MAX : mhz;
+
+    if (wl_list_empty(&output->modes) || custom) {
+        const int applied_mhz = refresh_rate > 0 ? mhz : 0;
+        wlr_log(WLR_INFO, "Applying custom mode %d, %d, %d mhz", width, height,
+                applied_mhz);
+        wlr_output_state_set_custom_mode(pending, width, height, applied_mhz);
+        return;
+    }
+
+    struct wlr_output_mode *mode, *best = NULL;
+    int best_diff_mhz = INT_MAX;
+    wl_list_for_each(mode, &output->modes, link) {
+        if (mode->width == width && mode->height == height) {
+            int diff_mhz = abs(mode->refresh - mhz);
+            if (diff_mhz < best_diff_mhz) {
+                best_diff_mhz = diff_mhz;
+                best          = mode;
+                if (best_diff_mhz == 0) {
+                    break;
+                }
+            }
+        }
+    }
+    if (!best) {
+        best = wlr_output_preferred_mode(output);
+        wlr_log(WLR_INFO,
+                "Configured mode (%dx%d@%.3fHz) not available, "
+                "applying preferred mode (%dx%d@%.3fHz)",
+                width, height, refresh_rate, best->width, best->height,
+                best->refresh / 1000.f);
+    }
+    wlr_output_state_set_mode(pending, best);
+}
+
+bool hrt_output_init(struct hrt_output *output,
+                     struct hrt_output_config *config) {
+    struct hrt_server *server     = output->server;
     struct wlr_output *wlr_output = output->wlr_output;
     struct wlr_output_state state;
     wlr_output_state_init(&state);
     wlr_output_state_set_enabled(&state, true);
 
-    struct wlr_output_mode *mode = wlr_output_preferred_mode(wlr_output);
-    if (mode != NULL) {
+    if (config && (config->width > 0 && config->height > 0)) {
+        set_mode(wlr_output, &state, config->width, config->height,
+                 config->refresh_rate, config->custom_mode);
+    } else if (!wl_list_empty(&wlr_output->modes)) {
+        struct wlr_output_mode *mode = wlr_output_preferred_mode(wlr_output);
         wlr_output_state_set_mode(&state, mode);
     }
 
     set_transform(&state);
 
-    wlr_output_state_set_scale(&state,
-                               compute_default_scale(wlr_output, &state));
+    if (config && config->scale > 0) {
+        // The factional-scale-v1 protocol uses increments of 120ths to send
+        // the scale factor to the client. Adjust the scale so that we use the
+        // same value as the clients'.
+        wlr_output_state_set_scale(&state, round(config->scale * 120) / 120);
+    } else {
+        wlr_output_state_set_scale(&state,
+                                   compute_default_scale(wlr_output, &state));
+    }
 
     if (!wlr_output_commit_state(wlr_output, &state)) {
         // FIXME: Actually do some error handling instead of just logging:
         wlr_log(WLR_ERROR, "Output state could not be committed");
+        return false;
     }
     wlr_output_state_finish(&state);
+
+    struct wlr_output_layout_output *l_output;
+    if (config && config->custom_position) {
+        l_output = wlr_output_layout_add(server->output_layout, wlr_output,
+                                         config->x, config->y);
+    } else {
+        l_output =
+            wlr_output_layout_add_auto(server->output_layout, wlr_output);
+    }
+    assert(l_output != nullptr);
+    struct wlr_scene_output *scene_output =
+        wlr_scene_output_create(server->scene, wlr_output);
+    wlr_scene_output_layout_add_output(server->scene_layout, l_output,
+                                       scene_output);
+    output->wlr_scene = scene_output;
+    return true;
 }
 
 static void handle_new_output(struct wl_listener *listener, void *data) {
@@ -193,19 +268,7 @@ static void handle_new_output(struct wl_listener *listener, void *data) {
     // Initialize and set the data pointer so it's available in any events that
     // are triggered in the subsequent code:
     struct hrt_output *output = hrt_output_create(server, wlr_output);
-    wlr_output->data = output;
-
-    wlr_output_init_render(wlr_output, server->allocator, server->renderer);
-
-    output_configure(output);
-
-    struct wlr_output_layout_output *l_output =
-        wlr_output_layout_add_auto(server->output_layout, wlr_output);
-    struct wlr_scene_output *scene_output =
-        wlr_scene_output_create(server->scene, wlr_output);
-    wlr_scene_output_layout_add_output(server->scene_layout, l_output,
-                                       scene_output);
-    output->wlr_scene = scene_output;
+    wlr_output->data          = output;
 
     server->output_callback->output_added(output);
 }
@@ -260,8 +323,8 @@ static void check_callbacks(const struct hrt_output_callbacks *callbacks) {
     assert(callbacks->output_layout_changed != nullptr);
 }
 
-bool hrt_output_init(struct hrt_server *server,
-                     const struct hrt_output_callbacks *callbacks) {
+bool hrt_server_output_init(struct hrt_server *server,
+                            const struct hrt_output_callbacks *callbacks) {
     check_callbacks(callbacks);
     server->output_callback   = callbacks;
     server->new_output.notify = handle_new_output;

--- a/heart/src/server.c
+++ b/heart/src/server.c
@@ -82,7 +82,7 @@ bool hrt_server_init(struct hrt_server *server,
         return false;
     }
 
-    if (!hrt_output_init(server, output_callbacks)) {
+    if (!hrt_server_output_init(server, output_callbacks)) {
         return false;
     }
     if (!hrt_seat_init(&server->seat, server, seat_callbacks)) {

--- a/lisp/heart/hrt-bindings.lisp
+++ b/lisp/heart/hrt-bindings.lisp
@@ -206,6 +206,16 @@ well behaved ones should."
 
 (cffi:defcstruct hrt-scene-output)
 
+(cffi:defcstruct hrt-output-config
+  (scale :double)
+  (custom-mode :bool)
+  (width :int)
+  (height :int)
+  (refresh-rate :float)
+  (custom-position :bool)
+  (x :int)
+  (y :int))
+
 (cffi:defcstruct hrt-output
   (wlr-output :pointer #| (:struct wlr-output) |#)
   (server (:pointer (:struct hrt-server)))
@@ -221,6 +231,16 @@ well behaved ones should."
   (output-added :pointer #| function ptr void (struct hrt_output *) |#)
   (output-removed :pointer #| function ptr void (struct hrt_output *) |#)
   (output-layout-changed :pointer #| function ptr void () |#))
+
+(declaim (inline hrt-output-init))
+(cffi:defcfun ("hrt_output_init" hrt-output-init) :bool
+  "Initialize the output with the given config. Without this call,
+the output will not be displayed.
+@param output the output to initalized
+@param config the configuration to use. To pick the default values,
+  pass nullptr."
+  (output (:pointer (:struct hrt-output)))
+  (config (:pointer (:struct hrt-output-config))))
 
 (declaim (inline hrt-output-resolution))
 (cffi:defcfun ("hrt_output_resolution" hrt-output-resolution) :void

--- a/lisp/heart/output.lisp
+++ b/lisp/heart/output.lisp
@@ -5,6 +5,39 @@
   (hrt-output cffi:null-pointer :type cffi:foreign-pointer :read-only t)
   (full-name "" :type string :read-only t))
 
+(defstruct output-config
+  (scale 1 :type (or number null) :read-only t)
+  (refresh-rate nil :type (or number null) :read-only t)
+  (custom-mode nil :type boolean :read-only t)
+  ;; a cons of (width . height)
+  (dimensions nil :type (or cons null) :read-only t)
+  ;; a cons of (x . y)
+  (position nil :type (or cons null) :read-only t))
+
+(defun %transfer-output-config (hrt-config config)
+  (cffi:with-foreign-slots
+      ((scale custom-mode width height refresh-rate custom-position x y)
+       hrt-config (:struct hrt-output-config))
+    (setf scale (if (output-config-scale config)
+                    (coerce (output-config-scale config) 'double-float)
+                    0.0d0))
+    (alexandria:when-let ((dimensions (output-config-dimensions config)))
+      (setf custom-mode (output-config-custom-mode config)
+            refresh-rate (alexandria:if-let ((rate (output-config-refresh-rate config)))
+                           (coerce rate 'single-float)
+                           0.0)
+            width (car dimensions)
+            height (cdr dimensions)))
+    (alexandria:when-let ((position (output-config-position config)))
+      (setf custom-position t
+            x (car position)
+            y (cdr position)))))
+
+(defmacro with-output-config ((var config) &body body)
+  `(cffi:with-foreign-object (,var '(:struct hrt-output-config))
+     (%transfer-output-config ,var ,config)
+     ,@body))
+
 (defun %get-output-full-name (hrt-output)
   (let ((make (hrt-output-make hrt-output))
 	(name (hrt-output-name hrt-output))
@@ -20,6 +53,15 @@
   (declare (type cffi:foreign-pointer hrt-output))
   (let ((name (%get-output-full-name hrt-output)))
     (%make-output hrt-output name)))
+
+(defun output-init (output config)
+  (if config
+      (with-output-config (hrt-config config)
+        (mahogany/log:log-string
+         :info "Appyling configuration to output ~S: ~S"
+         (output-full-name output) config)
+        (hrt-output-init (output-hrt-output output) hrt-config))
+      (hrt-output-init (output-hrt-output output) (cffi:null-pointer))))
 
 (defun destroy-output (mh-output)
   (declare (ignore mh-output)))

--- a/lisp/heart/package.lisp
+++ b/lisp/heart/package.lisp
@@ -43,6 +43,9 @@
            #:output-hrt-output
            #:make-output
            #:destroy-output
+           #:output-init
+           #:make-output-config
+           #:output-config
            #:hrt-keypress-info
            ;; output callbacks
            #:output-added

--- a/lisp/output-config.lisp
+++ b/lisp/output-config.lisp
@@ -1,0 +1,108 @@
+(in-package #:mahogany)
+
+(defstruct output-match-data
+  (name nil :type (or null string) :read-only t)
+  (make nil :type (or null string) :read-only t)
+  (model nil :type (or null string) :read-only t)
+  (serial nil :type (or null string) :read-only t)
+  (config nil :type hrt:output-config :read-only t))
+
+(defstruct (output-layout-config (:constructor %make-output-layout-config (name outputs)))
+  (name nil :type string :read-only t)
+  (outputs nil :type list :read-only t))
+
+(defun %output-config-from-clauses (clauses)
+  (let ((found (make-hash-table))
+        scale refresh-rate custom-mode dimensions position)
+    (dolist (c clauses)
+      (when (not (listp c))
+        (error (format nil "output config property spec must be a list, not ~S"
+                       c)))
+      (let ((present (gethash (first c) found)))
+        (when present
+          (error (format nil "duplicate property ~S in output config property list"
+                         (first c))))
+        (setf (gethash (first c) found) c)))
+    (macrolet ((with-clause (key lambda-list &body body)
+                 (let ((spec (gensym "spec")))
+                   `(alexandria:when-let ((,spec (gethash ,key found)))
+                      (destructuring-bind ,lambda-list (cdr ,spec)
+                        ,@body)))))
+      (with-clause :scale (s)
+        (setf scale s))
+      (with-clause :position (x y)
+        (setf position (cons x y)))
+      (with-clause :mode (width height &key refresh custom)
+        (unless (and width height)
+          (error "Both width and height need to be specified when setting a mode"))
+        (setf custom-mode custom
+              dimensions (cons width height)
+              refresh-rate refresh)))
+    (hrt:make-output-config :scale scale
+                            :refresh-rate refresh-rate
+                            :custom-mode custom-mode
+                            :dimensions dimensions
+                            :position position)))
+
+(defun %output-match-data-from-clause (clause config)
+  (etypecase clause
+    (list
+     (apply #'make-output-match-data
+            (nconc (list :config config) clause)))
+    (string
+     (make-output-match-data :name clause :config config))))
+
+(defun build-output-match-data (o)
+  (let* ((config (%output-config-from-clauses (cdr o)))
+         (match-data (%output-match-data-from-clause (first o) config)))
+    match-data))
+
+(defun make-output-layout-config (name outputs)
+  (let ((settings nil))
+    (dolist (o outputs)
+      (let ((match-data (build-output-match-data o)))
+        (push match-data settings)))
+    (%make-output-layout-config name settings)))
+
+(defvar *output-configurations* (make-hash-table)
+  "Name output configurations that define how a single output should be configured.")
+
+(defmacro define-output-config (name &body config)
+  (let ((name-symb (gensym "name")))
+    `(let ((,name-symb ,name))
+       (setf (gethash ,name-symb *output-configurations*)
+             (build-output-match-data (quote ,config))))))
+
+(defvar *output-layout-configurations* (make-hash-table)
+  "Named output layout configurations that define how a set of outputs
+should be configured and laid out.")
+
+(defmacro define-output-layout (name &body outputs)
+  (let ((name-symb (gensym "name")))
+    `(let* ((,name-symb ,name))
+       (setf (gethash ,name-symb *output-layout-configurations*)
+             (make-output-layout-config ,name-symb (quote ,outputs))))))
+
+(defun output-match-data-matches-p (output match-data)
+  (declare (type hrt:output output)
+           (type output-match-data match-data))
+  (with-accessors ((name output-match-data-name)
+                   (make output-match-data-make)
+                   (model output-match-data-model)
+                   (serial output-match-data-serial))
+      match-data
+    (macrolet ((present-compare (match-accessor val)
+                 `(if ,match-accessor
+                      (string= ,match-accessor ,val)
+                      t)))
+      (and
+       (present-compare name (hrt:output-name output))
+       (present-compare make (hrt:output-make output))
+       (present-compare model (hrt:output-model output))
+       (present-compare serial (hrt:output-serial output))))))
+
+(defun find-output-config (output)
+  "Find an individual output configuration that matches the given output."
+  (loop :for c :being :the :hash-value :of *output-configurations*
+        :when (output-match-data-matches-p output c)
+          :return c))

--- a/lisp/state.lisp
+++ b/lisp/state.lisp
@@ -80,6 +80,8 @@
       state
     (let ((mh-output (hrt:make-output hrt-output)))
       (log-string :debug "New output added ~S" (hrt:output-full-name mh-output))
+      ;; TODO: Pick a configuration to use instead of passing nil:
+      (hrt:output-init mh-output nil)
       (vector-push-extend mh-output outputs)
       (loop for g across groups
             do (group-add-output g mh-output (server-seat state))))))

--- a/lisp/state.lisp
+++ b/lisp/state.lisp
@@ -80,8 +80,11 @@
       state
     (let ((mh-output (hrt:make-output hrt-output)))
       (log-string :debug "New output added ~S" (hrt:output-full-name mh-output))
-      ;; TODO: Pick a configuration to use instead of passing nil:
-      (hrt:output-init mh-output nil)
+      (hrt:output-init mh-output
+                       (let ((output-match-data (find-output-config mh-output)))
+                         (if output-match-data
+                             (output-match-data-config output-match-data)
+                             nil)))
       (vector-push-extend mh-output outputs)
       (loop for g across groups
             do (group-add-output g mh-output (server-seat state))))))

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -72,6 +72,7 @@
                (:file "package")
                (:file "command")
                (:file "objects" :depends-on ("package" "ring-list"))
+               (:file "output-config" :depends-on ("heart"))
                (:file "message" :depends-on ("heart"))
                (:file "group" :depends-on ("objects" "heart" "globals"))
                (:file "state" :depends-on ("objects" "keyboard" "heart" "group"))


### PR DESCRIPTION
Start adding the ability to customize output configurations and layouts. This fully implements the `define-output-config` macro as described in  [this comment](https://github.com/stumpwm/mahogany/issues/59#issuecomment-4607816303).

It also includes a partial implementation of the the `define-output-layout` macro which allows the layout configurations to be defined, but has no provisions yet to apply them.

See #59.