### PR TITLE
Define and implement the algorithm for picking the correct output layout

### DIFF
--- a/doc/manual/output-configuration.org
+++ b/doc/manual/output-configuration.org
@@ -3,7 +3,7 @@
 ** Configuring individual Outputs
 
 To configure the position, scale, resolution and refresh rate of an
-output, you can use the =define-output-config= macro:
+individual output, you can use the =define-output-config= macro:
 
 #+BEGIN_SRC lisp
   (define-output-config "default"
@@ -24,24 +24,25 @@ resolution and position.
 The grammar for this macro is as follows:
 
 #+BEGIN_SRC text
-(define-output-config NAME OUTPUT-CLAUSE)
+  (define-output-config NAME OUTPUT-CLAUSE)
 
-NAME : name
+  NAME : name
 
-OUTPUT-CLAUSE : NAME-OR-DETAILS OUTPUT-PROPERTIES
+  OUTPUT-CLAUSE : NAME-OR-DETAILS OUTPUT-PROPERTIES
 
-NAME-OR-DETAILS : output-name | (&key name make model serial)
+  NAME-OR-DETAILS : output-name | (&key name make model serial)
 
-OUTPUT-PROPERTIES :
-     (:scale scale)
-   | (:mode width height &key refresh custom)
-   | (:position x y)
-   | (:mirror NAME-OR-DETAILS)
+  OUTPUT-PROPERTIES :
+       (:scale scale)
+     | (:mode width height &key refresh custom)
+     | (:position x y)
+     | (:mirror NAME-OR-DETAILS) ;; Not supported yet
+     | (:enabled enabled)        ;; Not supported yet
 #+END_SRC
 
-Note that screen mirroring is not supported yet.
+Note that screen mirroring and disabling outputs is not supported yet.
 
-** Configuration Priority
+*** Configuration Priority
 
 When there are mulitple configurations that could match the same
 output, the one with the most specificity is chosen. The order of
@@ -50,3 +51,88 @@ configuration with a property with higher precidence is picked over
 ones with less precidence, even if more properties match. For example,
 if a =serial= property matches, it will always have precidence over a
 configuration without that property.
+
+
+** Configuring Output Layouts
+
+**Note: the functionality in this section is partially
+implemented and will not work as described.**
+
+When multiple outputs are present, you can use the
+=define-output-layout= macro to declare configurations that are only
+active when certain outputs are connected. This macro is similar to
+=define-output-config=, but it takes a list of output properties
+instead of just a single one.
+
+For example, if you have a laptop that
+you use with different monitor setups, you can declare all
+setups, and mahogany will pick the closest matching one. Let's say
+there is a "theater" configuration, and a "desktop" configuration:
+
+#+BEGIN_SRC lisp
+  (mh::define-output-layout "theater"
+    ;; there's a single visio-branded TV
+    ((:make "visio")
+     (:scale 2))
+    ;; disable the laptop's screen (not implemented yet)
+    ((:name "eda")
+     (:enabled nil)))
+
+  (mh::define-output-layout "desktop"
+    ;; An external moditor is connected that is 1080p:
+    ((:name "DP-1" :make "HP")
+     (:position 0 0))
+    ;; Put the built-in monitor to the right:
+    ("eda"
+     (:position 1920 0)))
+#+END_SRC
+
+In this setup, if an output with a make of ="visio"= is connected, the
+="theather"= configuration is applied. If an output with make of "HP" is
+connected to the ="DP-1"= output, then the ="desktop"= configuration is
+applied.
+
+When an output is matched by both a =define-output-config= declaration
+and a =define-output-layout= configuration, the properties from the
+=define-output-config= declaration are applied unless they are
+overridden by the properties in =define-output-layout=. For example,
+if the following was also present in the configuration above, the
+="eda"= output would always have a scale of 2:
+
+#+BEGIN_SRC lisp
+  (mh::define-output-config "eda-default"
+    "eda"
+    (:scale 2))
+#+END_SRC
+
+*** Grammar
+
+#+BEGIN_SRC text
+  (define-output-layout NAME-OR-OPTIONS OUTPUT-CLAUSES)
+
+  NAME-OR-OPTIONS : name | (name priority)
+
+  OUTPUT-CLAUSES :
+       (NAME-OR-DETAILS OUTPUT-PROPERTIES)
+     | (NAME-OR-DETAILS OUTPUT-PROPERTIES) OUTPUT-CLAUSES
+
+  NAME-OR-DETAILS : output-name | (&key name make model serial)
+
+  OUTPUT-PROPERTIES :
+       (:scale scale)
+     | (:mode width height &key refresh custom)
+     | (:position x y)
+     | (:mirror NAME-OR-DETAILS) ;; Not supported yet
+     | (:enabled enabled)        ;; Not supported yet
+#+END_SRC
+
+*** Resolving Conflicts
+
+If multiple layouts could be applied with the current set of connected
+outputs, the following order is used to determine which one to use:
+1. The number of outputs matched; layouts with a higher number of
+   outputs will be preferred over ones with less.
+2. The priority of the layout as specified in the layout definitions
+3. The total specificity of the configuration of the individual output
+   matchers as defined in the
+   [[*Configuration Priority][configuration priority section]].

--- a/lisp/heart/output.lisp
+++ b/lisp/heart/output.lisp
@@ -14,6 +14,25 @@
   ;; a cons of (x . y)
   (position nil :type (or cons null) :read-only t))
 
