### PR TITLE
lisp: Disable foot input method on non-linux platforms

### DIFF
--- a/lisp/command.lisp
+++ b/lisp/command.lisp
@@ -1,15 +1,15 @@
 (in-package #:mahogany)
 
 (setf cl-interactive:*default-input-method*
-      #+sbcl
+      #+(and sbcl linux)
       (make-instance 'foot-input-method)
-      #-sbcl
+      #-(and sbcl linux)
       (make-instance 'rofi-input-method))
 
 (defparameter *input-methods-available*
   (list
    'rofi-input-method
-   #+sbcl
+   #+(and sbcl linux)
    'foot-input-method))
 
 (defun interactively-read-string (com im arg prompt)

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -88,7 +88,7 @@
                 ;; so that we could have a bunch of input methods
                 ;; but not have them loaded until needed:
                 :components ((:file "rofi-input-method")
-                             #+sbcl
+                             #+(and sbcl linux)
                              (:file "foot-input-method")))
                (:file "package")
                (:file "command" :depends-on ("input-methods" "globals" "message"))


### PR DESCRIPTION
Due to using the /proc filesystem, this input method only works on linux.

With #281 the rofi input method works, so I'm not too concerned about not having an input method on all supported platforms.

See #268.