### PR TITLE
hrt: Remove hrt_scene_layer

### DIFF
--- a/heart/include/hrt/hrt_border_box.h
+++ b/heart/include/hrt/hrt_border_box.h
@@ -19,7 +19,7 @@ void hrt_border_box_style_update(struct hrt_border_box_style *style,
                                  enum hrt_border_style border, float color[4],
                                  double line_width);
 
-struct hrt_border_box *hrt_border_box_create(struct hrt_scene_layer *parent,
+struct hrt_border_box *hrt_border_box_create(struct wlr_scene_tree *parent,
                                              struct hrt_border_box_style *style,
                                              int x, int y, int width,
                                              int height);

--- a/heart/include/hrt/hrt_scene.h
+++ b/heart/include/hrt/hrt_scene.h
@@ -38,13 +38,9 @@ struct hrt_scene_group {
     struct wlr_scene_tree *layers;
 };
 
-struct hrt_scene_layer {
-    struct wlr_scene_tree *tree;
-};
-
 struct hrt_scene_fullscreen_node {
     /// the tree holding the background node as well as the view:
-    struct hrt_scene_layer layer;
+    struct wlr_scene_tree *layer;
     struct wlr_scene_rect *background;
     struct hrt_view *view;
 };
@@ -63,19 +59,19 @@ void hrt_scene_group_destroy(struct hrt_scene_group *group);
 
 void hrt_scene_group_set_enabled(struct hrt_scene_group *group, bool enabled);
 
-struct hrt_scene_layer *hrt_scene_layer_create(struct hrt_scene_group *group);
+struct wlr_scene_tree *hrt_scene_layer_create(struct hrt_scene_group *group);
 
-void hrt_scene_layer_destroy(struct hrt_scene_layer *layer);
+void hrt_scene_layer_destroy(struct wlr_scene_tree *layer);
 
-void hrt_scene_layer_add_view(struct hrt_scene_layer *layer,
+void hrt_scene_layer_add_view(struct wlr_scene_tree *layer,
                               struct hrt_view *view);
 
 /**
  * Transfer all of the views in the source layer to the
  * destination layer
  **/
-void hrt_scene_layer_transfer(struct hrt_scene_layer *source,
-                              struct hrt_scene_layer *destination);
+void hrt_scene_layer_transfer(struct wlr_scene_tree *source,
+                              struct wlr_scene_tree *destination);
 
 struct wlr_scene_tree *hrt_scene_group_layers(struct hrt_scene_group *group);
 
@@ -86,7 +82,7 @@ struct wlr_scene_tree *hrt_scene_group_layers(struct hrt_scene_group *group);
  * Mode the hrt_view inside the node, removing it from where ever it was in the scene tree.
  **/
 struct hrt_scene_fullscreen_node *
-hrt_scene_create_fullscreen_node(struct hrt_scene_layer *layer,
+hrt_scene_create_fullscreen_node(struct wlr_scene_tree *layer,
                                  struct hrt_view *view,
                                  struct hrt_output *output);
 

--- a/heart/src/border_box.c
+++ b/heart/src/border_box.c
@@ -143,7 +143,7 @@ static bool buffer_accepts_input_p(struct wlr_scene_buffer *buffer, double *sx,
     return false;
 }
 
-struct hrt_border_box *hrt_border_box_create(struct hrt_scene_layer *parent,
+struct hrt_border_box *hrt_border_box_create(struct wlr_scene_tree *parent,
                                              struct hrt_border_box_style *style,
                                              int x, int y, int width,
                                              int height) {
@@ -161,8 +161,7 @@ struct hrt_border_box *hrt_border_box_create(struct hrt_scene_layer *parent,
 
     box->style = style;
 
-    box->scene_buffer =
-        wlr_scene_buffer_create(parent->tree, &box->buffer->base);
+    box->scene_buffer = wlr_scene_buffer_create(parent, &box->buffer->base);
     if (!box->scene_buffer) {
         wlr_log(WLR_ERROR, "Failed to build wlr_scene_buffer");
         goto error;

--- a/heart/src/scene.c
+++ b/heart/src/scene.c
@@ -1,11 +1,9 @@
 #include "hrt/hrt_output.h"
 #include "hrt/hrt_scene.h"
-#include "hrt/hrt_server.h"
 #include "hrt/hrt_view.h"
 #include "wlr/util/log.h"
 #include <assert.h>
 #include <stdlib.h>
-#include <time.h>
 #include <wayland-server-core.h>
 #include <wayland-util.h>
 
@@ -115,19 +113,18 @@ static void reparent_children(struct wlr_scene_tree *source,
     }
 }
 
-void hrt_scene_layer_transfer(struct hrt_scene_layer *source,
-                              struct hrt_scene_layer *destination) {
-    reparent_children(source->tree, destination->tree);
+void hrt_scene_layer_transfer(struct wlr_scene_tree *source,
+                              struct wlr_scene_tree *destination) {
+    reparent_children(source, destination);
 }
 
 struct wlr_scene_tree *hrt_scene_group_layers(struct hrt_scene_group *group) {
     return group->layers;
 }
 
-struct hrt_scene_layer *hrt_scene_layer_create(struct hrt_scene_group *group) {
-    struct hrt_scene_layer *layer = calloc(1, sizeof(*layer));
-    layer->tree                   = wlr_scene_tree_create(group->layers);
-    if (!layer->tree) {
+struct wlr_scene_tree *hrt_scene_layer_create(struct hrt_scene_group *group) {
+    struct wlr_scene_tree *layer = wlr_scene_tree_create(group->layers);
+    if (!layer) {
         wlr_log(WLR_ERROR,
                 "Could not create scene tree for hrt_scene_layer (group %p)",
                 group);
@@ -136,18 +133,17 @@ struct hrt_scene_layer *hrt_scene_layer_create(struct hrt_scene_group *group) {
     return layer;
 }
 
-void hrt_scene_layer_destroy(struct hrt_scene_layer *layer) {
-    wlr_scene_node_destroy(&layer->tree->node);
-    free(layer);
+void hrt_scene_layer_destroy(struct wlr_scene_tree *layer) {
+    wlr_scene_node_destroy(&layer->node);
 }
 
-void hrt_scene_layer_add_view(struct hrt_scene_layer *layer,
+void hrt_scene_layer_add_view(struct wlr_scene_tree *layer,
                               struct hrt_view *view) {
-    wlr_scene_node_reparent(&view->scene_tree->node, layer->tree);
+    wlr_scene_node_reparent(&view->scene_tree->node, layer);
 }
 
 struct hrt_scene_fullscreen_node *
-hrt_scene_create_fullscreen_node(struct hrt_scene_layer *layer,
+hrt_scene_create_fullscreen_node(struct wlr_scene_tree *layer,
                                  struct hrt_view *view,
                                  struct hrt_output *output) {
     struct hrt_scene_fullscreen_node *new_node = calloc(1, sizeof(*new_node));
@@ -157,7 +153,7 @@ hrt_scene_create_fullscreen_node(struct hrt_scene_layer *layer,
         return NULL;
     }
 
-    struct wlr_scene_tree *root = wlr_scene_tree_create(layer->tree);
+    struct wlr_scene_tree *root = wlr_scene_tree_create(layer);
     if (!root) {
         wlr_log(WLR_ERROR, "Failed to allocate wlr_scene_tree");
         return NULL;
@@ -181,7 +177,7 @@ hrt_scene_create_fullscreen_node(struct hrt_scene_layer *layer,
         return NULL;
     }
 
-    new_node->layer.tree = root;
+    new_node->layer      = root;
     new_node->background = rect;
     new_node->view       = view;
     root->node.data      = new_node;
@@ -198,7 +194,7 @@ hrt_scene_fullscreen_swap(struct hrt_scene_fullscreen_node *node,
                           struct hrt_view *view) {
     struct hrt_view *v       = node->view;
     struct wlr_scene_tree *p = view->scene_tree->node.parent;
-    hrt_view_reparent(view, node->layer.tree);
+    hrt_view_reparent(view, node->layer);
     hrt_view_reparent(node->view, p);
     node->view = view;
     hrt_view_fullscreen(view, true);
@@ -211,7 +207,7 @@ hrt_scene_fullscreen_node_destroy(struct hrt_scene_fullscreen_node *node) {
     hrt_view_reparent(view, node->background->node.parent->node.parent);
     // We don't need to free the background, as it's destroyed by
     // destroying its parent:
-    wlr_scene_node_destroy(&node->layer.tree->node);
+    wlr_scene_node_destroy(&node->layer->node);
     free(node);
 
     return view;
@@ -225,14 +221,14 @@ uint32_t hrt_scene_node_set_dimensions(struct hrt_scene_fullscreen_node *node,
 
 void hrt_scene_node_set_position(struct hrt_scene_fullscreen_node *node, int x,
                                  int y) {
-    wlr_scene_node_set_position(&node->layer.tree->node, x, y);
+    wlr_scene_node_set_position(&node->layer->node, x, y);
 }
 
 uint32_t hrt_scene_fullscreen_configure(struct hrt_scene_fullscreen_node *node,
                                         struct hrt_output *output) {
     int x, y;
     hrt_output_position(output, &x, &y);
-    wlr_scene_node_set_position(&node->layer.tree->node, x, y);
+    wlr_scene_node_set_position(&node->layer->node, x, y);
 
     int width, height;
     hrt_output_resolution(output, &width, &height);

--- a/lisp/heart/hrt-bindings.lisp
+++ b/lisp/heart/hrt-bindings.lisp
@@ -328,11 +328,8 @@ set the width and height of views."
 (cffi:defcstruct hrt-scene-group
   (layers :pointer #| (:struct wlr-scene-tree) |#))
 
-(cffi:defcstruct hrt-scene-layer
-  (tree :pointer #| (:struct wlr-scene-tree) |#))
-
 (cffi:defcstruct hrt-scene-fullscreen-node
-  (layer (:struct hrt-scene-layer))
+  (layer :pointer #| (:struct wlr-scene-tree) |#)
   (background :pointer #| (:struct wlr-scene-rect) |#)
   (view (:pointer (:struct hrt-view))))
 
@@ -370,18 +367,18 @@ set the width and height of views."
 
 #-HRT-DEBUG
 (declaim (inline hrt-scene-layer-create))
-(cffi:defcfun ("hrt_scene_layer_create" hrt-scene-layer-create) (:pointer (:struct hrt-scene-layer))
+(cffi:defcfun ("hrt_scene_layer_create" hrt-scene-layer-create) :pointer #| (:struct wlr-scene-tree) |#
   (group (:pointer (:struct hrt-scene-group))))
 
 #-HRT-DEBUG
 (declaim (inline hrt-scene-layer-destroy))
 (cffi:defcfun ("hrt_scene_layer_destroy" hrt-scene-layer-destroy) :void
-  (layer (:pointer (:struct hrt-scene-layer))))
+  (layer :pointer #| (:struct wlr-scene-tree) |#))
 
 #-HRT-DEBUG
 (declaim (inline hrt-scene-layer-add-view))
 (cffi:defcfun ("hrt_scene_layer_add_view" hrt-scene-layer-add-view) :void
-  (layer (:pointer (:struct hrt-scene-layer)))
+  (layer :pointer #| (:struct wlr-scene-tree) |#)
   (view (:pointer (:struct hrt-view))))
 
 #-HRT-DEBUG
@@ -389,8 +386,8 @@ set the width and height of views."
 (cffi:defcfun ("hrt_scene_layer_transfer" hrt-scene-layer-transfer) :void
   "Transfer all of the views in the source layer to the
 destination layer"
-  (source (:pointer (:struct hrt-scene-layer)))
-  (destination (:pointer (:struct hrt-scene-layer))))
+  (source :pointer #| (:struct wlr-scene-tree) |#)
+  (destination :pointer #| (:struct wlr-scene-tree) |#))
 
 #-HRT-DEBUG
 (declaim (inline hrt-scene-group-layers))
@@ -402,7 +399,7 @@ destination layer"
 (cffi:defcfun ("hrt_scene_create_fullscreen_node" hrt-scene-create-fullscreen-node) (:pointer (:struct hrt-scene-fullscreen-node))
   "Create a hrt_scene_fullscreen_layer with a black bacground of the given size.
 Mode the hrt_view inside the node, removing it from where ever it was in the scene tree."
-  (layer (:pointer (:struct hrt-scene-layer)))
+  (layer :pointer #| (:struct wlr-scene-tree) |#)
   (view (:pointer (:struct hrt-view)))
   (output (:pointer (:struct hrt-output))))
 
@@ -723,7 +720,7 @@ intial placement."
 #-HRT-DEBUG
 (declaim (inline hrt-border-box-create))
 (cffi:defcfun ("hrt_border_box_create" hrt-border-box-create) (:pointer (:struct hrt-border-box))
-  (parent (:pointer (:struct hrt-scene-layer)))
+  (parent :pointer #| (:struct wlr-scene-tree) |#)
   (style (:pointer (:struct hrt-border-box-style)))
   (x :int)
   (y :int)


### PR DESCRIPTION
We don't need the extra indirection that this gives us, and it should make traversing the scene graph easier from the lisp side.