### PR TITLE
lisp: Cleanup pipe creation/closing in foot input method

### DIFF
--- a/lisp/input-methods/foot-input-method.lisp
+++ b/lisp/input-methods/foot-input-method.lisp
@@ -15,49 +15,75 @@
 	     :input-method im
 	     :completions completions)))
 
+(defmacro with-unix-pipe ((read-spec write-spec) &body body)
+  (let (read-stream
+        write-stream
+        read-var
+        write-var)
+    (macrolet ((set-vars (spec stream-var var-symb)
+                 `(if (listp ,spec)
+                      (destructuring-bind (var &optional type)
+                          ,spec
+                        (ecase type
+                          (:stream
+                           (setf ,var-symb (gensym (symbol-name var))
+                                 ,stream-var var))
+                          ((or :fd nil)
+                           (setf ,var-symb var))))
+                      (setf ,var-symb ,spec))))
+      (set-vars read-spec read-stream read-var)
+      (set-vars write-spec write-stream write-var))
+    `(multiple-value-bind (,read-var ,write-var)
+         (sb-unix:unix-pipe)
+       (let (,@(when read-stream
+                 (list `(,read-stream (sb-sys:make-fd-stream ,read-var :input t))))
+             ,@(when write-stream
+                 (list `(,write-stream (sb-sys:make-fd-stream ,write-var :output t)))))
+       (unwind-protect
+            (progn
+              ,@body)
+         ,@(if read-stream
+               (list `(close ,read-stream))
+               (list `(sb-unix:unix-close ,read-var)))
+         ,@(if write-stream
+               (list `(close ,write-stream))
+               (list `(sb-unix:unix-close ,write-var)
+         )))))))
+
 (defmethod cl-interactive:input-method-read ((im foot-input-method)
 					     (prompt string)
 					     &key completions require-match
 					       initial-input history)
   (declare (ignore initial-input history))
-  (multiple-value-bind (read-fd write-fd)
-      (sb-unix:unix-pipe)
-    (unwind-protect
-	 (let ((curpid (sb-unix:unix-getpid))
-	       (read (sb-sys:make-fd-stream read-fd :input t))
-	       (write (sb-sys:make-fd-stream write-fd :output t)))
-	   (flet ((fzf-foot ()
-		        (multiple-value-bind (subrfd subwfd)
-			        (sb-unix:unix-pipe)
-		          (let ((write (sb-sys:make-fd-stream subwfd :output t)))
-			        (loop for comp in completions
-			              do (write-line comp write)
-				             (write-line comp))
-			        (force-output write)
-			        (sb-unix:unix-close subwfd)
-                    (let ((cmd (list "foot" "--" "sh" "-c"
-			                         (format nil "fzf --print-query --prompt=~S < /proc/~D/fd/~D | tail -1 > /proc/~D/fd/~D"
-				                             prompt curpid subrfd curpid write-fd))))
-			          (log-string :debug "Launching ~A" cmd)
-			          (uiop:launch-program cmd)))
-		          (unwind-protect (read-line read)
-			        (sb-unix:unix-close subrfd)))))
-	     (let ((pset nil)
-		       (res (fzf-foot)))
-	       (tagbody
-		    start
-		      (if require-match
-		          (if (find res completions :test #'string=)
-			          (return-from cl-interactive:input-method-read res)
-			          (progn
-			            (psetf pset t
-				               prompt (if pset
-					                      prompt
-					                      (concatenate 'string
-							                           "[Invalid Entry] "
-							                           prompt)))
-			            (setf res (fzf-foot))
-			            (go start)))
-		          (return-from cl-interactive:input-method-read res))))))
-      (sb-unix:unix-close write-fd)
-      (sb-unix:unix-close read-fd))))
+  (flet ((fzf-foot ()
+           (let ((curpid (sb-unix:unix-getpid)))
+             (with-unix-pipe ((read :stream) write-fd)
+		       (with-unix-pipe (subrfd (write :stream))
+			     (loop for comp in completions
+			           do (write-line comp write)
+				          (write-line comp))
+			     (force-output write)
+			     (close write)
+                 (let ((cmd (list "foot" "--" "sh" "-c"
+			                      (format nil "fzf --print-query --prompt=~S < /proc/~D/fd/~D | tail -1 > /proc/~D/fd/~D"
+				                          prompt curpid subrfd curpid write-fd))))
+			       (log-string :debug "Launching ~A" cmd)
+			       (uiop:launch-program cmd))
+		         (read-line read))))))
+	(let ((pset nil)
+		  (res (fzf-foot)))
+	  (tagbody
+	   start
+		 (if require-match
+		     (if (find res completions :test #'string=)
+			     (return-from cl-interactive:input-method-read res)
+			     (progn
+			       (psetf pset t
+				          prompt (if pset
+					                 prompt
+					                 (concatenate 'string
+							                      "[Invalid Entry] "
+							                      prompt)))
+			       (setf res (fzf-foot))
+			       (go start)))
+		     (return-from cl-interactive:input-method-read res))))))


### PR DESCRIPTION
Introduce `with-unix-pipe` to create pipes and the streams associated with them. This macro ensures that streams and pipes get closed.
+ Move pipe creation to where it's used