### PR TITLE
lisp: Separate compositor's current frame from a group's current frame

### DIFF
--- a/lisp/group.lisp
+++ b/lisp/group.lisp
@@ -44,26 +44,40 @@
     (hrt:view-set-hidden popped nil)
     popped))
 
-(defun group-suspend (group seat)
+(defun group-unfocus (group seat)
+  "Unfocus the group, but don't stop displaying it"
   (declare (type mahogany-group group))
-  (with-accessors ((focused-frame mahogany-group-current-frame)
-                   (hrt-group mahogany-group-hrt-group))
+  (with-accessors ((focused-frame mahogany-group-current-frame))
+      group
+    (when focused-frame
+      (tree:unmark-frame-focused focused-frame seat))))
+
+(defun group-focus (group seat)
+  "Focus the group, but don't stop displaying it"
+  (declare (type mahogany-group group))
+  (with-accessors ((focused-frame mahogany-group-current-frame))
+      group
+    (when focused-frame
+      (tree:mark-frame-focused focused-frame seat))))
+
+(defun group-suspend (group seat)
+  "Stop displaying the group"
+  (declare (type mahogany-group group))
+  (with-accessors ((hrt-group mahogany-group-hrt-group))
       group
     (log-string :debug "Suspending group ~A" (mahogany-group-name group))
+    (group-unfocus group seat)
     (setf (mahogany-group-active-p group) nil)
-    (when focused-frame
-      (tree:unmark-frame-focused focused-frame seat))
     (hrt:hrt-scene-group-set-enabled hrt-group nil)))
 
 (defun group-wakeup (group seat)
+  "Start displaying the group"
   (declare (type mahogany-group group))
-  (with-accessors ((focused-frame mahogany-group-current-frame)
-                   (hrt-group mahogany-group-hrt-group))
+  (with-accessors ((hrt-group mahogany-group-hrt-group))
       group
     (log-string :debug "Waking up group ~A" (mahogany-group-name group))
+    (group-focus group seat)
     (setf (mahogany-group-active-p group) nil)
-    (when focused-frame
-      (tree:mark-frame-focused focused-frame seat))
     (hrt:hrt-scene-group-set-enabled hrt-group t)))
 
 (defun group-transfer-views (group to-transfer)
@@ -92,7 +106,7 @@
     (tree:unmark-frame-focused frame seat)
     (setf current-frame nil)))
 
-(defun group-add-output (group output seat)
+(defun group-add-output (group output)
   (declare (type hrt:output output)
            (type mahogany-group group))
   (with-accessors ((output-map mahogany-group-output-map)
@@ -104,10 +118,11 @@
       (setf (gethash (hrt:output-full-name output) output-map) new-tree)
       (when (not current-frame)
         (let ((first-leaf (tree:find-first-leaf new-tree)))
-          (group-focus-frame group first-leaf seat)
+          (setf current-frame first-leaf)
           (alexandria:when-let ((spare (%pop-hidden-item hidden-views)))
-            (setf (tree:frame-view first-leaf) spare)))))
-    (log-string :trace "Group map: ~S" output-map)))
+            (setf (tree:frame-view first-leaf) spare))))
+      (log-string :trace "Group map: ~S" output-map)
+      new-tree)))
 
 (defun group-rearrange-output (group output)
   (declare (type mahogany-group group)
@@ -148,7 +163,8 @@ to match."
   (declare (type hrt:output output)
            (type mahogany-group group))
   (with-accessors ((output-map mahogany-group-output-map)
-                   (hidden-views mahogany-group-hidden-views))
+                   (hidden-views mahogany-group-hidden-views)
+                   (cur-frame mahogany-group-current-frame))
       group
     (let* ((output-name (hrt:output-full-name output))
            (tree (gethash output-name output-map)))
@@ -156,11 +172,9 @@ to match."
       (when (equalp output (group-current-output group))
         (group-unfocus-frame group (mahogany-group-current-frame group) seat)
         (alexandria:when-let ((other-tree (%first-hash-table-value output-map)))
-          (group-focus-frame group (tree:find-first-leaf other-tree) seat)))
-      (when (and (mahogany-group-current-frame group) (= 0 (hash-table-count output-map)))
-        (group-unfocus-frame group (mahogany-group-current-frame group) seat))
+          (setf cur-frame (tree:find-first-leaf other-tree))))
       (tree:remove-frame tree (lambda (x) (alexandria:when-let ((v (tree:frame-view x)))
-				            (%add-hidden hidden-views v)))))))
+				                            (%add-hidden hidden-views v)))))))
 
 (defun group-add-initialize-view (group view-ptr)
   (declare (type mahogany-group group)
@@ -233,8 +247,7 @@ to match."
                   (when (and to-replace
                              (not (tree:frame-view to-focus)))
                     (setf (tree:frame-view to-focus) (%pop-hidden-item hidden)))
-                  (setf (mahogany-group-current-frame group) to-focus)
-                  (tree:mark-frame-focused to-focus (server-seat *compositor-state*)))))))
+                  (setf (mahogany-group-current-frame group) to-focus))))))
           (tree:view-frame
            (setf (tree:frame-view f) nil)
            (when (> (ring-list:ring-list-size hidden) 0)
@@ -329,7 +342,6 @@ currently focused frame"
       ;; view:
       (when (eq (%group-current-output-node group)
                 output-node)
-        (tree:mark-frame-focused output-node (server-seat *compositor-state*))
         (setf (mahogany-group-current-frame group) output-node)))
     ;; Frame isn't visible; allow the view to be fullscreened and we will deal with it
     ;; when it becomes visible:
@@ -392,7 +404,6 @@ After this function is ran, the current frame needs to be set and focused."
             (prev-fullscreen (tree:set-fullscreen cur-output view)))
        (unless prev-fullscreen
          (%hide-views-under-fullscreen group cur-output #'ring-list:add-item))
-       (tree:mark-frame-focused cur-output (server-seat *compositor-state*))
        (setf (mahogany-group-current-frame group) cur-output)))
     (t
      (let ((hidden-data (gethash view (mahogany-group-hidden-view-map group))))
@@ -406,8 +417,7 @@ After this function is ran, the current frame needs to be set and focused."
              (log-string :trace "Hidden view is visible under fullscreen view")
              ;; The view should be visible, focus its frame:
              (let ((to-focus (%hidden-view-info-frame hidden-data)))
-               (setf (mahogany-group-current-frame group) to-focus)
-               (tree:mark-frame-focused to-focus (server-seat *compositor-state*))))
+               (setf (mahogany-group-current-frame group) to-focus)))
             (t
              (let ((to-focus (tree:find-focused-frame current-frame)))
                (setf (mahogany-group-current-frame group) to-focus)
@@ -443,18 +453,6 @@ After this function is ran, the current frame needs to be set and focused."
         (setf next-view (%swap-prev-hidden hidden-views view))
         (setf next-view (%pop-hidden-item hidden-views)))
       (%swap-view-into-frame group current-frame next-view))))
