### PR TITLE
lisp: Use a hash table for kmaps

### DIFF
--- a/lisp/keyboard/key-hash.lisp
+++ b/lisp/keyboard/key-hash.lisp
@@ -1,0 +1,42 @@
+(in-package #:mahogany/keyboard)
+
+;; For SBCL to inline the math,
+;; the constants here need to be fixnums and somewhat small:
+(declaim (type
+          fixnum
+          +x+ +y+ +z+))
+(defconstant +x+ 3499211612)
+(defconstant +y+ 581869302)
+(defconstant +z+ 3890346734)
+
+;; this is probably the more "correct" hash due to
+;; actually being for 32 bit numbers,
+;; but it's less efficient on 64 bit systems
+;; due to all the bit shifting to keep the results at 32
+;; bits each.
+#+(or 32-bit 32-bit-target)
+(defun sxhash-key (key)
+  (declare (type key key)
+           (optimize (speed 3) (safety 1) (debug 0)))
+  (flet ((hash-32 (a b)
+           (declare (type (unsigned-byte 32) a b)
+                    (optimize (speed 3)))
+           (let ((two-to-32 (expt 2 32)))
+             (mod (+ (* +x+ a) (floor (/ (* +y+ a) two-to-32))
+                     (* +y+ b) (floor (/ (* +z+ b) two-to-32)))
+                  two-to-32))))
+    (hash-32 (key-modifier-mask key) (key-keysym key))))
+
+#+(or 64-bit 64-bit-target)
+(defun sxhash-key (key)
+  (declare (type key key)
+           (optimize (speed 3) (safety 1)))
+  (flet ((hash-64 (a b)
+           (declare (type (unsigned-byte 64) a b)
+                    (optimize (speed 3)))
+           (let ((two-to-32 (expt 2 64)))
+             (mod (+ (* +x+ a) (floor (/ (* +y+ a) two-to-32))
+                     (* +y+ b) (floor (/ (* +z+ b) two-to-32)))
+                  two-to-32))))
+    (logand (hash-64 (key-modifier-mask key) (key-keysym key))
+            most-positive-fixnum)))

--- a/lisp/keyboard/kmap.lisp
+++ b/lisp/keyboard/kmap.lisp
@@ -5,25 +5,20 @@
   command)
 
 (defstruct kmap
-  ;; TODO: Maybe this should just be a hash table instead?
-  (bindings (make-array 0 :element-type 'binding :adjustable t :fill-pointer t)
-            :type (vector binding)
-            :read-only t))
+  (bindings
+   ;; Using a custom hash function yeilds a small performance improvement
+   ;; on SBCL, but not on CCL. Clasp hasn't been tested yet.
+   #+sbcl
+   (make-hash-table :test #'key-equal
+                    :hash-function #'sxhash-key)
+   #-sbcl
+   (make-hash-table :test 'equalp)
+   :read-only t :type hash-table))
 
 (defun define-key (map key cmd)
-  "Add a binding from the given key to the given command in the keymap. If the command
-is nil, remove the binding for the given key."
-  (declare (type kmap map)
-           (type key key))
-  (let ((bindings (kmap-bindings map))
-        (new-binding (make-binding key cmd)))
-    (dotimes (i (length bindings))
-      (let ((val (binding-key (aref bindings i))))
-        (when (equalp val key)
-          (setf (aref bindings i) new-binding)
-          (return-from define-key new-binding))))
-    (vector-push-extend new-binding bindings 1))
-  map)
+  (if cmd
+      (setf (gethash key (kmap-bindings map)) cmd)
+      (remhash key (kmap-bindings map))))
 
 (defun %build-define-list (map body)
   (let* ((map-var (gensym "kmap")))
@@ -68,10 +63,9 @@ Example:
 (defun kmap-lookup (keymap key)
   "Find the command associated with the given key in the keymap"
   (declare (type key key)
-           (type kmap keymap))
-  (let ((ret (find key (kmap-bindings keymap) :key 'binding-key :test 'key-equal)))
-    (when ret
-      (binding-command ret))))
+           (type kmap keymap)
+           (optimize (speed 3) (safety 1)))
+  (gethash key (kmap-bindings keymap)))
 
 (defun pprint-kmap (map &optional (stream *standard-output*))
   "Pretty-print a `kmap' human-readably."
@@ -80,9 +74,9 @@ Example:
   (pprint-logical-block (stream nil :prefix "(" :suffix ")")
     (pprint-indent :current 2 stream)
     (write (type-of map) :stream stream)
-    (loop :for binding :across (kmap-bindings map)
-          :for key := (binding-key binding)
-          :for command := (binding-command binding)
+    (loop :for key :being :the :hash-keys
+          :in (kmap-bindings map)
+          :using (hash-value command)
           :do (pprint-newline :mandatory stream)
               (pprint-key key stream)
               (write-string " -> " stream)

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -65,9 +65,14 @@
                              (:file "transaction" :depends-on ("server"))))
                (:module keyboard
                 :depends-on ("util")
+                :serial t
                 :components ((:file "package")
                              (:file "keytrans")
                              (:file "key")
+                             ;; hashing tested on 64 bit SBCL,
+                             ;; needs testing on 32 bit SBCL:
+                             #+(and sbcl 64-bit)
+                             (:file "key-hash")
                              (:file "kmap")))
                (:module tree
                 :depends-on ("log" "util" "interfaces" "heart")


### PR DESCRIPTION
Instead of using an array (and a non-simple one, at that), use a hash table. This significantly speeds up lookup for a kmap of about 30 bindings, which is smaller than many of stumpwm's kmaps.
+ Add a custom hash function for keys, which adds a bit of speed. It's not much, but I'll take what I can get.

This probably won't have a noticeable effect on most machines, but looking up 10 million keys with a map size of 30 went from about 3 seconds to about .5 seconds.