### PR TITLE
lisp: Define a priority ordering for output configurations

### DIFF
--- a/doc/manual/output-configuration.org
+++ b/doc/manual/output-configuration.org
@@ -40,3 +40,13 @@ OUTPUT-PROPERTIES :
 #+END_SRC
 
 Note that screen mirroring is not supported yet.
+
+** Configuration Priority
+
+When there are mulitple configurations that could match the same
+output, the one with the most specificity is chosen. The order of
+precidence for outputs are =:name=, =:make=, =model=, and =serial=. A
+configuration with a property with higher precidence is picked over
+ones with less precidence, even if more properties match. For example,
+if a =serial= property matches, it will always have precidence over a
+configuration without that property.

--- a/lisp/output-config.lisp
+++ b/lisp/output-config.lisp
@@ -64,7 +64,7 @@
         (push match-data settings)))
     (%make-output-layout-config name settings)))
 
-(defvar *output-configurations* (make-hash-table)
+(defvar *output-configurations* (make-hash-table :test 'equalp)
   "Name output configurations that define how a single output should be configured.")
 
 (defmacro define-output-config (name &body config)
@@ -73,7 +73,7 @@
        (setf (gethash ,name-symb *output-configurations*)
              (build-output-match-data (quote ,config))))))
 
-(defvar *output-layout-configurations* (make-hash-table)
+(defvar *output-layout-configurations* (make-hash-table :test 'equalp)
   "Named output layout configurations that define how a set of outputs
 should be configured and laid out.")
 
@@ -83,7 +83,7 @@ should be configured and laid out.")
        (setf (gethash ,name-symb *output-layout-configurations*)
              (make-output-layout-config ,name-symb (quote ,outputs))))))
 
-(defun output-match-data-matches-p (output match-data)
+(defun score-output-match-data-match (output match-data)
   (declare (type hrt:output output)
            (type output-match-data match-data))
   (with-accessors ((name output-match-data-name)
@@ -91,18 +91,34 @@ should be configured and laid out.")
                    (model output-match-data-model)
                    (serial output-match-data-serial))
       match-data
-    (macrolet ((present-compare (match-accessor val)
-                 `(if ,match-accessor
-                      (string= ,match-accessor ,val)
-                      t)))
-      (and
-       (present-compare name (hrt:output-name output))
-       (present-compare make (hrt:output-make output))
-       (present-compare model (hrt:output-model output))
-       (present-compare serial (hrt:output-serial output))))))
+    (macrolet ((present-compare (match-accessor val score)
+                 `(if (and ,match-accessor (string= ,match-accessor ,val))
+                      ,score
+                      0)))
+      (+
+       (present-compare name (hrt:output-name output) 1)
+       (present-compare make (hrt:output-make output) 2)
+       (present-compare model (hrt:output-model output) 4)
+       (present-compare serial (hrt:output-serial output) 8)))))
 
 (defun find-output-config (output)
   "Find an individual output configuration that matches the given output."
-  (loop :for c :being :the :hash-value :of *output-configurations*
-        :when (output-match-data-matches-p output c)
-          :return c))
+  (let ((score 0))
+    (with-hash-table-iterator (iter *output-configurations*)
+      (multiple-value-bind (more key matching)
+          (iter)
+        (declare (ignore key))
+        (unless more
+          (return-from find-output-config))
+        (setf score (score-output-match-data-match output matching))
+        (loop
+          (multiple-value-bind (more key cur)
+              (iter)
+            (declare (ignore key))
+            (unless more
+              (return))
+            (let ((cur-score (score-output-match-data-match output cur)))
+              (when (> cur-score score)
+                (setf score cur-score
+                      matching cur)))))
+        (values matching score)))))

--- a/mahogany-test.asd
+++ b/mahogany-test.asd
@@ -14,6 +14,7 @@ This file is a part of mahogany.
                (:file "theme/theme-tests")
 	           (:file "tree-tests" :depends-on ("util"))
 	           (:file "keyboard-tests")
+               (:file "output-config-tests" :depends-on ("util"))
 	           (:file "kmap-modes")
 	           (:file "config-system-tests")
 	           (:file "log-tests"))

