### PR TITLE
Expose layer shell properties to the front end

### DIFF
--- a/cffi/hrt-bindings.yml
+++ b/cffi/hrt-bindings.yml
@@ -27,6 +27,7 @@ enum-constants:
     names:
     - window-gravity
     - hrt-border-style
+    - hrt-layer-shell-keyboard-interactivity
 make-inline:
   - include:
       match: "hrt.*"

--- a/heart/include/hrt/hrt_layer_shell.h
+++ b/heart/include/hrt/hrt_layer_shell.h
@@ -2,6 +2,7 @@
 #define HRT_LAYER_SHELL
 
 #include "hrt_scene.h"
+#include "wlr-layer-shell-unstable-v1-protocol.h"
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_output.h>
@@ -35,6 +36,17 @@ struct hrt_layer_shell_callbacks {
     layer_shell_event_handler layer_surface_mapped;
     layer_shell_event_handler layer_surface_unmapped;
     void (*layers_reconfigured)(struct hrt_output *);
+    layer_shell_event_handler keyboard_interactivity_updated;
+    layer_shell_event_handler layer_changed;
+};
+
+enum hrt_layer_shell_keyboard_interactivity {
+    HRT_LAYER_SHELL_KEYBOARD_NONE =
+        ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE,
+    HRT_LAYER_SHELL_KEYBOARD_EXCLUSIVE =
+        ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE,
+    HRT_LAYER_SHELL_KEYBOARD_ON_DEMAND =
+        ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_ON_DEMAND,
 };
 
 /**
@@ -65,5 +77,15 @@ void hrt_layer_surface_focus(struct hrt_layer_shell_surface *surface,
 
 void hrt_layer_surface_unfocus(struct hrt_layer_shell_surface *surface,
                                struct hrt_seat *seat);
+
+enum hrt_layer_shell_keyboard_interactivity
+hrt_layer_surface_keyboard_interactivity(
+    struct hrt_layer_shell_surface *surface);
+
+enum zwlr_layer_shell_v1_layer
+hrt_layer_surface_layer(struct hrt_layer_shell_surface *surface);
+
+void hrt_layer_surface_position(struct hrt_layer_shell_surface *surface, int *x,
+                                int *y);
 
 #endif

--- a/heart/src/layer_shell.c
+++ b/heart/src/layer_shell.c
@@ -8,6 +8,7 @@
 #include "hrt/hrt_output.h"
 #include "hrt/hrt_scene.h"
 #include "scene_descriptor.h"
+#include "wlr-layer-shell-unstable-v1-protocol.h"
 #include "wlr/util/box.h"
 #include "wlr/util/log.h"
 
@@ -72,13 +73,19 @@ void hrt_layer_shell_surface_place(struct hrt_layer_shell_surface *surface,
         return;
     }
     wlr_log(WLR_DEBUG, "Surface created");
-    surface->output = output;
-    surface->tree   = surface->scene_surface->tree;
+    surface->output                = output;
+    surface->layer_surface->output = output->wlr_output;
+    surface->tree                  = surface->scene_surface->tree;
 }
 
 void hrt_layer_shell_surface_set_output(
     struct hrt_layer_shell_surface *layer_shell, struct hrt_output *output) {
     layer_shell->layer_surface->output = output->wlr_output;
+}
+
+enum zwlr_layer_shell_v1_layer
+hrt_layer_shell_surface_get_layer(struct hrt_layer_shell_surface *layer_shell) {
+    return layer_shell->layer_surface->current.layer;
 }
 
 static void hrt_layer_shell_destroy(struct wl_listener *listener, void *data) {
@@ -94,6 +101,8 @@ static void check_callbacks(const struct hrt_layer_shell_callbacks *callbacks) {
     assert(callbacks->layer_surface_mapped != nullptr);
     assert(callbacks->layer_surface_unmapped != nullptr);
     assert(callbacks->layers_reconfigured != nullptr);
+    assert(callbacks->keyboard_interactivity_updated != nullptr);
+    assert(callbacks->layer_changed != nullptr);
 }
 
 bool hrt_layer_shell_init(struct hrt_server *server,
@@ -201,6 +210,18 @@ static void handle_surface_commit(struct wl_listener *listener, void *data) {
         surface->mapped               = layer_surface->surface->mapped;
         struct hrt_output *hrt_output = surface->output;
         hrt_layer_shell_arrange_layers(hrt_output, true);
+    }
+
+    if (surface->mapped) {
+        bool keyboard_interactive =
+            committed & WLR_LAYER_SURFACE_V1_STATE_KEYBOARD_INTERACTIVITY;
+        if (keyboard_interactive) {
+            surface->callbacks->keyboard_interactivity_updated(surface);
+        }
+        bool layer_changed = committed & WLR_LAYER_SURFACE_V1_STATE_LAYER;
+        if (layer_changed) {
+            surface->callbacks->layer_changed(surface);
+        }
     }
 }
 
@@ -366,7 +387,26 @@ void hrt_layer_shell_finish_init(struct hrt_layer_shell_surface *surface) {
 
 struct hrt_output *
 hrt_layer_surface_output(struct hrt_layer_shell_surface *layer_shell) {
-    return (struct hrt_output *)layer_shell->layer_surface->data;
+    struct wlr_output *output = layer_shell->layer_surface->output;
+    if (output) {
+        return (struct hrt_output *)output->data;
+    } else {
+        return nullptr;
+    }
+}
+
+enum hrt_layer_shell_keyboard_interactivity
+hrt_layer_surface_keyboard_interactivity(
+    struct hrt_layer_shell_surface *surface
+) {
+    return (
+               enum hrt_layer_shell_keyboard_interactivity
+    )surface->layer_surface->current.keyboard_interactive;
+}
+
+enum zwlr_layer_shell_v1_layer
+hrt_layer_surface_layer(struct hrt_layer_shell_surface *surface) {
+    return surface->layer_surface->current.layer;
 }
 
 void hrt_layer_surface_focus(struct hrt_layer_shell_surface *surface,
@@ -380,4 +420,10 @@ void hrt_layer_surface_unfocus(struct hrt_layer_shell_surface *surface,
                                struct hrt_seat *seat) {
     hrt_seat_keyboard_focus_surface_clear(seat,
                                           surface->layer_surface->surface);
+}
+
+void hrt_layer_surface_position(struct hrt_layer_shell_surface *surface, int *x,
+                                int *y) {
+    *x = surface->tree->node.x;
+    *y = surface->tree->node.y;
 }

--- a/lisp/events.lisp
+++ b/lisp/events.lisp
@@ -99,20 +99,39 @@
     ((surface :pointer))
     ()
   (log-string :trace "Layer shell recieved")
-  (mahogany-state-layer-shell-handle *compositor-state* surface))
+  (silence-notes
+   (mahogany-state-layer-shell-handle *compositor-state* surface)))
 
 (hrt:define-hrt-callback handle-layer-shell-mapped :void
     ((surface :pointer))
     ()
-  (log-string :trace "Layer shell mapped"))
+  (log-string :trace "Layer shell mapped")
+  (silence-notes
+   (state-layer-surface-add *compositor-state* surface)))
 
 (hrt:define-hrt-callback handle-layer-shell-unmapped :void
     ((surface :pointer))
     ()
-  (log-string :trace "Layer shell unmapped"))
+  (log-string :trace "Layer shell unmapped")
+  (silence-notes
+   (state-layer-surface-remove *compositor-state* surface)))
 
 (hrt:define-hrt-callback handle-layer-shell-arrange :void
     ((output-ptr (:pointer (:struct hrt:hrt-output))))
     ()
   (let ((output (%find-output output-ptr *compositor-state*)))
     (mahogany-state-layers-arrange *compositor-state* output)))
+
+(hrt:define-hrt-callback handle-layer-shell-keyboard-interactivity :void
+    ((surface :pointer))
+    ()
+  (silence-notes
+    (log-string :trace "Keyboard interactivity of surface ~S changed"
+                surface)))
+
+(hrt:define-hrt-callback handle-layer-shell-layer-changed :void
+    ((surface :pointer))
+    ()
+  (silence-notes
+    (log-string :trace "Surface ~S moved to layer ~S"
+                surface surface)))

--- a/lisp/heart/hrt-bindings.lisp
+++ b/lisp/heart/hrt-bindings.lisp
@@ -352,7 +352,7 @@ set the width and height of views."
 (declaim (inline hrt-scene-output-get-layer))
 (cffi:defcfun ("hrt_scene_output_get_layer" hrt-scene-output-get-layer) :pointer #| (:struct wlr-scene-tree) |#
   (output (:pointer (:struct hrt-scene-output)))
-  (layer-type :unsigned-int #| zwlr-layer-shell-v1-layer |#))
+  (layer-type zwlr-layer-shell-v1-layer))
 
 #-HRT-DEBUG
 (declaim (inline hrt-scene-group-destroy))
@@ -553,7 +553,14 @@ whenever the semaphore is non-zero."
   (new-layer-surface layer-shell-event-handler)
   (layer-surface-mapped layer-shell-event-handler)
   (layer-surface-unmapped layer-shell-event-handler)
-  (layers-reconfigured :pointer #| function ptr void (struct hrt_output *) |#))
+  (layers-reconfigured :pointer #| function ptr void (struct hrt_output *) |#)
+  (keyboard-interactivity-updated layer-shell-event-handler)
+  (layer-changed layer-shell-event-handler))
+
+(cffi:defcenum hrt-layer-shell-keyboard-interactivity
+  (:layer-shell-keyboard-none 0)
+  (:layer-shell-keyboard-exclusive 1)
+  (:layer-shell-keyboard-on-demand 2))
 
 #-HRT-DEBUG
 (declaim (inline hrt-layer-shell-surface-abort))
@@ -563,8 +570,8 @@ whenever the semaphore is non-zero."
 
 #-HRT-DEBUG
 (declaim (inline hrt-layer-surface-output))
-(cffi:defcfun ("hrt_layer_surface_output" hrt-layer-surface-output) (:pointer (:struct hrt-output))
-  (layer-shell (:pointer (:struct hrt-layer-shell-surface))))
+(cffi:defcfun ("hrt_layer_surface_output" %hrt-layer-surface-output) (:pointer (:struct hrt-output))
+  (layer-shell (:pointer (:struct hrt-layer-shell-surface))))xo
 
 #-HRT-DEBUG
 (declaim (inline hrt-layer-shell-surface-set-output))
@@ -597,6 +604,23 @@ intial placement."
 (cffi:defcfun ("hrt_layer_surface_unfocus" hrt-layer-surface-unfocus) :void
   (surface (:pointer (:struct hrt-layer-shell-surface)))
   (seat (:pointer (:struct hrt-seat))))
+
+#-HRT-DEBUG
+(declaim (inline hrt-layer-surface-keyboard-interactivity))
+(cffi:defcfun ("hrt_layer_surface_keyboard_interactivity" hrt-layer-surface-keyboard-interactivity) hrt-layer-shell-keyboard-interactivity
+  (surface (:pointer (:struct hrt-layer-shell-surface))))
+
+#-HRT-DEBUG
+(declaim (inline hrt-layer-surface-layer))
+(cffi:defcfun ("hrt_layer_surface_layer" hrt-layer-surface-layer) zwlr-layer-shell-v1-layer
+  (surface (:pointer (:struct hrt-layer-shell-surface))))
+
+#-HRT-DEBUG
+(declaim (inline hrt-layer-surface-position))
+(cffi:defcfun ("hrt_layer_surface_position" hrt-layer-surface-position) :void
+  (surface (:pointer (:struct hrt-layer-shell-surface)))
+  (x (:pointer :int))
+  (y (:pointer :int)))
 
 ;; next section imported from file build/include/hrt/hrt_server.h
 

--- a/lisp/heart/layer-shell.lisp
+++ b/lisp/heart/layer-shell.lisp
@@ -1,9 +1,56 @@
 (in-package #:hrt)
 
-;; (declaim (inline layer-surface-output))
-(defun layer-surface-output (layer-surface)
-  (declare (type cffi:foreign-pointer layer-surface))
-  (let ((output (hrt-layer-surface-output layer-surface)))
+(defstruct (layer-surface (:constructor make-layer-surface (hrt-layer-surface)))
+  (hrt-layer-surface nil :type cffi:foreign-pointer))
+
+#-HRT-DEBUG
+(declaim (inline hrt-layer-surface-output))
+(defun hrt-layer-surface-output (ptr)
+  (declare (type cffi:foreign-pointer ptr))
+  (let ((output (%hrt-layer-surface-output ptr)))
     (if (cffi:null-pointer-p output)
         nil
         output)))
+
+#-HRT-DEBUG
+(declaim (inline layer-surface-output))
+(defun layer-surface-output (layer-surface)
+  (declare (type layer-surface layer-surface))
+  (hrt-layer-surface-output (layer-surface-hrt-layer-surface layer-surface)))
+
+#-HRT-DEBUG
+(declaim (inline layer-surface-keyboard-interactivity))
+(defun layer-surface-keyboard-interactivity (layer-surface)
+  (declare (type layer-surface layer-surface))
+  (hrt-layer-surface-keyboard-interactivity
+   (layer-surface-hrt-layer-surface layer-surface)))
+
+#-HRT-DEBUG
+(declaim (inline layer-surface-layer-layer))
+(defun layer-surface-layer (layer-surface)
+  (declare (type layer-surface layer-surface))
+  (hrt-layer-surface-layer
+   (layer-surface-hrt-layer-surface layer-surface)))
+
+#-HRT-DEBUG
+(declaim (inline layer-surface-focus))
+(defun layer-surface-focus (layer-surface seat)
+  (declare (type layer-surface layer-shell))
+  (hrt-layer-surface-focus (layer-surface-hrt-layer-surface layer-surface)
+                           seat))
+
+#-HRT-DEBUG
+(declaim (inline layer-surface-unfocus))
+(defun layer-surface-unfocus (layer-surface seat)
+  (declare (type layer-surface layer-shell))
+  (hrt-layer-surface-unfocus (layer-surface-hrt-layer-surface layer-surface)
+                             seat))
+
+#-HRT-DEBUG
+(declaim (inline layer-surface-position))
+(defun layer-surface-position (layer-surface)
+  (declare (type layer-surface layer-shell))
+  (let ((hrt-surface (layer-surface-hrt-layer-surface layer-surface)))
+    (with-return-by-value ((x :int) (y :int))
+      (hrt-layer-surface-position hrt-surface
+                                  x y))))

--- a/lisp/heart/package.lisp
+++ b/lisp/heart/package.lisp
@@ -7,7 +7,9 @@
            #:wl-keyboard-key-state
            #:+wl-keyboard-key-state-released+
            #:+wl-keyboard-key-state-pressed+
-           #:+wl-keyboard-key-state-repeated+))
+           #:+wl-keyboard-key-state-repeated+
+           #:zwlr-layer-surface-v1-keyboard-interactivity
+           #:zwlr-layer-shell-v1-layer))
 
 (defpackage #:wlr
   (:use :cl #:wayland)
@@ -35,6 +37,7 @@
            #:layer-surface-mapped
            #:layer-surface-unmapped
            #:layers-reconfigured
+           #:make-layer-surface
            #:new-view
            #:view-size-changed
            #:hrt-view
@@ -149,6 +152,10 @@
            #:load-foreign-libraries
            ;; layer shell methods
            #:layer-surface-output
+           #:hrt-layer-surface-output
+           #:layer-surface-keyboard-interactivity
+           #:layer-changed
+           #:keyboard-interactivity-updated
            #:hrt-layer-shell-surface-set-output
            #:hrt-layer-shell-surface-abort
            #:hrt-layer-shell-surface-place

--- a/lisp/heart/wl-bindings.lisp
+++ b/lisp/heart/wl-bindings.lisp
@@ -28,3 +28,9 @@
   (:keyboard-interactivity-none 0)
   (:keyboard-interactivity-exclusive 1)
   (:keyboard-interactivity-on-demand 2))
+
+(cffi:defcenum zwlr-layer-shell-v1-layer
+  (:layer-background 0)
+  (:layer-bottom 1)
+  (:layer-top 2)
+  (:layer-overlay 3))

--- a/lisp/main.lisp
+++ b/lisp/main.lisp
@@ -59,7 +59,9 @@ further up. "
     (hrt:new-layer-surface handle-layer-shell-recieved)
     (hrt:layer-surface-mapped handle-layer-shell-mapped)
     (hrt:layer-surface-unmapped handle-layer-shell-unmapped)
-    (hrt:layers-reconfigured handle-layer-shell-arrange)))
+    (hrt:layers-reconfigured handle-layer-shell-arrange)
+    (hrt:keyboard-interactivity-updated handle-layer-shell-keyboard-interactivity)
+    (hrt:layer-changed handle-layer-shell-layer-changed)))
 
 (defun run-server (args)
   (hrt:load-foreign-libraries)

--- a/lisp/objects.lisp
+++ b/lisp/objects.lisp
@@ -31,6 +31,9 @@
    :read-only t)
   (views (make-hash-table)
    :type hash-table
+   :read-only t)
+  (layer-surfaces (make-hash-table)
+   :type hash-table
    :read-only t))
 
 (declaim (inline state-current-group))

--- a/lisp/state.lisp
+++ b/lisp/state.lisp
@@ -280,7 +280,7 @@ KEYMAP-CREATION-ERROR if the rules are invalid or malformed."
 
 (defun %get-or-autoassign-output (state hrt-layer-shell)
   (declare (type mahogany-state state))
-  (alexandria:if-let ((hrt-output (hrt:layer-surface-output hrt-layer-shell)))
+  (alexandria:if-let ((hrt-output (hrt:hrt-layer-surface-output hrt-layer-shell)))
     (the (or hrt:output null) (%find-output hrt-output state))
     (let ((current-output (group-current-output (state-current-group state))))
       ;; TODO: try to use the fallback output:
@@ -298,3 +298,21 @@ KEYMAP-CREATION-ERROR if the rules are invalid or malformed."
       (hrt:hrt-layer-shell-surface-place hrt-layer-shell (hrt:output-hrt-output output))
       (hrt:hrt-layer-shell-finish-init hrt-layer-shell))
     (hrt:hrt-layer-shell-surface-abort hrt-layer-shell)))
+
+(defun state-layer-surface-add (state hrt-layer-surface)
+  (declare (type mahogany-state state))
+  (let* ((surfaces (state-layer-surfaces state))
+         (new-surface (hrt:make-layer-surface hrt-layer-surface))
+         (output (%find-output (hrt:layer-surface-output new-surface) state)))
+    (setf (gethash hrt-layer-surface surfaces) new-surface)
+    (log-string
+     :info
+     "New Layer surface on output ~S~%, layer ~S with keyboard ~S keyboard"
+     output
+     (hrt::layer-surface-layer new-surface)
+     (hrt:layer-surface-keyboard-interactivity new-surface))))
+
+(defun state-layer-surface-remove (state hrt-layer-surface)
+  (declare (type mahogany-state state))
+  (let ((surfaces (state-layer-surfaces state)))
+    (remhash hrt-layer-surface surfaces)))


### PR DESCRIPTION
Expose the methods needed to get the properties of a layer surface to the lisp side, and add the appropriate helper methods.

See #85.