### PR TITLE
SBCL: Reduce pointer and integer boxing notes in callbacks

### DIFF
--- a/lisp/events.lisp
+++ b/lisp/events.lisp
@@ -1,63 +1,94 @@
 (in-package #:mahogany)
 
+(defmacro silence-notes (&body body)
+  `(locally
+       (declare
+        #+sbcl
+        (sb-ext:muffle-conditions sb-ext:compiler-note))
+     ,@body))
+
+(defmacro %with-found-view (state (view-var view-ptr) &body body)
+  ;; There might be a way to prevent SBCL from needing to box
+  ;; the 64 bit pointers in order to hash them, but it's not obvious.
+  ;; Silence the note to make more important notes more visible:
+  `(alexandria:if-let ((,view-var (silence-notes
+                                   (gethash (cffi:pointer-address ,view-ptr)
+                                            (slot-value ,state 'views)))))
+     (progn
+       ,@body)
+     (silence-notes
+      (log-string :error "Could not find mahogany view associated with pointer ~S"
+                  (cffi:pointer-address ,view-ptr)))))
+
 (hrt:define-hrt-callback handle-new-view-event :void
     ((view (:pointer (:struct hrt:hrt-view))))
     ()
   (log-string :trace "New view callback called!")
-  (mahogany-state-view-add *compositor-state* view))
+  (silence-notes
+   (mahogany-state-view-add *compositor-state* view)))
 
 (hrt:define-hrt-callback handle-view-size-changed :void
-    ((view (:pointer (:struct hrt:hrt-view))))
+    ((view-ptr (:pointer (:struct hrt:hrt-view))))
     ()
   (log-string :trace "View size changed")
-  (mahogany-state-view-size-changed *compositor-state* view))
+  (%with-found-view *compositor-state* (view view-ptr)
+    (mahogany-state-view-size-changed *compositor-state* view)))
 
 (hrt:define-hrt-callback handle-view-mapped :void
-    ((view (:pointer (:struct hrt:hrt-view))))
+    ((view-ptr (:pointer (:struct hrt:hrt-view))))
     ()
   (log-string :trace "View Mapped!")
-  (mahogany-state-view-map *compositor-state* view))
+  (%with-found-view *compositor-state* (view view-ptr)
+    (mahogany-state-view-map *compositor-state* view)))
 
 (hrt:define-hrt-callback handle-view-unmapped :void
-    ((view (:pointer (:struct hrt:hrt-view))))
+    ((view-ptr (:pointer (:struct hrt:hrt-view))))
     ()
   (log-string :trace "View unmapped!")
-  (mahogany-state-view-unmap *compositor-state* view))
+  (%with-found-view *compositor-state* (view view-ptr)
+    (mahogany-state-view-unmap *compositor-state* view)))
 
 (hrt:define-hrt-callback handle-view-destroyed-event :void
     ((view (:pointer (:struct hrt:hrt-view))))
     ()
   (log-string :trace "View destroyed callback called!")
-  (mahogany-state-view-remove *compositor-state*  view))
+  (silence-notes
+   (mahogany-state-view-remove *compositor-state*  view)))
 
 (hrt:define-hrt-callback handle-view-minimize :void
-    ((view (:pointer (:struct hrt:hrt-view))))
+    ((view-ptr (:pointer (:struct hrt:hrt-view))))
     ()
   (log-string :trace "View minimize callback called!")
-  (mahogany-state-view-minimize *compositor-state* view))
+  (%with-found-view *compositor-state* (view view-ptr)
+    (mahogany-state-view-minimize *compositor-state* view)))
 
 (hrt:define-hrt-callback handle-view-maximize :void
-    ((view (:pointer (:struct hrt:hrt-view))))
+    ((view-ptr (:pointer (:struct hrt:hrt-view))))
     ()
   (log-string :trace "View maximize callback called!")
-  (mahogany-state-view-maximize *compositor-state* view))
+  (%with-found-view *compositor-state* (view view-ptr)
+    (mahogany-state-view-maximize *compositor-state* view)))
 
 (hrt:define-hrt-callback handle-request-fullscreen :bool
-    ((view (:pointer (:struct hrt:hrt-view)))
-     (output (:pointer (:struct hrt:hrt-output)))
+    ((view-ptr (:pointer (:struct hrt:hrt-view)))
+     (output-ptr (:pointer (:struct hrt:hrt-output)))
      (fullscreen :bool))
     (:error-val nil)
-  (mahogany-state-view-fullscreen *compositor-state* view output fullscreen))
+  (let ((output (%find-output output-ptr *compositor-state*)))
+    (%with-found-view *compositor-state* (view view-ptr)
+      (mahogany-state-view-fullscreen *compositor-state* view output fullscreen))))
 
 (hrt:define-hrt-callback handle-new-output :void
-    ((output (:pointer (:struct hrt:hrt-output))))
+    ((output-ptr (:pointer (:struct hrt:hrt-output))))
     ()
-  (mahogany-state-output-add *compositor-state* output))
+  (silence-notes
+   (mahogany-state-output-add *compositor-state* output-ptr)))
 
 (hrt:define-hrt-callback handle-output-removed :void
-    ((output (:pointer (:struct hrt:hrt-output))))
+    ((output-ptr (:pointer (:struct hrt:hrt-output))))
     ()
-  (mahogany-state-output-remove *compositor-state* output))
+  (silence-notes
+   (mahogany-state-output-remove *compositor-state* output-ptr)))
 
 (hrt:define-hrt-callback handle-output-layout-change :void
     ()
@@ -81,6 +112,7 @@
   (log-string :trace "Layer shell unmapped"))
 
 (hrt:define-hrt-callback handle-layer-shell-arrange :void
-    ((output (:pointer (:struct hrt:hrt-output))))
+    ((output-ptr (:pointer (:struct hrt:hrt-output))))
     ()
-  (mahogany-state-layers-arrange *compositor-state* output))
+  (let ((output (%find-output output-ptr *compositor-state*)))
+    (mahogany-state-layers-arrange *compositor-state* output)))

