### PR TITLE
Remove dependency on cl-wayland

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "heart/wlroots"]
 	path = heart/subprojects/wlroots
 	url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-[submodule "dependencies/cl-wayland"]
-	path = dependencies/cl-wayland
-	url = https://github.com/sdilts/cl-wayland.git
 [submodule "dependencies/cl-xkbcommon"]
 	path = dependencies/cl-xkbcommon
 	url = https://github.com/sdilts/cl-xkbcommon.git

--- a/.guix/modules/mahogany-package.scm
+++ b/.guix/modules/mahogany-package.scm
@@ -56,7 +56,6 @@
      (list mahogany-heart
            sbcl-xkbcommon
            libxkbcommon
-           sbcl-cl-wayland
            sbcl-alexandria
            sbcl-cl-ansi-text
            sbcl-terminfo

--- a/cffi/wl-bindings.yml
+++ b/cffi/wl-bindings.yml
@@ -1,0 +1,9 @@
+output: lisp/heart/wl-bindings-gen.lisp
+package: wl
+files:
+- /usr/include/wayland-util.h
+- /usr/include/wayland-server-protocol.h
+- /usr/include/wayland-server-core.h
+enum_constants:
+  include:
+    match: ".*"

--- a/lisp/heart/package.lisp
+++ b/lisp/heart/package.lisp
@@ -1,5 +1,13 @@
+(defpackage #:wayland
+  (:use :cl)
+  (:nicknames #:wl)
+  (:export #:wl-list
+           #:wl-listener
+           #:wl-output-transform
+           #:wl-keyboard-key-state))
+
 (defpackage #:wlr
-  (:use :cl #:wayland-server-core)
+  (:use :cl #:wayland)
   (:export
    ;; Symbols for wlr-box:
    #:wlr-box
@@ -10,7 +18,7 @@
    #:wlr-log-importance))
 
 (defpackage #:mahogany/core
-  (:use :cl #:wayland-server-core #:xkb #:wlr)
+  (:use :cl #:wayland #:xkb #:wlr)
   (:local-nicknames (#:mh/interface #:mahogany/wm-interface)
                     (#:colors #:cl-colors2))
   (:nicknames #:hrt)

--- a/lisp/heart/wl-bindings.lisp
+++ b/lisp/heart/wl-bindings.lisp
@@ -1,0 +1,25 @@
+(in-package #:wl)
+
+(cffi:defcstruct wl-list
+  (prev :pointer)
+  (next :pointer))
+
+(cffi:defcstruct wl-listener
+  "wl_listener struct"
+  (link (:struct wl-list))
+  (notify :pointer))
+
+(cffi:defcenum wl-output-transform
+  +output-transform-normal+
+  +output-transform-90+
+  +output-transform-180+
+  +output-transform-270+
+  +output-transform-flipped+
+  +output-transform-flipped-90+
+  +output-transform-flipped-180+
+  +output-transform-flipped-270+)
+
+(cffi:defcenum wl-keyboard-key-state
+  +wl-keyboard-key-state-released+
+  +wl-keyboard-key-state-pressed+
+  +wl-keyboard-key-state-repeated+)

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -15,7 +15,6 @@
                #:terminfo
                #:adopt
                #:xkbcommon
-               #:cl-wayland
                #:iterate
                #:atomics
                #:fset
@@ -40,7 +39,8 @@
                (:module heart
                 :depends-on ("interfaces" "theme" "util" "log")
                 :components ((:file "package")
-                             (:file "wlr-bindings" :depends-on ("package"))
+                             (:file "wl-bindings" :depends-on ("package"))
+                             (:file "wlr-bindings" :depends-on ("wl-bindings"))
                              (:file "hrt-libs" :depends-on ("package"))
                              (:file "hrt-bindings" :depends-on ("wlr-bindings"))
                              (:file "callback" :depends-on ("package"))


### PR DESCRIPTION
Instead, just have our own declarations for the tiny subset of items we need. This reduces the image size and makes it more clear that we aren't really doing anything related to wayland in the lisp code. If we do go back to calling these functions, there are a few different libraries that may have gained better support by then.