-
-(defun group-next-frame (group seat)
-  (declare (type mahogany-group group))
-  (let* ((current-frame (mahogany-group-current-frame group))
-         (next-frame (tree:frame-next current-frame)))
-    (group-focus-frame group next-frame seat)))
-
-(defun group-prev-frame (group seat)
-  (declare (type mahogany-group group))
-  (let* ((current-frame (mahogany-group-current-frame group))
-         (prev-frame (tree:frame-prev current-frame)))
-    (group-focus-frame group prev-frame seat)))
 
 (defun group-maximize-view (group view)
   (declare (type mahogany-group group)

--- a/lisp/key-bindings.lisp
+++ b/lisp/key-bindings.lisp
@@ -16,14 +16,14 @@
 (defcommand split-frame-h ()
   (:documentation "Split the current frame horizontally")
   (:method ()
-    (let ((frame (mahogany-current-frame *compositor-state*)))
+    (let ((frame (state-current-frame *compositor-state*)))
       (when frame
         (tree:split-frame-h frame :direction :right)))))
 
 (defcommand split-frame-v ()
   (:documentation "Split the current frame horizontally")
   (:method ()
-    (let ((frame (mahogany-current-frame *compositor-state*)))
+    (let ((frame (state-current-frame *compositor-state*)))
       (when frame
         (tree:split-frame-v frame :direction :bottom)))))
 
@@ -34,35 +34,33 @@
 
 (defcommand close-current-view ()
   (:method ()
-    (let ((frame (mahogany-current-frame *compositor-state*)))
+    (let ((frame (state-current-frame *compositor-state*)))
       (alexandria:when-let ((view (mahogany/tree:frame-view frame)))
         (hrt:view-request-close view)))))
 
 (defcommand next-view ()
   (:documentation "Raise the next hidden view in the current group")
   (:method ()
-    (let ((group (state-current-group *compositor-state*)))
-      (group-next-hidden group))))
+    (state-next-hidden-frame *compositor-state*)))
 
 (defcommand previous-view ()
   (:documentation "Raise the next hidden view in the current group")
   (:method ()
-    (let ((group (state-current-group *compositor-state*)))
-      (group-previous-hidden group))))
+    (state-next-hidden-frame *compositor-state*)))
 
 (defcommand next-frame (seat)
   (:documentation
    "Set the current frame to the next one in the frame graph")
   (:method (seat)
-    (let ((group (state-current-group *compositor-state*)))
-      (group-next-frame group seat))))
+    (let ((cur-frame (state-current-frame *compositor-state*)))
+      (state-focus-frame *compositor-state* (tree:frame-next cur-frame) seat))))
 
 (defcommand prev-frame (seat)
   (:documentation
    "Set the current frame to the previous one in the frame graph")
   (:method (seat)
-    (let ((group (state-current-group *compositor-state*)))
-      (group-prev-frame group seat))))
+    (let ((cur-frame (state-current-frame *compositor-state*)))
+      (state-focus-frame *compositor-state* (tree:frame-prev cur-frame) seat))))
 
 (defcommand gnew ()
   (:method ()

--- a/lisp/objects.lisp
+++ b/lisp/objects.lisp
@@ -19,6 +19,7 @@
   (server nil :type (or null cffi:foreign-pointer))
   (key-state (make-key-state nil):type key-state)
   (%current-group nil :type (or null mahogany-group))
+  (%current-frame nil)
   (%keybindings nil :type list)
   (active-kmap-modes nil :type list)
   (%prefix-key (kbd "C-t") :type key)
@@ -40,6 +41,11 @@
 (defun state-current-group (state)
   (declare (type mahogany-state state))
   (state-%current-group state))
+
+(declaim (inline state-current-frame))
+(defun state-current-frame (state)
+  (declare (type mahogany-state state))
+  (state-%current-frame state))
 
 (declaim (inline state-keybindings))
 (defun state-keybindings (state)

--- a/lisp/state.lisp
+++ b/lisp/state.lisp
@@ -51,6 +51,8 @@
   (hrt:hrt-server-stop (state-server state)))
 
 (defun (setf state-current-group) (group state)
+  (declare (type mahogany-state state)
+           (type mahogany-group group))
   (with-accessors ((hidden-groups state-hidden-groups)
                    (server state-server))
       state
@@ -60,7 +62,18 @@
       (group-suspend (state-current-group state) (hrt:hrt-server-seat server)))
     (setf (state-%current-group state) group)
     (group-wakeup group (hrt:hrt-server-seat server))
+    (alexandria:when-let ((group-frame (mahogany-group-current-frame group)))
+      (state-focus-frame state group-frame (server-seat state)))
     (hrt:dirty-view-transaction)))
+
+(defun state-focus-frame (state new-frame seat)
+  "Focus the given frame. The frame must either be a member of
+the current group or a layer shell frame"
+  (with-accessors ((cur-frame state-%current-frame)
+                   (cur-group state-current-group))
+      state
+    (group-focus-frame cur-group new-frame seat)
+    (setf cur-frame new-frame)))
 
 (defun server-keystate-reset (state)
   (setf (state-key-state state)
@@ -90,7 +103,11 @@
                              nil)))
       (vector-push-extend mh-output outputs)
       (loop for g across groups
-            do (group-add-output g mh-output (server-seat state))))))
+            do (group-add-output g mh-output))
+      (unless (state-%current-frame state)
+        (let ((cur-group (state-current-group state)))
+          (group-focus cur-group (server-seat state))
+        (setf (state-%current-frame state) (mahogany-group-current-frame cur-group)))))))
 
 (declaim (inline %find-output))
 (defun %find-output (hrt-output state)
@@ -101,7 +118,8 @@
 
 (defun mahogany-state-output-remove (state hrt-output)
   (with-accessors ((outputs state-outputs)
-                   (groups state-groups))
+                   (groups state-groups)
+                   (cur-frame state-%current-frame))
       state
     (let ((mh-output (%find-output hrt-output state)))
       (log-string :debug "Output removed ~S" (hrt:output-full-name mh-output))
@@ -109,7 +127,11 @@
             do (group-remove-output g mh-output (server-seat state)))
       ;; TODO: Is there a better way to remove an item from a vector when we could know the index?
       (setf outputs (delete mh-output outputs :test #'equalp))
-      (hrt:destroy-output mh-output))))
+      (hrt:destroy-output mh-output))
+    (setf cur-frame (mahogany-group-current-frame
+                     (state-current-group state)))
+    (when (and cur-frame (> (length outputs) 0))
+      (tree:mark-frame-focused cur-frame (server-seat state)))))
 
 (defun mahogany-state-group-add (state &key group-name (make-current t))
   (let ((index (+ 1 (length (state-groups state)))))
@@ -121,7 +143,7 @@
                        (state-outputs state-outputs))
           state
         (loop for o across state-outputs
-              do (group-add-output new-group o (server-seat state)))
+              do (group-add-output new-group o))
         (cond
           (make-current
            (ring-list:add-item hidden-groups current-group)
@@ -202,6 +224,13 @@
         (remhash (cffi:pointer-address view-ptr) views))
       (log-string :error "Could not find mahogany view associated with pointer ~S" view-ptr))))
 
