### PR TITLE
Add layer shell frames to the frame tree

### DIFF
--- a/lisp/group.lisp
+++ b/lisp/group.lisp
@@ -95,26 +95,26 @@
 
 (defun group-focus-frame (group frame seat)
   (with-accessors ((current-frame mahogany-group-current-frame)) group
-    (unless (eql current-frame frame)
-      (when current-frame
-        (group-unfocus-frame group current-frame seat))
-      (tree:mark-frame-focused frame seat)
-      (setf current-frame frame))))
+    (when current-frame
+      (group-unfocus-frame group current-frame seat))
+    (tree:mark-frame-focused frame seat)
+    (setf current-frame frame)))
 
 (defun group-unfocus-frame (group frame seat)
   (with-accessors ((current-frame mahogany-group-current-frame)) group
     (tree:unmark-frame-focused frame seat)
     (setf current-frame nil)))
 
-(defun group-add-output (group output)
-  (declare (type hrt:output output)
+(defun group-add-output (group output-container
+                               &aux (output (tree::output-container-output output-container)))
+  (declare (type tree:output-container output-container)
            (type mahogany-group group))
   (with-accessors ((output-map mahogany-group-output-map)
                    (tiled-container mahogany-group-tiled-container)
                    (current-frame mahogany-group-current-frame)
                    (hidden-views mahogany-group-hidden-views))
       group
-    (let ((new-tree (tree:tree-output-add tiled-container output)))
+    (let ((new-tree (tree:tree-output-add tiled-container output-container)))
       (setf (gethash (hrt:output-full-name output) output-map) new-tree)
       (when (not current-frame)
         (let ((first-leaf (tree:find-first-leaf new-tree)))
@@ -138,9 +138,8 @@
 to match."
   (log-string :debug "Reconfiguring group ~S outputs"
               (mahogany-group-name group))
-  (with-accessors ((output-map mahogany-group-output-map)) group
-    (loop for output across outputs
-          do (group-rearrange-output group output))))
+  (loop for output across outputs
+        do (group-rearrange-output group (tree:output-container-output output))))
 
 (defun %first-hash-table-value (table)
   (declare (type hash-table table)
@@ -155,12 +154,15 @@ to match."
          (output-node (tree:find-root-frame cur-frame)))
     output-node))
 
+(declaim (ftype (function (mahogany-group) (or null hrt:output)) group-current-output))
 (defun group-current-output (group)
   "Return the output that contains the group's currently focused frame"
-  (tree:output-node-output (%group-current-output-node group)))
+  (alexandria:when-let ((cur-output-node (%group-current-output-node group)))
+    (tree:output-container-output (tree:output-node-output cur-output-node))))
 
-(defun group-remove-output (group output seat)
-  (declare (type hrt:output output)
+(defun group-remove-output (group output-container seat
+                            &aux (output (tree::output-container-output output-container)))
+  (declare (type tree:output-container output-container)
            (type mahogany-group group))
   (with-accessors ((output-map mahogany-group-output-map)
                    (hidden-views mahogany-group-hidden-views)
@@ -169,7 +171,7 @@ to match."
     (let* ((output-name (hrt:output-full-name output))
            (tree (gethash output-name output-map)))
       (remhash output-name output-map)
-      (when (equalp output (group-current-output group))
+      (when (equalp output-container (group-current-output group))
         (group-unfocus-frame group (mahogany-group-current-frame group) seat)
         (alexandria:when-let ((other-tree (%first-hash-table-value output-map)))
           (setf cur-frame (tree:find-first-leaf other-tree))))

--- a/lisp/heart/layer-shell.lisp
+++ b/lisp/heart/layer-shell.lisp
@@ -33,6 +33,14 @@
    (layer-surface-hrt-layer-surface layer-surface)))
 
 #-HRT-DEBUG
+(declaim (inline layer-shell-surface-place))
+(defun layer-shell-surface-place (hrt-layer-shell output)
+  (declare (type cffi:foreign-pointer hrt-layer-shell)
+           (type output output))
+  (hrt-layer-shell-surface-place hrt-layer-shell
+                                 (hrt:output-hrt-output output)))
+
+#-HRT-DEBUG
 (declaim (inline layer-surface-focus))
 (defun layer-surface-focus (layer-surface seat)
   (declare (type layer-surface layer-shell))

--- a/lisp/heart/output.lisp
+++ b/lisp/heart/output.lisp
@@ -122,3 +122,41 @@
 (defun output-serial (output)
   (declare (type output output))
   (hrt-output-serial (output-hrt-output output)))
+
+(declaim (inline output-scene))
+(defun output-scene (output)
+  (declare (type output output))
+  (cffi:foreign-slot-value (output-hrt-output output)
+                           '(:struct hrt-output)
+                           'scene))
+
+(defun output-scene-layer (output-scene layer)
+  (declare (type cffi:foreign-pointer output-scene))
+  (ecase layer
+    (:layer-background
+     (cffi:foreign-slot-value output-scene '(:struct hrt-scene-output)
+                              'background))
+    (:layer-bottom
+     (cffi:foreign-slot-value output-scene '(:struct hrt-scene-output)
+                               'bottom))
+    (:layer-top
+     (cffi:foreign-slot-value output-scene '(:struct hrt-scene-output)
+                               'top))
+    (:layer-overlay
+     (cffi:foreign-slot-value output-scene '(:struct hrt-scene-output)
+                               'overlay))))
+
+(define-compiler-macro output-scene-layer (&whole whole output-scene layer)
+  (if (constantp layer)
+      (let ((slot-name (ecase layer
+                         (:layer-background
+                          'background)
+                         (:layer-bottom
+                          'bottom)
+                         (:layer-top
+                          'top)
+                         (:layer-overlay
+                          'overlay))))
+        `(cffi:foreign-slot-value ,output-scene '(:struct hrt-scene-output)
+                                  (quote ,slot-name)))
+      whole))

--- a/lisp/heart/package.lisp
+++ b/lisp/heart/package.lisp
@@ -153,6 +153,7 @@
            ;; layer shell methods
            #:layer-surface-output
            #:hrt-layer-surface-output
+           #:layer-surface
            #:layer-surface-keyboard-interactivity
            #:layer-surface-position
            #:layer-surface-dimensions
@@ -160,5 +161,5 @@
            #:keyboard-interactivity-updated
            #:hrt-layer-shell-surface-set-output
            #:hrt-layer-shell-surface-abort
-           #:hrt-layer-shell-surface-place
+           #:layer-shell-surface-place
            #:hrt-layer-shell-finish-init))

--- a/lisp/heart/package.lisp
+++ b/lisp/heart/package.lisp
@@ -83,6 +83,8 @@
            #:output-removed
            #:output-layout-changed
            ;; output methods:
+           #:output-scene
+           #:output-scene-layer
            #:output-resolution
            #:output-position
            #:output-usable-area

--- a/lisp/objects.lisp
+++ b/lisp/objects.lisp
@@ -8,7 +8,8 @@
   (hrt-group (cffi:null-pointer) :type cffi:foreign-pointer :read-only t)
   (tiled-container nil :type tree:layer-container :read-only t)
   (output-map (make-hash-table :test 'equal) :type hash-table :read-only t)
-  (current-frame nil :type (or tree:frame tree:output-node null))
+  (current-frame nil ;; :type (or tree:frame tree:output-node null)
+   )
   (hidden-views (ring-list:make-ring-list) :type ring-list:ring-list)
   ;; Map that contains views hidden by fullscreen windows.
   ;; view -> %hidden-view-info
@@ -23,9 +24,11 @@
   (%keybindings nil :type list)
   (active-kmap-modes nil :type list)
   (%prefix-key (kbd "C-t") :type key)
-  (outputs (make-array 0 :element-type 'hrt:output :adjustable t :fill-pointer t)
-   :type (vector hrt:output *))
-  (groups (make-array 0 :element-type 'mahogany-group :adjustable t :fill-pointer t)
+  (outputs (make-array 0 :element-type 'tree::output-container
+                         :adjustable t :fill-pointer t)
+   :type (vector tree::output-container *))
+  (groups (make-array 0 :element-type 'mahogany-group
+                        :adjustable t :fill-pointer t)
    :type (vector mahogany-group *))
   (hidden-groups (ring-list:make-ring-list)
    :type ring-list:ring-list

--- a/lisp/state.lisp
+++ b/lisp/state.lisp
@@ -37,6 +37,9 @@
   (with-accessors ((groups state-groups)
                    (server state-server))
       state
+    ;; Clear the current frame so that subsequent cleanup code
+    ;; doesn't try to switch focus to an invalid frame:
+    (setf (state-%current-frame state) nil)
     (let ((scene-tree (hrt:hrt-server-scene-tree server))
           (seat (hrt:hrt-server-seat server)))
       (loop for g across groups
@@ -66,14 +69,31 @@
       (state-focus-frame state group-frame (server-seat state)))
     (hrt:dirty-view-transaction)))
 
+(defun group-frame-p (frame)
+  ;; TODO: It might be better to start storing the
+  ;; group that a frame is in, so we can use that
+  ;; instead of just relying on the type. It would
+  ;; also make it possible to pass arbitrary frames
+  ;; to state-focus-frame
+  (not (typep frame 'tree::layer-shell-frame)))
+
 (defun state-focus-frame (state new-frame seat)
   "Focus the given frame. The frame must either be a member of
 the current group or a layer shell frame"
   (with-accessors ((cur-frame state-%current-frame)
                    (cur-group state-current-group))
       state
-    (group-focus-frame cur-group new-frame seat)
-    (setf cur-frame new-frame)))
+    (unless (eql cur-frame new-frame)
+      ;; Determine if the frame is in a group:
+      (let ((cur-in-group (group-frame-p cur-frame))
+            (next-in-group (group-frame-p new-frame)))
+        (if next-in-group
+            (group-focus-frame cur-group new-frame seat)
+            (progn
+              (when cur-in-group
+                (group-unfocus cur-group seat))
+              (tree:mark-frame-focused new-frame seat))))
+      (setf cur-frame new-frame))))
 
 (defun server-keystate-reset (state)
   (setf (state-key-state state)
@@ -93,7 +113,8 @@ the current group or a layer shell frame"
                    (groups state-groups)
                    (scene mahogany-state-scene))
       state
-    (let ((mh-output (hrt:make-output hrt-output)))
+    (let* ((mh-output (hrt:make-output hrt-output))
+           (output-container (tree::make-output-container mh-output)))
       (log-string :debug "New output added ~S" (hrt:output-full-name mh-output))
       ;; (mahogany/output-config::
       (hrt:output-init mh-output
@@ -101,9 +122,9 @@ the current group or a layer shell frame"
                          (if output-match-data
                              (mahogany/output-config::output-match-data-config output-match-data)
                              nil)))
-      (vector-push-extend mh-output outputs)
+      (vector-push-extend output-container outputs)
       (loop for g across groups
-            do (group-add-output g mh-output))
+            do (group-add-output g output-container))
       (unless (state-%current-frame state)
         (let ((cur-group (state-current-group state)))
           (group-focus cur-group (server-seat state))
@@ -113,7 +134,7 @@ the current group or a layer shell frame"
 (defun %find-output (hrt-output state)
   (declare (type mahogany-state state))
   (find hrt-output (state-outputs state)
-        :key #'hrt:output-hrt-output
+        :key #'tree::output-container-output-ptr
         :test #'cffi:pointer-eq))
 
 (defun mahogany-state-output-remove (state hrt-output)
@@ -121,12 +142,13 @@ the current group or a layer shell frame"
                    (groups state-groups)
                    (cur-frame state-%current-frame))
       state
-    (let ((mh-output (%find-output hrt-output state)))
+    (let* ((output-container (%find-output hrt-output state))
+          (mh-output (tree::output-container-output output-container)))
       (log-string :debug "Output removed ~S" (hrt:output-full-name mh-output))
       (loop for g across groups
-            do (group-remove-output g mh-output (server-seat state)))
+            do (group-remove-output g output-container (server-seat state)))
       ;; TODO: Is there a better way to remove an item from a vector when we could know the index?
-      (setf outputs (delete mh-output outputs :test #'equalp))
+      (setf outputs (delete output-container outputs :test #'equalp))
       (hrt:destroy-output mh-output))
     (setf cur-frame (mahogany-group-current-frame
                      (state-current-group state)))
@@ -187,12 +209,13 @@ the current group or a layer shell frame"
 
 (defun mahogany-state-layers-arrange (state output)
   (declare (type mahogany-state state))
-  (log-string :debug "layer shell layers re-arranged on output ~S"
-              (hrt:output-full-name output))
-  (hrt:with-view-transaction ()
-    (with-accessors ((groups state-groups)) state
-      (loop for g across groups
-            do (group-rearrange-output g output)))))
+  (let ((hrt-output (tree:output-container-output output)))
+    (log-string :debug "layer shell layers re-arranged on output ~S"
+              (hrt:output-full-name hrt-output))
+    (hrt:with-view-transaction ()
+      (with-accessors ((groups state-groups)) state
+        (loop for g across groups
+              do (group-rearrange-output g hrt-output))))))
 
 (defun mahogany-state-view-add (state view-ptr)
   (declare (type mahogany-state state)
@@ -319,10 +342,11 @@ KEYMAP-CREATION-ERROR if the rules are invalid or malformed."
       ;; Either that, or just turn this into a warning or return a boolean?
       (error 'xkb:keymap-creation-error))))
 
+(declaim (ftype (function (mahogany-state cffi:foreign-pointer) hrt:output)))
 (defun %get-or-autoassign-output (state hrt-layer-shell)
   (declare (type mahogany-state state))
   (alexandria:if-let ((hrt-output (hrt:hrt-layer-surface-output hrt-layer-shell)))
-    (the (or hrt:output null) (%find-output hrt-output state))
+    (tree:output-container-output (%find-output hrt-output state))
     (let ((current-output (group-current-output (state-current-group state))))
       ;; TODO: try to use the fallback output:
       (unless current-output
@@ -330,13 +354,14 @@ KEYMAP-CREATION-ERROR if the rules are invalid or malformed."
 	    (return-from %get-or-autoassign-output nil))
       (hrt:hrt-layer-shell-surface-set-output hrt-layer-shell
                                               (hrt:output-hrt-output current-output))
-      (the hrt:output current-output))))
+      current-output)))
 
 (defun mahogany-state-layer-shell-handle (state hrt-layer-shell)
   (declare (type mahogany-state state))
   (alexandria:if-let ((output (%get-or-autoassign-output state hrt-layer-shell)))
     (progn
-      (hrt:hrt-layer-shell-surface-place hrt-layer-shell (hrt:output-hrt-output output))
+      (hrt:layer-shell-surface-place hrt-layer-shell
+                                     output)
       (hrt:hrt-layer-shell-finish-init hrt-layer-shell))
     (hrt:hrt-layer-shell-surface-abort hrt-layer-shell)))
 
@@ -344,16 +369,39 @@ KEYMAP-CREATION-ERROR if the rules are invalid or malformed."
   (declare (type mahogany-state state))
   (let* ((surfaces (state-layer-surfaces state))
          (new-surface (hrt:make-layer-surface hrt-layer-surface))
-         (output (%find-output (hrt:layer-surface-output new-surface) state)))
-    (setf (gethash hrt-layer-surface surfaces) new-surface)
+         (output-container (%find-output (hrt:layer-surface-output new-surface)
+                                         state))
+         (interactivity (hrt:layer-surface-keyboard-interactivity new-surface)))
+    (setf (gethash (cffi:pointer-address hrt-layer-surface) surfaces) new-surface)
     (log-string
      :info
      "New Layer surface on output ~S~%, layer ~S with keyboard ~S keyboard"
-     output
+     (tree::output-container-output output-container)
      (hrt::layer-surface-layer new-surface)
-     (hrt:layer-surface-keyboard-interactivity new-surface))))
+     interactivity)
+    ;; If the surface can't be focused, don't do anything to place it.
+    ;; Otherwise, add it to the tree data structure so we can navigate
+    ;; to it by keyboard. The only difference between exclusive and
+    ;; "on demand" surfaces is that we focus exclusive surfaces when
+    ;; they appear.
+    ;; We need to do something different
+    ;; in the future for bottom or background surfaces.
+    (unless (eq :layer-shell-keyboard-none interactivity)
+      (let ((add-node (tree::output-container-add-layer-shell output-container new-surface)))
+        (when (eq :layer-shell-keyboard-exclusive interactivity)
+          (state-focus-frame state add-node (server-seat state)))))))
 
 (defun state-layer-surface-remove (state hrt-layer-surface)
   (declare (type mahogany-state state))
-  (let ((surfaces (state-layer-surfaces state)))
-    (remhash hrt-layer-surface surfaces)))
+  (let* ((surfaces (state-layer-surfaces state))
+         (surface-ptr (cffi:pointer-address hrt-layer-surface))
+         (surface (gethash surface-ptr surfaces))
+         (output-container (%find-output (hrt:layer-surface-output surface)
+                                         state))
+         (removed-frame (tree::output-container-remove-layer-shell
+                         output-container surface)))
+    (when (eq (state-current-frame state) removed-frame)
+      (state-focus-frame state (mahogany-group-current-frame
+                                (state-current-group state))
+                         (server-seat state)))
+    (remhash surface-ptr surfaces)))

--- a/lisp/tree/layer-shell.lisp
+++ b/lisp/tree/layer-shell.lisp
@@ -1,0 +1,53 @@
+(in-package #:mahogany/tree)
+
+(defclass layer-shell-frame ()
+  ((layer-shell :initarg :layer-shell
+                :type hrt:layer-surface)
+   (parent :initarg :parent
+           :initform nil
+           :type (or null tree-parent)
+           :accessor frame-parent)
+   (next :initform nil
+         :type (or tree-node null)
+         :reader frame-next)
+   (prev :initform nil
+         :type (or tree-node null)
+         :reader frame-prev)
+   (focused :initarg :focused
+            :reader frame-focused
+            :initform nil
+            :type boolean))
+  (:documentation "Frame tree node that contains a layer shell surface"))
+
+(defmethod in-frame-p ((frame layer-shell-frame) x y)
+  (let ((shell (slot-value frame 'layer-shell)))
+    (multiple-value-bind (frame-x frame-y)
+        (hrt:layer-surface-position shell)
+      (multiple-value-bind (frame-width frame-height)
+          (hrt:layer-surface-dimensions shell)
+        (and (<= frame-x x)
+             (<  x (+ frame-x frame-width))
+             (<= frame-y y)
+             (<  y (+ frame-y frame-height)))))))
+
+(defmethod frame-position ((frame layer-shell-frame))
+  (let ((shell (layer-shell-frame-shell frame)))
+    (hrt:layer-surface-position shell)))
+
+(defmethod (setf %frame-prev) (prev (frame layer-shell-frame))
+  (setf (slot-value frame 'prev) prev))
+
+(defmethod (setf %frame-next) (next (frame layer-shell-frame))
+  (setf (slot-value frame 'next) next))
+
+(defmethod mark-frame-focused ((frame layer-shell-frame) seat)
+  (setf (slot-value frame 'focused) t))
+
+(defmethod mark-frame-focused :after ((frame layer-shell-frame) seat)
+  (hrt::layer-surface-focus (slot-value frame 'layer-shell) seat))
+
+(defmethod mark-frame-unfocused :after ((frame layer-shell-frame) seat)
+  (hrt::layer-surface-unfocus (slot-value frame 'layer-shell) seat))
+
+(defmethod frame-position ((frame layer-shell-frame))
+  (hrt::layer-surface-position (slot-value frame 'layer-shell)))

--- a/lisp/tree/output-container.lisp
+++ b/lisp/tree/output-container.lisp
@@ -1,0 +1,147 @@
+(in-package #:mahogany/tree)
+
+(defclass output-container ()
+  ((hrt-output :initarg :output
+               :reader output-container-output
+               :type hrt:output)
+   (background-layer :initarg :background
+                     :type list
+                     :initform nil
+                     :reader output-container-background)
+   (bottom-layer :initarg :bottom
+                 :initform nil
+                 :type list
+                 :reader output-container-bottom)
+   (top-layer :initarg :top
+              :initform nil
+              :type list
+              :reader output-container-top)
+   (overlay-layer :initarg :overlay
+                  :initform nil
+                  :type list
+                  :reader output-container-overlay)))
+
+(defun output-container-add-layer-shell (output-container surface)
+  (declare (type output-container output-container)
+           (type hrt::layer-surface surface))
+  (let ((node (make-instance 'layer-shell-frame
+                             :layer-shell surface))
+        (layer (hrt::layer-surface-layer surface)))
+    (macrolet ((add-to-layer (slot)
+                 `(with-slots (,slot) output-container
+                    (push node ,slot)
+                    (setf ,slot
+                          (sort-by-location ,slot t)))))
+      (case layer
+        (:layer-background
+         (add-to-layer background-layer))
+        (:layer-bottom
+         (add-to-layer bottom-layer))
+        (:layer-top
+         (add-to-layer top-layer))
+        (:layer-overlay
+         (add-to-layer overlay-layer))))
+    node))
+
+(defun output-container-remove-layer-shell (output-container surface)
+  (declare (type output-container output-container)
+           (type hrt::layer-surface surface))
+  (macrolet ((remove-from-layer (slot)
+               `(with-slots (,slot) output-container
+                  (let ((var (find surface ,slot
+                                   :key (lambda (x)
+                                          (slot-value x 'layer-shell)))))
+                    (cond
+                      (var
+                       (setf ,slot (sort-by-location (remove var ,slot) t))
+                       var)
+                      (t
+                       (log-string
+                        :error
+                        "Could not find layer shell an any layers: ~S"
+                        surface)
+                       nil))))))
+    (case (hrt::layer-surface-layer surface)
+      (:layer-background
+       (remove-from-layer background-layer))
+      (:layer-bottom
+       (remove-from-layer bottom-layer))
+      (:layer-top
+       (remove-from-layer top-layer))
+      (:layer-overlay
+       (remove-from-layer overlay-layer)))))
+
+(declaim (inline output-container-output-ptr))
+(defun output-container-output-ptr (container)
+  (declare (type output-container container))
+  (hrt:output-hrt-output (output-container-output container)))
+
+(defun make-output-container (output)
+  (declare (type hrt:output output))
+  ;; (let ((output-scene (hrt:output-scene output)))
+  ;; (macrolet ((make-layer (layer)
+  ;;              ;; We use a macro so we can open code the access to the layer:
+  ;;              `(make-instance 'layer-container
+  ;;                              :hrt-layer (hrt:output-scene-layer output-scene
+  ;;                                                                 ,layer))))
+  (make-instance 'output-container
+                 :output output
+                 ;; :background (make-layer :layer-background)
+                 ;; :bottom (make-layer :layer-bottom)
+                 ;; :top (make-layer :layer-top)
+                 ;; :overlay (make-layer :layer-overlay)
+                 ))
+;;))
+
+(defmethod frame-position ((container output-container))
+  (hrt:output-position (output-container-output container)))
+
+(defun output-container-search-top (container x y)
+  (declare (type output-container container))
+  (macrolet ((search-layer (layer)
+               ;; Since the list is sorted, we might be able to
+               ;; do something smarter than look at the whole
+               ;; list, but it should be fairly short:
+               `(dolist (f (slot-value container (quote ,layer)))
+                  (when (in-frame-p f x y)
+                    (return-from output-container-search-top f)))))
+    (search-layer overlay-layer)
+    (search-layer top-layer)))
+
+(defun output-container-search-bottom (container x y)
+  (declare (type output-container container))
+  ;; The lists are sorted, so we can skip some
+  (macrolet ((search-layer (layer)
+               `(dolist (f (slot-value container (quote ,layer)))
+                  (when (in-frame-p f x y)
+                    (return-from output-container-search-bottom f)))))
+    (search-layer bottom-layer)
+    (search-layer background-layer)))
+
+(defun %left-to-right (a b)
+  (multiple-value-bind (a-x a-y)
+      (frame-position a)
+    (multiple-value-bind (b-x b-y)
+        (frame-position b)
+      (if (= a-y b-y)
+          (< a-x b-x)
+          (< a-y b-y)))))
+
+(defun sort-by-location (items &optional modify)
+  "Rearrange the frame-next and frame-prev pointers in ITEMS so that
+the linked list is sorted left-to-right. Returns a sorted sequence
+of the same type as ITEMS."
+  (declare (type sequence items))
+  (let ((seq (if modify items (copy-seq items))))
+    (when (> (length items) 0)
+      (let* ((sorted (sort seq #'%left-to-right))
+             (first (elt sorted 0))
+             (cur first))
+        (loop for elem being the elements of sorted
+              do (setf (%frame-next cur) elem
+                       (%frame-prev elem) cur
+                       cur elem))
+        (setf (%frame-next cur) first
+              (%frame-prev first) cur)
+        seq))
+    seq))

--- a/lisp/tree/output-node.lisp
+++ b/lisp/tree/output-node.lisp
@@ -26,8 +26,9 @@ view, if there was one."
           (%frame-prev next) output-node))
   (log-string :trace "~@<Making output node fullscreen:~I ~:_~S ~:_on layer ~S~:>"
               output-node (layer-container-layer (frame-parent output-node)))
-  (let ((output (output-node-output output-node))
-        (fullscreen (output-node-fullscreen output-node)))
+  (let* ((container (output-node-output output-node))
+         (output (output-container-output container))
+         (fullscreen (output-node-fullscreen output-node)))
     (alexandria:if-let ((fullscreen-data fullscreen))
       ;; There's already a fullscreen item, swap the new one in:
       (let ((fullscreen-node (%fullscreen-data-node fullscreen-data))
@@ -87,7 +88,8 @@ view, if there was one."
 (defmethod in-frame-p ((parent output-node) x y)
   ;; Use the dimensions and position of the output:
   (declare (type real x y))
-  (let ((output (output-node-output parent)))
+  (let* ((container (output-node-output parent))
+         (output (output-container-output container)))
     (multiple-value-bind (frame-width frame-height) (hrt:output-resolution output)
       (multiple-value-bind (frame-x frame-y) (hrt:output-position output)
         (and (<= frame-x x)
@@ -99,9 +101,22 @@ view, if there was one."
   ;; If there is a fullscreen window, return this node:
   (if (output-node-fullscreen parent)
       parent
-      ;; output nodes have exactly 1 child:
-      (let ((f (car (tree-children parent))))
-        (frame-at f x y))))
+      (progn
+        (alexandria:when-let
+            ((layer-frame (output-container-search-top
+                           (output-node-output parent)
+                           x y)))
+          (return-from frame-at layer-frame))
+        ;; output nodes have exactly 1 child:
+        (alexandria:when-let*
+            ((f (car (tree-children parent)))
+             (found (frame-at f x y)))
+          (return-from frame-at found))
+        ;; Note that unless a bottom surface requests an exclusive
+        ;; zone, none of the layers underneath the tiling layer
+        ;; will be accessable.
+        (output-container-search-bottom
+         (output-node-output parent) x y))))
 
 (defmethod find-view-frame ((node output-node) view)
   (alexandria:if-let ((data (output-node-fullscreen node)))

--- a/lisp/tree/package.lisp
+++ b/lisp/tree/package.lisp
@@ -52,6 +52,8 @@
            #:frame-prev
            #:frame-find-layer
            #:find-frame-if
+           #:output-container
+           #:output-container-output
            #:output-node
            #:output-node-output
            #:set-fullscreen

--- a/lisp/tree/tree-interface.lisp
+++ b/lisp/tree/tree-interface.lisp
@@ -114,15 +114,15 @@ should not be directly instantiated; inherit from it instead."))
            :type (or null tree-parent)
            :accessor frame-parent)
    (output :initarg :output
-           :type (not null)
+           :type output-container
            :reader output-node-output)
    (fullscreen :initform nil
                :type (or null %fullscreen-data)
                :accessor output-node-fullscreen)
    (focused :initarg :focused
-         :reader frame-focused
-         :initform nil
-         :type boolean))
+            :reader frame-focused
+            :initform nil
+            :type boolean))
   (:documentation
    "A node in the frame tree that contains the tiled frames tied to
 a specific output."))
@@ -223,6 +223,12 @@ a view assigned to it."))
     (log-string :trace "frame unfocused")
     (setf (slot-value frame 'focused) nil)))
 
+(defgeneric frame-position (frame)
+  (:documentation "Returns the (X, Y) position of the frame as
+multiple values.")
+  (:method ((frame frame))
+    (values (frame-x frame) (frame-y frame))))
+
 ;; helper functions:
 
 (defgeneric root-frame-p (frame)
@@ -251,9 +257,12 @@ a view assigned to it."))
   (do ((cur-frame frame (frame-parent cur-frame)))
     ((typep cur-frame 'layer-container) cur-frame)))
 
-(defun tree-output-add (layer-container output)
+(defun tree-output-add (layer-container output-container
+                        &aux (output (output-container-output
+                                      output-container)))
   "Add a new output node to the layer container. Returns (output-node new-view-frame)."
-  (declare (type layer-container layer-container))
+  (declare (type layer-container layer-container)
+           (type output-container output-container))
   (multiple-value-bind (x y)
       (hrt:output-position output)
     (multiple-value-bind (width height)
@@ -261,7 +270,7 @@ a view assigned to it."))
       (with-accessors ((container-children tree-children)) layer-container
         (let* ((new-output (make-instance 'output-node
                                           :parent layer-container
-                                          :output output))
+                                          :output output-container))
                (new-tree (make-instance 'view-frame :x x :y y
                                                     :width width :height height
                                                     :parent new-output))

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -78,8 +78,13 @@
                 :depends-on ("log" "util" "interfaces" "heart")
                 :components ((:file "package")
                              (:file "tree-interface")
+                             (:file "layer-shell"
+                              :depends-on ("package"))
+                             (:file "output-container"
+                              :depends-on ("tree-interface" "layer-shell"))
                              (:file "tree-parent" :depends-on ("tree-interface"))
-                             (:file "output-node" :depends-on ("tree-interface"))
+                             (:file "output-node"
+                              :depends-on ("tree-interface" "output-container"))
                              (:file "frame" :depends-on ("tree-interface"))
                              (:file "view" :depends-on ("tree-interface"))))
                (:module input-methods

--- a/test/tree-tests.lisp
+++ b/test/tree-tests.lisp
@@ -15,7 +15,9 @@
                      (output)
                      (declare (ignore output))
                      (values width height)))
-    (tree:tree-output-add container (make-mock-output))))
+    (tree:tree-output-add container (make-instance 'tree:output-container
+                                                   :output
+                                                   (make-mock-output)))))
 
 (defun make-tree-for-tests (&key (x 0) (y 0) (width 100) (height 100))
   (let ((container (make-instance 'tree:layer-container


### PR DESCRIPTION
Do this by adding a wrapper around `hrt:output` objects that holds the frames for each output.

This makes focusing somewhat functional; layer shells can be focused by being clicked on or by being created with the layer shell exclusive role; this does not add exclusive keyboard focus functionality, as these surfaces can lose their focus.

See #85.