+(defun output-config-merge (base override)
+  (macrolet ((override-val (accessor)
+                 `(if (,accessor override)
+                      (,accessor override)
+                      (,accessor base))))
+    (let ((dimensions (output-config-dimensions base))
+          (refresh-rate (output-config-refresh-rate base))
+          (custom-mode (output-config-custom-mode base)))
+      (when (output-config-dimensions override)
+        (setf dimensions (output-config-dimensions override)
+              refresh-rate (output-config-refresh-rate override)
+              custom-mode (output-config-custom-mode override))
+      (make-output-config
+       :scale (override-val output-config-scale)
+       :position (override-val output-config-position)
+       :dimensions dimensions
+       :refresh-rate refresh-rate
+       :custom-mode custom-mode)))))
+
 (defun %transfer-output-config (hrt-config config)
   (cffi:with-foreign-slots
       ((scale custom-mode width height refresh-rate custom-position x y)

--- a/lisp/heart/package.lisp
+++ b/lisp/heart/package.lisp
@@ -73,6 +73,7 @@
            #:output-init
            #:make-output-config
            #:output-config
+           #:output-config-merge
            #:hrt-keypress-info
            ;; output callbacks
            #:output-added

--- a/lisp/output-config.lisp
+++ b/lisp/output-config.lisp
@@ -1,4 +1,4 @@
-(in-package #:mahogany)
+(in-package #:mahogany/output-config)
 
 (defstruct output-match-data
   (name nil :type (or null string) :read-only t)
@@ -7,8 +7,11 @@
   (serial nil :type (or null string) :read-only t)
   (config nil :type hrt:output-config :read-only t))
 
-(defstruct (output-layout-config (:constructor %make-output-layout-config (name outputs)))
+(defstruct (output-layout-config
+            (:constructor %make-output-layout-config
+                (name priority outputs)))
   (name nil :type string :read-only t)
+  (priority 0 :type fixnum :read-only t)
   (outputs nil :type list :read-only t))
 
 (defun %output-config-from-clauses (clauses)
@@ -57,12 +60,25 @@
          (match-data (%output-match-data-from-clause (first o) config)))
     match-data))
 
-(defun make-output-layout-config (name outputs)
+(defun %compare-specificity (a b)
+  (declare (type output-match-data a b))
+  (flet ((%score-match-data (x)
+           (+
+            (if (output-match-data-serial x) 8 0)
+            (if (output-match-data-model x) 4 0)
+            (if (output-match-data-make x) 2 0)
+            (if (output-match-data-name x) 1 0))))
+    (> (%score-match-data a) (%score-match-data b))))
+
+(defun make-output-layout-config (name priority outputs)
   (let ((settings nil))
     (dolist (o outputs)
       (let ((match-data (build-output-match-data o)))
         (push match-data settings)))
-    (%make-output-layout-config name settings)))
+    ;; Sort the configs now so that we don't need to
+    ;; repeatedly do it when matching configurations:
+    (setf settings (sort settings #'%compare-specificity))
+    (%make-output-layout-config name priority settings)))
 
 (defvar *output-configurations* (make-hash-table :test 'equalp)
   "Name output configurations that define how a single output should be configured.")
@@ -77,11 +93,22 @@
   "Named output layout configurations that define how a set of outputs
 should be configured and laid out.")
 
-(defmacro define-output-layout (name &body outputs)
-  (let ((name-symb (gensym "name")))
-    `(let* ((,name-symb ,name))
-       (setf (gethash ,name-symb *output-layout-configurations*)
-             (make-output-layout-config ,name-symb (quote ,outputs))))))
+(defmacro define-output-layout (name-or-options &body outputs)
+  (let* ((name-symb (gensym "name"))
+         (priority-symb (gensym "priority")))
+    (multiple-value-bind (name-val priority-val)
+        (if (listp name-or-options)
+            (destructuring-bind (name-val priority-val)
+                name-or-options
+              (values name-val priority-val))
+            (values name-or-options 0))
+      `(let ((,name-symb ,name-val)
+             (,priority-symb ,priority-val))
+         (setf (gethash ,name-symb *output-layout-configurations*)
+               (make-output-layout-config
+                ,name-symb
+                ,priority-symb
+                (quote ,outputs)))))))
 
 (defun score-output-match-data-match (output match-data)
   (declare (type hrt:output output)
@@ -101,24 +128,154 @@ should be configured and laid out.")
        (present-compare model (hrt:output-model output) 4)
        (present-compare serial (hrt:output-serial output) 8)))))
 
-(defun find-output-config (output)
-  "Find an individual output configuration that matches the given output."
+(defun find-max-score (table items score-fn)
+  (declare (type hash-table table)
+           (type (function (t t) fixnum) score-fn))
   (let ((score 0))
-    (with-hash-table-iterator (iter *output-configurations*)
+    (with-hash-table-iterator (iter table)
       (multiple-value-bind (more key matching)
           (iter)
         (declare (ignore key))
         (unless more
-          (return-from find-output-config))
-        (setf score (score-output-match-data-match output matching))
+          (return-from find-max-score))
+        (setf score (funcall score-fn items matching))
         (loop
           (multiple-value-bind (more key cur)
               (iter)
             (declare (ignore key))
             (unless more
               (return))
-            (let ((cur-score (score-output-match-data-match output cur)))
+            (let ((cur-score (funcall score-fn items cur)))
               (when (> cur-score score)
                 (setf score cur-score
                       matching cur)))))
         (values matching score)))))
+
+(defun find-output-config (output)
+  "Find an individual output configuration that matches the given output."
+  (find-max-score *output-configurations*
+                  output
+                  #'score-output-match-data-match))
+
+(defstruct (%config-match
+            (:constructor make-%config-match (output config score)))
+  (output nil :type hrt:output)
+  (config nil :type output-match-data)
+  (score 0 :type fixnum))
+
+(defun score-layout-configuration (outputs config)
+  (declare (type output-layout-config config)
+           ;; Make this code work with both arrays and lists;
+           ;; it's an array right now, but that may change:
+           (type sequence outputs))
+  ;; Correctly matching configurations to their outputs
+  ;; probably involves scoring each possible combination, then picking
+  ;; the highest scoring output for each configuration.
+  ;; Using a greedy algorithm where the most-specific
+  ;; configurations are matched first should get us there
+  ;; most of the time; during testing, I wasn't able to come up
+  ;; with a configuration that this didn't work with. Maybe it
+  ;; is the optimial solution?
+  (let ((found nil)
+        (remaining outputs))
+    (dolist (c (output-layout-config-outputs config))
+      (unless (> (length remaining) 0)
+        (return nil))
+      (let* ((cur (elt remaining 0))
+             (score (score-output-match-data-match cur c)))
+        (map nil (lambda (o)
+                   (let ((cur-score (score-output-match-data-match o c)))
+                      (when (> cur-score score)
+                        (setf score cur-score
+                              cur o))))
+             (mahogany/util:rest-seq remaining))
+        (cond
+          ((> score 0)
+           (push (make-%config-match cur c score) found)
+           (setf remaining (remove cur remaining)))
+          (t
+           (return-from score-layout-configuration nil)))))
+    found))
+
+(defun %filter-layout-matches-length (matches)
+  (let ((max-length (apply #'max (mapcar (lambda (x)
+                                           (length (cdr x)))
+                                         matches))))
+    (loop :for v :in matches
+          :nconcing (when (= (length (cdr v)) max-length)
+                      (list v)))))
+
+(defun %filter-layout-matches-priority (matches)
+  (let ((priority-vals (list))
+        (priority most-negative-fixnum))
+    (dolist (match matches)
+      (let ((cur-priority (output-layout-config-priority (car match))))
+        (cond
+          ((= cur-priority priority)
+           (push match priority-vals))
+          ((> cur-priority priority)
+           (setf priority cur-priority
+                 priority-vals (list match))))))
+    priority-vals))
+
+(defun maximum (list predicate key)
+  (when list
+    (let* ((m0 (first list))
+           (m1 (funcall key m0)))
+      (mapc (lambda (e0 &aux (e1 (funcall key e0)))
+              (when (funcall predicate e1 m1)
+                (psetf m0 e0 m1 e1)))
+            list)
+      m0)))
+
+(defun find-output-layout-config (outputs)
+  (let* ((matching
+           (loop :for v :being :the :hash-value :of *output-layout-configurations*
+                 :nconcing (let ((scores (score-layout-configuration outputs v)))
+                             (if scores
+                                 (list (cons v scores))
+                                 nil))))
+         (num-matching (length matching)))
+    (when (= num-matching 0)
+      (return-from find-output-layout-config nil))
+    (when (= num-matching 1)
+      (return-from find-output-layout-config (cdr (car matching))))
+    ;; filter out the matches that match fewer outputs:
+    (let ((remaining (%filter-layout-matches-length matching)))
+      (when (= (length remaining) 1)
+        (return-from find-output-layout-config (cdr (car remaining))))
+      ;; Now look at the configuration's priority:
+      (let ((priority-vals (%filter-layout-matches-priority remaining)))
+        (when (= (length priority-vals) 1)
+          (return-from find-output-layout-config (cdr (car priority-vals))))
+        ;; Finally, take the sum of the scores and use that:
+        (let* ((scores (mapcar (lambda (x)
+                                 (cons
+                                  (reduce (lambda (total y)
+                                            (+ total (%config-match-score y)))
+                                          (cdr x)
+                                          :initial-value 0)
+                                  x))
+                               priority-vals))
+               (max-score (maximum scores #'< #'car)))
+          (cddr max-score))))))
+
+(defun find-output-configurations (outputs)
+  (let ((layout (find-output-layout-config outputs))
+        (configurations (make-hash-table :test 'equalp)))
+    (dolist (o outputs)
+      (let ((base (find-output-config o))
+            (from-layout (alexandria:when-let
+                             ((l (find o layout :key '%config-match-output)))
+                           (%config-match-config l))))
+        (cond
+          ((and base from-layout)
+           (setf (gethash o configurations)
+                 (hrt:output-config-merge base from-layout)))
+          (base
+           (setf (gethash o configurations)
+                 base)
+          (from-layout
+           (setf (gethash o configurations)
+                 from-layout))))))
+    configurations))

--- a/lisp/package.lisp
+++ b/lisp/package.lisp
@@ -1,3 +1,10 @@
+(defpackage #:mahogany/output-config
+  (:use #:cl)
+  (:export #:find-output-configurations
+           #:find-output-config
+           #:define-output-config
+           #:define-output-layout))
+
 (defpackage #:mahogany
   (:use :cl
         #:alexandria
@@ -5,6 +12,11 @@
         #:mahogany/wm-interface
         #:mahogany/util
         #:mahogany/keyboard)
+  (:import-from #:mahogany/output-config
+                #:find-output-configurations
+                #:find-output-config
+                #:define-output-config
+                #:define-output-layout)
   (:import-from #:cl-interactive/input-method
                 #:input-method
                 #:prepare-completions-for-input-method

--- a/lisp/state.lisp
+++ b/lisp/state.lisp
@@ -82,10 +82,11 @@
       state
     (let ((mh-output (hrt:make-output hrt-output)))
       (log-string :debug "New output added ~S" (hrt:output-full-name mh-output))
+      ;; (mahogany/output-config::
       (hrt:output-init mh-output
                        (let ((output-match-data (find-output-config mh-output)))
                          (if output-match-data
-                             (output-match-data-config output-match-data)
+                             (mahogany/output-config::output-match-data-config output-match-data)
                              nil)))
       (vector-push-extend mh-output outputs)
       (loop for g across groups

--- a/lisp/util.lisp
+++ b/lisp/util.lisp
@@ -7,7 +7,8 @@
            #:condition-text
            #:defglobal
            #:disable-fpu-exceptions
-           #:enable-debugger))
+           #:enable-debugger
+           #:rest-seq))
 
 (in-package #:mahogany/util)
 
@@ -37,3 +38,23 @@ When this error is signaled, the only appropriate thing to do is exit."))
   (sb-ext:enable-debugger)
   #+clasp
   (ext:enable-debugger))
+
+#+sbcl
+(declaim (sb-ext:maybe-inline rest-seq))
+(defun rest-seq (seq)
+  (declare (type sequence seq)
+           (optimize (speed 3)))
+  ;; SBCL complains about missed optimizations,
+  ;; so break vector and simple-array types
+  ;; into different cases, even though the code
+  ;; is the same:
+  (etypecase seq
+    (simple-array (make-array (- (length seq) 1)
+                              :displaced-to seq
+                              :element-type (array-element-type seq)
+                              :displaced-index-offset 1))
+    (vector (make-array (- (length seq) 1)
+                        :displaced-to seq
+                        :element-type (array-element-type seq)
+                        :displaced-index-offset 1))
+    (list (cdr seq))))

--- a/mahogany-test.asd
+++ b/mahogany-test.asd
@@ -17,7 +17,9 @@ This file is a part of mahogany.
                (:file "output-config-tests" :depends-on ("util"))
 	           (:file "kmap-modes")
 	           (:file "config-system-tests")
-	           (:file "log-tests"))
+	           (:file "log-tests")
+               (:module "heart"
+                :components ((:file "output-tests"))))
   :description "Test System for mahogany."
   :perform (test-op :after (op c)
                     (uiop/package:symbol-call "FIASCO" "ALL-TESTS")))

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -88,10 +88,10 @@
                (:file "package")
                (:file "command" :depends-on ("input-methods" "globals" "message"))
                (:file "objects" :depends-on ("package" "ring-list"))
-               (:file "output-config" :depends-on ("heart"))
+               (:file "output-config" :depends-on ("heart" "package"))
                (:file "message" :depends-on ("heart" "config"))
                (:file "group" :depends-on ("objects" "heart" "globals"))
-               (:file "state" :depends-on ("objects" "keyboard" "heart" "group"))
+               (:file "state" :depends-on ("objects" "keyboard" "heart" "group" "output-config"))
                (:file "globals" :depends-on ("objects" "system"))
                (:file "kmap-modes"
                 :depends-on ("objects" "globals" "keyboard" "input" "command"))

--- a/test/heart/output-tests.lisp
+++ b/test/heart/output-tests.lisp
@@ -1,0 +1,24 @@
+(fiasco:define-test-package #:mahogany-tests/heart/output
+  (:local-nicknames (#:alex #:alexandria))
+  (:use #:mahogany/wm-interface
+        #:mahogany/test/util))
+
+(in-package #:mahogany-tests/heart/output)
+
+(fiasco:deftest output-config-merge-handles-mode ()
+  (let* ((base (hrt:make-output-config
+                :scale 2
+                :refresh-rate 60
+                :custom-mode t
+                :dimensions (cons 600 600)
+                :position (cons 20 20)))
+         (override (hrt:make-output-config
+                    :dimensions (cons 1080 960)
+                    :refresh-rate 90))
+         (merged (hrt:output-config-merge base override)))
+    (is (equal (hrt::output-config-dimensions merged)
+               (cons 1080 960)))
+    (is (equal  (hrt::output-config-refresh-rate merged)
+                90))
+    (is (eq (hrt::output-config-custom-mode merged)
+            nil))))

--- a/test/output-config-tests.lisp
+++ b/test/output-config-tests.lisp
@@ -1,5 +1,5 @@
 (fiasco:define-test-package #:mahogany-tests/output-config
-  (:local-nicknames (#:mh #:mahogany)
+  (:local-nicknames (#:mh/output #:mahogany/output-config)
                     (#:alex #:alexandria))
   (:use #:mahogany/wm-interface
         #:mahogany/test/util))
@@ -39,7 +39,7 @@
          ,@body))))
 
 (defmacro with-mock-configurations (&body body)
-  `(let ((mh::*output-configurations* (make-hash-table :test 'equalp)))
+  `(let ((mh/output::*output-configurations* (make-hash-table :test 'equalp)))
      ,@body))
 
 (defmacro define-find-output-config-test (&rest properties)
@@ -49,9 +49,9 @@
     `(fiasco:deftest ,(intern test-name) ()
        (with-mock-configurations
          (with-output-properties ((output ,@output-properties))
-           (let* ((config (mh::define-output-config "test"
+           (let* ((config (mh/output::define-output-config "test"
                             ,output-properties))
-                  (result (mh::find-output-config output)))
+                  (result (mh/output::find-output-config output)))
              (is (eq result config))))))))
 
 (define-find-output-config-test :name)
@@ -71,11 +71,11 @@
     `(fiasco:deftest ,(intern test-name) ()
        (with-mock-configurations
          (with-output-properties ((output ,@output-properties))
-           (mh::define-output-config "other"
+           (mh/output::define-output-config "other"
              ,other-properties)
-           (let* ((make-config (mh::define-output-config "priority"
+           (let* ((make-config (mh/output::define-output-config "priority"
                                  ,priority-properties))
-                  (result (mh::find-output-config output)))
+                  (result (mh/output::find-output-config output)))
              (is (eq result make-config))))))))
 
 (define-find-output-config-priority-test
@@ -92,3 +92,135 @@
 	:output (:name :make :model :serial)
     :priority (:serial)
     :other (:name :make :model))
+
+(defmacro with-mock-layout (&body body)
+  `(let ((mh/output::*output-layout-configurations* (make-hash-table)))
+    ,@body))
+
+(defmacro define-layout-test (name args &body body)
+  `(fiasco:deftest ,name ,args
+     (with-mock-layout
+       ,@body)))
+
+(define-layout-test define-output-layout-sets-priority ()
+  (let ((layout (mh/output:define-output-layout ("name" 5)
+				  ("output"))))
+    (is (= (mh/output::output-layout-config-priority layout) 5))))
+
+(define-layout-test define-output-layout-sets-priority-when-not-specified ()
+  (let ((layout (mh/output:define-output-layout "name"
+				  ("output"))))
+    (is (= (mh/output::output-layout-config-priority layout) 0))))
+
+(define-layout-test score-layout-configuration-no-match ()
+  (mh/output:define-output-layout "name"
+    ((:name "output")))
+  (with-output-properties ((output :name "asdf"))
+    (let ((result (mh/output::find-output-layout-config (list output))))
+      (is (null result)))))
+
+(defun check-match-data (entry &key output matched scored)
+  (unless (and output matched scored)
+    (error "All keys to check-match-data need to be supplied"))
+  (with-accessors ((found-output mh/output::%config-match-output)
+                   (match mh/output::%config-match-config)
+                   (score mh/output::%config-match-score))
+      entry
+    (is (= scored score))
+    (is (eq found-output output))
+    (is (eq matched match))))
+
+(define-layout-test find-output-layout-config-scores-output ()
+  (let ((layout (mh/output:define-output-layout "name"
+				  ("output"))))
+    (with-output-properties ((output :name "output"))
+	  (let* ((result (mh/output::find-output-layout-config
+                     (list output)))
+            (entry (car result)))
+        (is entry)
+        (check-match-data
+         entry
+         :output output
+         :matched (first (mh/output::output-layout-config-outputs layout))
+         :scored 1)))))
+
+(define-layout-test find-output-layout-config-scores-output-2 ()
+  (let* ((layout (mh/output:define-output-layout "name"
+				   ((:make "HP"))
+				   ((:name "output" :make "HP")
+				    (:position 10 10)))))
+    (with-output-properties ((output
+							  :make "HP"
+							  :name "output")
+						     (o2 :make "HP"))
+      (let ((result (mh/output::find-output-layout-config
+	                 (list output o2))))
+        (is result)
+        (is (= (length result) 2))
+        (check-match-data
+         (first result)
+         :output o2
+         :matched (second (mh/output::output-layout-config-outputs layout))
+         :scored 2)
+        (check-match-data
+         (second result)
+         :output output
+         :matched (first (mh/output::output-layout-config-outputs layout))
+         :scored 3)))))
+
+(define-layout-test find-output-layout-config-maximizes-matches ()
+  (let* ((layout (mh/output:define-output-layout "name"
+				   ((:make "HP"))
+				   ((:name "output" :make "HP")
+				    (:position 10 10)))))
+    ;; Make the single one also valid:
+    (mh/output:define-output-layout "single"
+      ((:name "output" :make "HP")
+       (:position 20 20)))
+    (with-output-properties ((output
+							  :make "HP"
+							  :name "output")
+						     (o2 :make "HP"))
+      (let ((result (mh/output::find-output-layout-config
+	                 (list output o2))))
+        (is result)
+        (is (= (length result) 2))
+        (check-match-data
+         (first result)
+         :output o2
+         :matched (second (mh/output::output-layout-config-outputs layout))
+         :scored 2)
+        (check-match-data
+         (second result)
+         :output output
+         :matched (first (mh/output::output-layout-config-outputs layout))
+         :scored 3)))))
+
+(define-layout-test find-output-layout-config-total-score ()
+  ;; This one matches, has the same number of outputs,
+  ;; same priority, but a higher total score:
+  (mh/output:define-output-layout ("single" 10)
+    ((:name "output" :make "HP")
+     (:position 20 20)))
+  (let* ((layout (mh/output:define-output-layout ("name" 10)
+				   ((:name "output" :make "HP" :model "model")
+				    (:position 10 10)))))
+    (with-output-properties ((output
+							  :make "HP"
+							  :name "output")
+						     (o2 :make "HP"))
+      (let ((result (mh/output::find-output-layout-config
+	                 (make-array 2 :initial-contents (list output o2)))))
+        (is result)
+        (is (= (length result) 1))
+        (check-match-data
+         (first result)
+         :output output
+         :matched (first (mh/output::output-layout-config-outputs layout))
+         :scored 3)))))
+
+(define-layout-test find-output-configurations-no-layouts ()
+  (with-output-properties ((output :name "output"))
+	(let* ((result (mh/output:find-output-configurations
+					(list output))))
+	  (is (= (hash-table-count result) 0)))))


### PR DESCRIPTION
Pick the correct output layout by evaluating matches in the following order:
1. The number of outputs matched.
2. The priority of the layout.
3. The total specificity of the configuration of the individual output matchers.

I debated on if the number of outputs in a layout must match the connected outputs, but I think allowing more connected outputs than what is present in a layout also makes sense.

See #59.