### PR TITLE
lisp: Improve type correctness for hrt-keypress-info

### DIFF
--- a/lisp/heart/hrt-bindings.lisp
+++ b/lisp/heart/hrt-bindings.lisp
@@ -39,7 +39,7 @@
   (keysyms :pointer #| xkb-keysym-t |#)
   (modifiers :uint32)
   (keysyms-len :size)
-  (wl-key-state :int #| enum wl-keyboard-key-state |#))
+  (wl-key-state :unsigned-int #| enum wl-keyboard-key-state |#))
 
 (cffi:defcstruct hrt-seat-callbacks
   (button-event :pointer #| function ptr void (struct hrt_seat *, struct wlr_pointer_button_event *) |#)

--- a/lisp/heart/package.lisp
+++ b/lisp/heart/package.lisp
@@ -4,7 +4,10 @@
   (:export #:wl-list
            #:wl-listener
            #:wl-output-transform
-           #:wl-keyboard-key-state))
+           #:wl-keyboard-key-state
+           #:+wl-keyboard-key-state-released+
+           #:+wl-keyboard-key-state-pressed+
+           #:+wl-keyboard-key-state-repeated+))
 
 (defpackage #:wlr
   (:use :cl #:wayland)

--- a/lisp/input.lisp
+++ b/lisp/input.lisp
@@ -97,12 +97,12 @@ Values:
 
 (defun handle-key-event (state key seat event-state)
   (declare (type key key)
-           (type bit event-state)
+           (type (unsigned-byte 32) event-state)
            (type mahogany-state state)
            (optimize (speed 3)))
   (let ((key-state (state-key-state state)))
     (declare (type key-state key-state))
-    (if (= event-state 1)
+    (if (= event-state wl:+wl-keyboard-key-state-pressed+)
         (check-and-run-keybinding key seat key-state)
         (key-state-active-p key-state))))
 


### PR DESCRIPTION
The wl-key-state field is an enum, which has an underlying type of `unsigned int` on all of the platforms we care about. We don't use the enum value here, as we don't want to have the (small) overhead of converting the number to a symbol.