--- a/test/output-config-tests.lisp
+++ b/test/output-config-tests.lisp
@@ -1,0 +1,94 @@
+(fiasco:define-test-package #:mahogany-tests/output-config
+  (:local-nicknames (#:mh #:mahogany)
+                    (#:alex #:alexandria))
+  (:use #:mahogany/wm-interface
+        #:mahogany/test/util))
+
+(in-package #:mahogany-tests/output-config)
+
+(eval-when (:compile-toplevel :load-toplevel)
+  (defun %build-cond-form (specs accessor key)
+    (let ((cond-cases (mapcan (lambda (x)
+                                (alex:when-let ((val (getf (cdr x) key)))
+                                  `(((eq ,(car x) output)
+                                     ,val))))
+                              specs)))
+      `(,accessor (output)
+                  ,(if cond-cases
+                       `(cond
+                          ,@cond-cases)
+                       `(declare (ignore output))))))
+  (defun %output-properties-from-keys (keys)
+    (mapcan (lambda (x)
+              (list x (symbol-name x)))
+            keys)))
+
+(defmacro with-output-properties (specs &body body)
+  (let ((vars (mapcar #'first specs))
+        (name-form (%build-cond-form specs 'hrt:output-name :name))
+        (make-form (%build-cond-form specs 'hrt:output-make :make))
+        (model-form (%build-cond-form specs 'hrt:output-model :model))
+        (serial-form (%build-cond-form specs 'hrt:output-serial :serial)))
+    `(let (,@(mapcar (lambda (x) `(,x (make-mock-output
+                                       :full-name ,(symbol-name x))))
+                     vars))
+       (cl-mock:dflet (,name-form
+                       ,make-form
+                       ,model-form
+                       ,serial-form)
+         ,@body))))
+
+(defmacro with-mock-configurations (&body body)
+  `(let ((mh::*output-configurations* (make-hash-table :test 'equalp)))
+     ,@body))
+
+(defmacro define-find-output-config-test (&rest properties)
+  (let* ((test-name (format nil "FIND-OUTPUT-CONFIG-MATCHES-~{~A~^-~}"
+                           properties))
+         (output-properties (%output-properties-from-keys properties)))
+    `(fiasco:deftest ,(intern test-name) ()
+       (with-mock-configurations
+         (with-output-properties ((output ,@output-properties))
+           (let* ((config (mh::define-output-config "test"
+                            ,output-properties))
+                  (result (mh::find-output-config output)))
+             (is (eq result config))))))))
+
+(define-find-output-config-test :name)
+(define-find-output-config-test :make)
+(define-find-output-config-test :model)
+(define-find-output-config-test :serial)
+(define-find-output-config-test :name :make :model :serial)
+(define-find-output-config-test :name :make)
+
+(defmacro define-find-output-config-priority-test (&key output priority other)
+  (let ((test-name (format nil
+                           "FIND-OUTPUT-CONFIG-PRIORITIZES-~{~A~^-~}-OVER-~{~A~^-~}"
+                           priority other))
+        (output-properties (%output-properties-from-keys output))
+        (priority-properties (%output-properties-from-keys priority))
+        (other-properties (%output-properties-from-keys other)))
+    `(fiasco:deftest ,(intern test-name) ()
+       (with-mock-configurations
+         (with-output-properties ((output ,@output-properties))
+           (mh::define-output-config "other"
+             ,other-properties)
+           (let* ((make-config (mh::define-output-config "priority"
+                                 ,priority-properties))
+                  (result (mh::find-output-config output)))
+             (is (eq result make-config))))))))
+
+(define-find-output-config-priority-test
+	:output (:name :make)
+    :priority (:make)
+    :other (:model))
+
+(define-find-output-config-priority-test
+	:output (:name :make :model :serial)
+    :priority (:model)
+    :other (:name))
+
+(define-find-output-config-priority-test
+	:output (:name :make :model :serial)
+    :priority (:serial)
+    :other (:name :make :model))

--- a/test/tree-tests.lisp
+++ b/test/tree-tests.lisp
@@ -5,8 +5,6 @@
 
 (in-package #:mahogany-tests/tree)
 
-(defstruct (mock-output (:include mahogany/core:output)))
-
 (defun container-add-mock-output (container
                                   &key (x 0) (y 0) (width 100) (height 100))
   (cl-mock:dflet ((hrt:output-position
@@ -496,9 +494,6 @@
              (new-output (container-add-mock-output container))
              (prev-frame (tree:frame-prev new-output)))
         (is (eq prev-frame new-frame))))))
-
-(defstruct (mock-view (:include hrt::view)
-                      (:constructor make-mock-view (hrt-view))))
 
 (fiasco:deftest find-view-finds-empty ()
   (with-border-box-mocks ()

--- a/test/util.lisp
+++ b/test/util.lisp
@@ -1,8 +1,17 @@
 (defpackage #:mahogany/test/util
   (:use :cl)
-  (:export #:define-matrix))
+  (:export #:define-matrix
+           #:mock-output
+           #:make-mock-output
+           #:mock-view
+           #:make-mock-view))
 
 (in-package #:mahogany/test/util)
+
+(defstruct (mock-output (:include mahogany/core:output)))
+
+(defstruct (mock-view (:include hrt::view)
+                      (:constructor make-mock-view (hrt-view))))
 
 (defun build-func-code (fn-name-string var-list body)
   (dolist (v var-list)


### PR DESCRIPTION
Resolve ties when there are multiple output configurations by picking the one with the most specificity.

Part of #59.