--- a/lisp/state.lisp
+++ b/lisp/state.lisp
@@ -91,16 +91,18 @@
       (loop for g across groups
             do (group-add-output g mh-output (server-seat state))))))
 
-(defun %find-output (hrt-output outputs)
-  (find hrt-output outputs
-      :key #'hrt:output-hrt-output
-      :test #'cffi:pointer-eq))
+(declaim (inline %find-output))
+(defun %find-output (hrt-output state)
+  (declare (type mahogany-state state))
+  (find hrt-output (state-outputs state)
+        :key #'hrt:output-hrt-output
+        :test #'cffi:pointer-eq))
 
 (defun mahogany-state-output-remove (state hrt-output)
   (with-accessors ((outputs state-outputs)
                    (groups state-groups))
       state
-    (let ((mh-output (%find-output hrt-output outputs)))
+    (let ((mh-output (%find-output hrt-output state)))
       (log-string :debug "Output removed ~S" (hrt:output-full-name mh-output))
       (loop for g across groups
             do (group-remove-output g mh-output (server-seat state)))
@@ -160,15 +162,14 @@
       (loop for g across groups
             do (group-reconfigure-outputs g (state-outputs state))))))
 
-(defun mahogany-state-layers-arrange (state hrt-output)
+(defun mahogany-state-layers-arrange (state output)
   (declare (type mahogany-state state))
-  (let ((output (%find-output hrt-output (state-outputs state))))
-    (log-string :debug "layer shell layers re-arranged on output ~S"
-                (hrt:output-full-name output))
-    (hrt:with-view-transaction ()
-      (with-accessors ((groups state-groups)) state
-        (loop for g across groups
-              do (group-rearrange-output g output))))))
+  (log-string :debug "layer shell layers re-arranged on output ~S"
+              (hrt:output-full-name output))
+  (hrt:with-view-transaction ()
+    (with-accessors ((groups state-groups)) state
+      (loop for g across groups
+            do (group-rearrange-output g output)))))
 
 (defun mahogany-state-view-add (state view-ptr)
   (declare (type mahogany-state state)
@@ -179,13 +180,6 @@
       state
     (let ((new-view (group-add-initialize-view current-group view-ptr)))
       (setf (gethash (cffi:pointer-address view-ptr) view-tbl) new-view))))
-
-(defmacro %with-found-view (state (view-var view-ptr) &body body)
-  `(alexandria:if-let ((,view-var (gethash (cffi:pointer-address ,view-ptr)
-                                           (slot-value ,state 'views))))
-     (progn
-       ,@body)
-     (log-string :error "Could not find mahogany view associated with pointer ~S" ,view-ptr)))
 
 (defun %find-view-in-groups (view groups)
   (find-if (lambda (g) (member view (mahogany-group-views g))) groups))
@@ -207,58 +201,52 @@
         (remhash (cffi:pointer-address view-ptr) views))
       (log-string :error "Could not find mahogany view associated with pointer ~S" view-ptr))))
 
-(defun mahogany-state-view-fullscreen (state view-ptr output-ptr set-fullscreen)
+(defun mahogany-state-view-fullscreen (state view output set-fullscreen)
   (declare (type mahogany-state state)
-	   (type cffi:foreign-pointer view-ptr))
-  (let ((output (%find-output output-ptr (state-outputs state))))
-    (%with-found-view state (view view-ptr)
-      (%with-found-group state (group view)
-        (log-string :debug
-                    "~@<Fullscreen requested (~:[no~;yes~]):~I ~:_view ~S ~:_on output ~S~:>"
-                    set-fullscreen view output)
-	(group-set-fullscreen group view output set-fullscreen)))))
+	       (type hrt:view view))
+  (%with-found-group state (group view)
+    (log-string :debug
+                "~@<Fullscreen requested (~:[no~;yes~]):~I ~:_view ~S ~:_on output ~S~:>"
+                set-fullscreen view output)
+	(group-set-fullscreen group view output set-fullscreen)))
 
-(defun mahogany-state-view-map (state view-ptr)
+(defun mahogany-state-view-map (state view)
   (declare (type mahogany-state state)
-           (type cffi:foreign-pointer view-ptr))
-  (%with-found-view state (view view-ptr)
-    (%with-found-group state (group view)
-      (group-map-view group view))))
+           (type hrt:view view))
+  (%with-found-group state (group view)
+    (group-map-view group view)))
 
-(defun mahogany-state-view-unmap (state view-ptr)
+(defun mahogany-state-view-unmap (state view)
   (declare (type mahogany-state state)
-           (type cffi:foreign-pointer view-ptr))
-  (%with-found-view state (view view-ptr)
-    (%with-found-group state (group view)
-      (group-unmap-view group view))))
+           (type hrt:view view))
+  (%with-found-group state (group view)
+    (group-unmap-view group view)))
 
-(defun mahogany-state-view-size-changed (state view-ptr)
+(defun mahogany-state-view-size-changed (state view)
   (declare (type mahogany-state state)
-	   (type cffi:foreign-pointer view-ptr))
-  (%with-found-view state (view view-ptr)
-    ;; For now, just check to see if the view is now under the cursor:
-    (hrt:dirty-view-transaction)
-    ;; TODO: Center the view in its frame if the dimensions do not match. May
-    ;;  also need to do something if it's now bigger than the frame:
-    ))
+	       (type hrt:view view)
+           (ignore state view))
+  ;; For now, just check to see if the view is now under the cursor:
+  (hrt:dirty-view-transaction)
+  ;; TODO: Center the view in its frame if the dimensions do not match. May
+  ;;  also need to do something if it's now bigger than the frame:
+  )
 
-(defun mahogany-state-view-maximize (state view-ptr)
+(defun mahogany-state-view-maximize (state view)
   (declare (type mahogany-state state)
-           (type cffi:foreign-pointer view-ptr))
-  (%with-found-view state (view view-ptr)
-    (%with-found-group state (group view)
-      (if (member *follow-config-events* '(:all :maximize))
-          (group-maximize-view group view)
-          (hrt:view-configure view)))))
+           (type hrt:view view))
+  (%with-found-group state (group view)
+    (if (member *follow-config-events* '(:all :maximize))
+        (group-maximize-view group view)
+        (hrt:view-configure view))))
 
-(defun mahogany-state-view-minimize (state view-ptr)
+(defun mahogany-state-view-minimize (state view)
   (declare (type mahogany-state state)
-           (type cffi:foreign-pointer view-ptr))
-  (%with-found-view state (view view-ptr)
-    (%with-found-group state (group view)
-      (if (member *follow-config-events* '(:all :minimize))
-          (group-minimize-view group view)
-          (hrt:view-configure view)))))
+           (type hrt:view view))
+  (%with-found-group state (group view)
+    (if (member *follow-config-events* '(:all :minimize))
+        (group-minimize-view group view)
+        (hrt:view-configure view))))
 
 (defun state-next-hidden-group (state)
   (declare (type mahogany-state state))
@@ -292,8 +280,7 @@ KEYMAP-CREATION-ERROR if the rules are invalid or malformed."
 (defun %get-or-autoassign-output (state hrt-layer-shell)
   (declare (type mahogany-state state))
   (alexandria:if-let ((hrt-output (hrt:layer-surface-output hrt-layer-shell)))
-      (with-accessors ((outputs state-outputs)) state
-        (the (or hrt:output null) (%find-output hrt-output outputs)))
+    (the (or hrt:output null) (%find-output hrt-output state))
     (let ((current-output (group-current-output (state-current-group state))))
       ;; TODO: try to use the fallback output:
       (unless current-output


### PR DESCRIPTION
SBCL is clever enough to recognize that it doesn't need to box callback parameters, but overzealously warns when an action taken does box these values. Move some of the lookups of these objects into the callbacks to reduce the need for boxing.
+ Muffle the warnings where it can't avoid boxing; it still needs to box the pointer values when putting them as keys of a hash table, but no longer needs to box the pointers themselves.