### PR TITLE
hrt: Upgrade wlroots to 0.20

### DIFF
--- a/cffi/hrt-bindings.yml
+++ b/cffi/hrt-bindings.yml
@@ -1,7 +1,7 @@
 output: lisp/heart/hrt-bindings.lisp
 package: hrt
 pkg-config:
-  - wlroots-0.19
+  - wlroots-0.20
   - heart
 arguments:
   - "-DWLR_USE_UNSTABLE"

--- a/cffi/wlr-bindings.yml
+++ b/cffi/wlr-bindings.yml
@@ -1,7 +1,7 @@
 output: lisp/heart/wlr-bindings.lisp
 package: wlr
 pkg-config:
-  - wlroots-0.19
+  - wlroots-0.20
 arguments:
   - "-DWLR_USE_UNSTABLE"
   - "-Ibuild/include/wlroots-0.18/"

--- a/heart/meson.build
+++ b/heart/meson.build
@@ -22,7 +22,7 @@ add_project_arguments(
 
 cc = meson.get_compiler('c')
 
-wlroots_version = ['>=0.19.0', '<0.20.0']
+wlroots_version = ['>=0.20.0', '<0.21.0']
 
 cairo          = dependency('cairo', required: true)
 pangocairo     = dependency('pangocairo', required: true)

--- a/lisp/heart/hrt-libs.lisp
+++ b/lisp/heart/hrt-libs.lisp
@@ -4,7 +4,7 @@
   (:unix "libheart.so"))
 
 (cffi:define-foreign-library libwlroots
-  (:unix "libwlroots-0.19.so"))
+  (:unix "libwlroots-0.20.so"))
 
 (defun load-foreign-libraries ()
   (cffi:use-foreign-library libwlroots)


### PR DESCRIPTION
Upgrade wlroots to 0.20.

There were no API changes this round, but as usual, the library added more consistency checks and changed how initialization worked for some objects. All of those updates have already been applied.