+(defun %cur-frame-set-from-group (state group)
+  (declare (type mahogany-state state)
+           (type mahogany-group group))
+  (let ((cur-frame (mahogany-group-current-frame group)))
+    (setf (state-%current-frame state) cur-frame)
+    (tree:mark-frame-focused cur-frame (server-seat state))))
+
 (defun mahogany-state-view-fullscreen (state view output set-fullscreen)
   (declare (type mahogany-state state)
 	       (type hrt:view view))
@@ -209,19 +238,24 @@
     (log-string :debug
                 "~@<Fullscreen requested (~:[no~;yes~]):~I ~:_view ~S ~:_on output ~S~:>"
                 set-fullscreen view output)
-	(group-set-fullscreen group view output set-fullscreen)))
+	(group-set-fullscreen group view output set-fullscreen)
+    (%cur-frame-set-from-group state group)))
 
 (defun mahogany-state-view-map (state view)
   (declare (type mahogany-state state)
            (type hrt:view view))
   (%with-found-group state (group view)
-    (group-map-view group view)))
+    (group-map-view group view)
+    ;; Mapping the view can cause focus to change:
+    (%cur-frame-set-from-group state group)))
 
 (defun mahogany-state-view-unmap (state view)
   (declare (type mahogany-state state)
            (type hrt:view view))
   (%with-found-group state (group view)
-    (group-unmap-view group view)))
+    (group-unmap-view group view)
+    ;; Unmapping the view can cause focus to change:
+    (%cur-frame-set-from-group state group)))
 
 (defun mahogany-state-view-size-changed (state view)
   (declare (type mahogany-state state)
@@ -249,6 +283,16 @@
         (group-minimize-view group view)
         (hrt:view-configure view))))
 
