### PR TITLE
Implement semi-working version of stumpwm's grab-pointer

### DIFF
--- a/heart/include/hrt/hrt_input.h
+++ b/heart/include/hrt/hrt_input.h
@@ -46,6 +46,7 @@ struct hrt_seat {
 
     const struct hrt_seat_callbacks *callbacks;
     char *cursor_image;
+    size_t cursor_img_buf_len;
 
     struct {
         struct wl_listener seat;

--- a/heart/include/hrt/hrt_input.h
+++ b/heart/include/hrt/hrt_input.h
@@ -89,7 +89,8 @@ struct hrt_input {
 
 /**
  * Send the appropriate cursor event to the view under the
- * cursor.
+ * cursor and ensure the cursor has the correct image
+ * for what it is hovering over.
  **/
 void hrt_seat_reset_view_under(struct hrt_seat *seat);
 
@@ -102,6 +103,11 @@ void hrt_seat_reset_view_under(struct hrt_seat *seat);
  * names.
  */
 void hrt_seat_set_cursor_img(struct hrt_seat *seat, char *img_name);
+
+/**
+ * Set the cursor image back to the default.
+ **/
+void hrt_seat_reset_cursor_img(struct hrt_seat *seat);
 
 void hrt_seat_notify_button(struct hrt_seat *seat,
                             struct wlr_pointer_button_event *event);

--- a/heart/src/cursor.c
+++ b/heart/src/cursor.c
@@ -1,3 +1,6 @@
+#include <stdlib.h>
+#include <string.h>
+
 #include "hrt/hrt_view.h"
 #include "wlr/util/log.h"
 #include <wayland-util.h>
@@ -55,6 +58,40 @@ void hrt_seat_reset_view_under(struct hrt_seat *seat) {
     } else {
         wlr_seat_pointer_clear_focus(seat->seat);
     }
+}
+
+static void seat_set_cursor_img(struct hrt_seat *seat, char *img_name) {
+    // Ensure that our buffer is big enough,
+    // unless the string is super big
+    const size_t len = strlen(img_name) + 1;
+    if (len > seat->cursor_img_buf_len) {
+        if (len > 100) {
+            wlr_log(WLR_ERROR,
+                    "Ignoring hrt_set_cursor_img: cursor name is unreasonable "
+                    "large: %s",
+                    img_name);
+            return;
+        }
+        char *new_ptr = realloc(seat->cursor_image, len);
+        if (!new_ptr) {
+            wlr_log(WLR_ERROR, "Failed to realloc cursor name buffer");
+            return;
+        }
+    }
+    memcpy(seat->cursor_image, img_name, len);
+}
+
+void hrt_seat_set_cursor_img(struct hrt_seat *seat, char *img_name) {
+    seat_set_cursor_img(seat, img_name);
+    wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager,
+                           seat->cursor_image);
+}
+
+void hrt_seat_reset_cursor_img(struct hrt_seat *seat) {
+    seat_set_cursor_img(seat, "default");
+    // TODO: investigate; this may send the pointer_enter event
+    // when the pointer is already in the view. Does that matter?
+    hrt_seat_reset_view_under(seat);
 }
 
 static void handle_cursor_motion(struct hrt_seat *seat, uint32_t time) {

--- a/heart/src/input.c
+++ b/heart/src/input.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <string.h>
 #include <wayland-server-core.h>
 #include <wayland-util.h>
 #include <wlr/util/log.h>
@@ -204,6 +205,8 @@ static void handle_start_drag(struct wl_listener *listener, void *data) {
 static void handle_seat_destroy(struct wl_listener *listener, void *data) {
     // struct wlr_seat *wlr_seat = data;
     struct hrt_seat *seat = wl_container_of(listener, seat, destroy);
+    seat->cursor_img_buf_len = 0;
+    free(seat->cursor_image);
 
     hrt_keyboard_destroy(seat);
     hrt_cursor_destroy(seat);
@@ -261,7 +264,10 @@ bool hrt_seat_init(struct hrt_seat *seat, struct hrt_server *server,
     seat->destroy.seat.notify = handle_seat_destroy;
     wl_signal_add(&seat->seat->events.destroy, &seat->destroy.seat);
 
-    seat->cursor_image = "left_ptr";
+    const char *const default_cursor = "default";
+    seat->cursor_img_buf_len = strlen(default_cursor) + 1;
+    seat->cursor_image   = calloc(20, sizeof(char));
+    memcpy(seat->cursor_image, default_cursor, seat->cursor_img_buf_len);
 
     return true;
 }

--- a/heart/src/seat.c
+++ b/heart/src/seat.c
@@ -1,34 +1,10 @@
 #include <hrt/hrt_input.h>
 
-#include <stdlib.h>
-#include <string.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_pointer.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/util/log.h>
 #include <xkbcommon/xkbcommon.h>
-
-void hrt_seat_set_cursor_img(struct hrt_seat *seat, char *img_name) {
-    // Ensure that our buffer is big enough,
-    // unless the string is super big
-    const size_t len = strlen(img_name) + 1;
-    if (len > seat->cursor_img_buf_len) {
-        if (len > 100) {
-            wlr_log(WLR_ERROR, "Ignoring hrt_set_cursor_img: cursor name is unreasonable large: %s",
-                   img_name);
-          return;
-        }
-        char *new_ptr = realloc(seat->cursor_image, len);
-        if (!new_ptr) {
-            wlr_log(WLR_ERROR, "Failed to realloc cursor name buffer");
-            return;
-        }
-    }
-    memcpy(seat->cursor_image, img_name, len);
-
-    wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager,
-                           seat->cursor_image);
-}
 
 void hrt_seat_notify_button(struct hrt_seat *seat,
                             struct wlr_pointer_button_event *event) {

--- a/heart/src/seat.c
+++ b/heart/src/seat.c
@@ -1,12 +1,31 @@
 #include <hrt/hrt_input.h>
 
+#include <stdlib.h>
+#include <string.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_pointer.h>
 #include <wlr/types/wlr_seat.h>
+#include <wlr/util/log.h>
 #include <xkbcommon/xkbcommon.h>
 
 void hrt_seat_set_cursor_img(struct hrt_seat *seat, char *img_name) {
-    seat->cursor_image = img_name;
+    // Ensure that our buffer is big enough,
+    // unless the string is super big
+    const size_t len = strlen(img_name) + 1;
+    if (len > seat->cursor_img_buf_len) {
+        if (len > 100) {
+            wlr_log(WLR_ERROR, "Ignoring hrt_set_cursor_img: cursor name is unreasonable large: %s",
+                   img_name);
+          return;
+        }
+        char *new_ptr = realloc(seat->cursor_image, len);
+        if (!new_ptr) {
+            wlr_log(WLR_ERROR, "Failed to realloc cursor name buffer");
+            return;
+        }
+    }
+    memcpy(seat->cursor_image, img_name, len);
+
     wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager,
                            seat->cursor_image);
 }

--- a/lisp/heart/hrt-bindings.lisp
+++ b/lisp/heart/hrt-bindings.lisp
@@ -33,6 +33,7 @@
   (start-drag (:struct wl-listener))
   (callbacks (:pointer (:struct hrt-seat-callbacks)))
   (cursor-image (:pointer :char))
+  (cursor-img-buf-len :size)
   (destroy (:struct hrt-seat-destroy)))
 
 (cffi:defcstruct hrt-keypress-info

--- a/lisp/heart/hrt-bindings.lisp
+++ b/lisp/heart/hrt-bindings.lisp
@@ -57,7 +57,8 @@
 (declaim (inline hrt-seat-reset-view-under))
 (cffi:defcfun ("hrt_seat_reset_view_under" hrt-seat-reset-view-under) :void
   "Send the appropriate cursor event to the view under the
-cursor."
+cursor and ensure the cursor has the correct image
+for what it is hovering over."
   (seat (:pointer (:struct hrt-seat))))
 
 #-HRT-DEBUG
@@ -71,6 +72,12 @@ See themes section of man xcursor(3) to find where to find valid cursor
 names."
   (seat (:pointer (:struct hrt-seat)))
   (img-name (:pointer :char)))
+
+#-HRT-DEBUG
+(declaim (inline hrt-seat-reset-cursor-img))
+(cffi:defcfun ("hrt_seat_reset_cursor_img" hrt-seat-reset-cursor-img) :void
+  "Set the cursor image back to the default."
+  (seat (:pointer (:struct hrt-seat))))
 
 #-HRT-DEBUG
 (declaim (inline hrt-seat-notify-button))

--- a/lisp/heart/package.lisp
+++ b/lisp/heart/package.lisp
@@ -62,6 +62,8 @@
            ;; Seat
            #:hrt-seat
            #:hrt-seat-reset-view-under
+           #:seat-set-cursor-img
+           #:hrt-seat-reset-cursor-img
            #:hrt-seat-notify-button
            #:hrt-seat-notify-axis
            #:hrt-seat-cursor-lx

--- a/lisp/heart/seat.lisp
+++ b/lisp/heart/seat.lisp
@@ -1,0 +1,7 @@
+(in-package #:hrt)
+
+(defun seat-set-cursor-img (seat cursor-name)
+  (declare (type string cursor-name)
+           (type cffi:foreign-pointer seat))
+  (cffi:with-foreign-string (str cursor-name)
+    (hrt-seat-set-cursor-img seat str)))

--- a/lisp/input.lisp
+++ b/lisp/input.lisp
@@ -69,22 +69,24 @@ Values:
       (log-string :trace "Already handling keybinding: ~A" handling-keybinding)
       (flet ((reset-state ()
                (log-string :trace "Reseting keyboard state")
+               (hrt:hrt-seat-reset-cursor-img seat)
                (server-keystate-reset *compositor-state*)))
         (multiple-value-bind (matched result)
             (key-state-advance key key-state)
           (cond
             (;; A known keybinding was pressed:
              matched
-             (when result
-               (reset-state)
-               ;; Only consume the pressed key if we have a command
-               ;; and not a special keyword:
-               (if (eq :pass-through result)
-                   (return-from check-and-run-keybinding nil)
-                   (execute-command result
-		                    (key-state-sequence key-state) seat)))
-             ;; Consume the pressed key)
-	         t)
+             (cond
+               (result
+                (reset-state)
+                ;; Only consume the pressed key if we have a command
+                ;; and not a special keyword:
+                (if (eq :pass-through result)
+                    (return-from check-and-run-keybinding nil)
+                    (execute-command result
+		                             (key-state-sequence key-state) seat)))
+               (t (hrt:seat-set-cursor-img seat "help")
+                  t)))
             (;; No keybinding was pressed but we were expecting one.
              handling-keybinding
              (toast-message *compositor-state* (%unkown-keybinding-message key-state key))

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -59,6 +59,8 @@
                               :depends-on ("cffi-util" "hrt-bindings" "output"))
                              (:file "border-box"
                               :depends-on ("cffi-util" "hrt-bindings"))
+                             (:file "seat"
+                              :depends-on ("package"))
                              (:file "server"
                               :depends-on ("package" "hrt-bindings" "callback"))
                              (:file "layer-shell")


### PR DESCRIPTION
Change the default cursor image when the keybinding state is active, and reset it once it finishes.

This isn't actually the right solution, as we need to unfocus whatever is on the seat to avoid the subsequent key presses from being passed to clients. In addition, the cursor is updated to what the client asks for whenever it moves over a client; unfocusing the seat should fix this as well.

See #189.