+(defun state-next-hidden-frame (state)
+  (let ((group (state-current-group *compositor-state*)))
+    (group-next-hidden group)
+    (%cur-frame-set-from-group state group)))
+
+(defun state-prev-hidden-frame (state)
+  (let ((group (state-current-group *compositor-state*)))
+    (group-previous-hidden group)
+    (%cur-frame-set-from-group state group)))
+
 (defun state-next-hidden-group (state)
   (declare (type mahogany-state state))
   (let ((current-group (state-current-group state))
@@ -263,9 +307,6 @@
         (hidden-groups (state-hidden-groups state)))
     (when (> (ring-list:ring-list-size hidden-groups) 0)
       (setf (state-current-group state) (ring-list:swap-previous hidden-groups current-group)))))
-
-(defun mahogany-current-frame (state)
-  (mahogany-group-current-frame (state-current-group state)))
 
 (defun mahogany-set-keymap (state &key (rules (cffi:null-pointer)) (keymap-flags :no-flags))
   "Set the xkb keymap using the provided rules and flags. Signals a


### PR DESCRIPTION
Since layer shell frames won't be part of any group, there needs to be a separate current frame for the state, which represents the frame that is actually focused.

Breaking: any code that uses the group focus functions will need to use the state focus functions instead.

See #85.