### PR TITLE
Implement seat grabbing

### DIFF
--- a/heart/example/main.c
+++ b/heart/example/main.c
@@ -102,8 +102,6 @@ static void view_destroy_callback(struct hrt_view *view) {
     puts("View destroy callback called");
 }
 
-static bool showNormalCursor = true;
-
 static const char *gravity_names[] = {
     "top right",
     "top left",
@@ -156,12 +154,7 @@ static bool keyboard_callback(struct hrt_seat *seat,
         char buffer[20];
         xkb_keysym_get_name(info->keysyms[i], buffer, sizeof(buffer));
         printf(" %s", buffer);
-        if (strcmp(buffer, "c") == 0) {
-            puts("Changing Cursor\n");
-            hrt_seat_set_cursor_img(
-                seat, showNormalCursor ? "context-menu" : "left_ptr");
-            showNormalCursor = !showNormalCursor;
-        } else if (strcmp(buffer, "m") == 0 && server.current_output != NULL) {
+        if (strcmp(buffer, "m") == 0 && server.current_output != NULL) {
             show_message();
         } else if (strcmp(buffer, "o") == 0 &&
                    wl_list_length(&server.outputs) > 1) {

--- a/heart/include/hrt/hrt_input.h
+++ b/heart/include/hrt/hrt_input.h
@@ -47,6 +47,7 @@ struct hrt_seat {
     const struct hrt_seat_callbacks *callbacks;
     char *cursor_image;
     size_t cursor_img_buf_len;
+    bool grabbed;
 
     struct {
         struct wl_listener seat;
@@ -89,19 +90,21 @@ struct hrt_input {
 
 /**
  * Send the appropriate cursor event to the view under the
- * cursor.
+ * cursor and ensure the cursor has the correct image
+ * for what it is hovering over.
  **/
 void hrt_seat_reset_view_under(struct hrt_seat *seat);
 
 /**
- * Set the seat's default cursor image to the given cursor name.
- *
- * Does not take ownership of the string.
- *
- * See themes section of man xcursor(3) to find where to find valid cursor
- * names.
- */
-void hrt_seat_set_cursor_img(struct hrt_seat *seat, char *img_name);
+ * Unfocus all clients and prevent input events from being emitted
+ * and set the cursor image to the given image name.
+ **/
+void hrt_seat_grab(struct hrt_seat *seat, char *img_name);
+
+/**
+ * Reactivate input events and return to normal cursor image behavior.
+ **/
+void hrt_seat_ungrab(struct hrt_seat *seat);
 
 void hrt_seat_notify_button(struct hrt_seat *seat,
                             struct wlr_pointer_button_event *event);

--- a/heart/include/hrt/hrt_input.h
+++ b/heart/include/hrt/hrt_input.h
@@ -46,6 +46,7 @@ struct hrt_seat {
 
     const struct hrt_seat_callbacks *callbacks;
     char *cursor_image;
+    size_t cursor_img_buf_len;
 
     struct {
         struct wl_listener seat;

--- a/heart/src/cursor.c
+++ b/heart/src/cursor.c
@@ -1,4 +1,3 @@
-#include "hrt/hrt_view.h"
 #include "wlr/util/log.h"
 #include <wayland-util.h>
 #include <wlr/types/wlr_xcursor_manager.h>
@@ -42,35 +41,40 @@ static void *find_view_at(struct hrt_server *server, double lx, double ly,
 }
 
 void hrt_seat_reset_view_under(struct hrt_seat *seat) {
-    double sx, sy;
-    struct wlr_surface *found_surface = NULL;
-    void *view = find_view_at(seat->server, seat->cursor->x, seat->cursor->y,
-                              &found_surface, &sx, &sy);
-    if (!view) {
-        wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager,
-                               seat->cursor_image);
-    }
-    if (found_surface) {
-        wlr_seat_pointer_notify_enter(seat->seat, found_surface, sx, sy);
-    } else {
-        wlr_seat_pointer_clear_focus(seat->seat);
+    if (!seat->grabbed) {
+        double sx, sy;
+        struct wlr_surface *found_surface = NULL;
+        void *view = find_view_at(seat->server, seat->cursor->x,
+                                  seat->cursor->y, &found_surface, &sx, &sy);
+
+        if (!view) {
+            wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager,
+                                   seat->cursor_image);
+        }
+        if (found_surface) {
+            wlr_seat_pointer_notify_enter(seat->seat, found_surface, sx, sy);
+        } else {
+            wlr_seat_pointer_clear_focus(seat->seat);
+        }
     }
 }
 
 static void handle_cursor_motion(struct hrt_seat *seat, uint32_t time) {
-    double sx, sy;
-    struct wlr_surface *found_surface = NULL;
-    void *view = find_view_at(seat->server, seat->cursor->x, seat->cursor->y,
-                              &found_surface, &sx, &sy);
-    if (!view) {
-        wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager,
-                               seat->cursor_image);
-    }
-    if (found_surface) {
-        wlr_seat_pointer_notify_enter(seat->seat, found_surface, sx, sy);
-        wlr_seat_pointer_notify_motion(seat->seat, time, sx, sy);
-    } else {
-        wlr_seat_pointer_clear_focus(seat->seat);
+    if (!seat->grabbed) {
+        double sx, sy;
+        struct wlr_surface *found_surface = NULL;
+        void *view = find_view_at(seat->server, seat->cursor->x,
+                                  seat->cursor->y, &found_surface, &sx, &sy);
+        if (!view) {
+            wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager,
+                                   seat->cursor_image);
+        }
+        if (found_surface) {
+            wlr_seat_pointer_notify_enter(seat->seat, found_surface, sx, sy);
+            wlr_seat_pointer_notify_motion(seat->seat, time, sx, sy);
+        } else {
+            wlr_seat_pointer_clear_focus(seat->seat);
+        }
     }
 }
 
@@ -92,17 +96,20 @@ static void seat_motion_absolute(struct wl_listener *listener, void *data) {
 
 static void seat_button(struct wl_listener *listener, void *data) {
     struct hrt_seat *seat = wl_container_of(listener, seat, button);
-    struct wlr_pointer_button_event *event = data;
-    /* Notify the client with pointer focus that a button press has occurred */
+    if (!seat->grabbed) {
+        struct wlr_pointer_button_event *event = data;
 
-    seat->callbacks->button_event(seat, event);
+        /* Notify the client with pointer focus that a button press has occurred */
+        seat->callbacks->button_event(seat, event);
+    }
 }
 
 static void seat_axis(struct wl_listener *listener, void *data) {
-    struct hrt_seat *seat             = wl_container_of(listener, seat, axis);
-    struct wlr_pointer_axis_event *ev = data;
-
-    seat->callbacks->wheel_event(seat, ev);
+    struct hrt_seat *seat = wl_container_of(listener, seat, axis);
+    if (!seat->grabbed) {
+        struct wlr_pointer_axis_event *ev = data;
+        seat->callbacks->wheel_event(seat, ev);
+    }
 }
 
 static void seat_frame(struct wl_listener *listener, void *data) {

--- a/heart/src/input.c
+++ b/heart/src/input.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <string.h>
 #include <wayland-server-core.h>
 #include <wayland-util.h>
 #include <wlr/util/log.h>
@@ -204,6 +205,8 @@ static void handle_start_drag(struct wl_listener *listener, void *data) {
 static void handle_seat_destroy(struct wl_listener *listener, void *data) {
     // struct wlr_seat *wlr_seat = data;
     struct hrt_seat *seat = wl_container_of(listener, seat, destroy);
+    seat->cursor_img_buf_len = 0;
+    free(seat->cursor_image);
 
     hrt_keyboard_destroy(seat);
     hrt_cursor_destroy(seat);
@@ -261,7 +264,10 @@ bool hrt_seat_init(struct hrt_seat *seat, struct hrt_server *server,
     seat->destroy.seat.notify = handle_seat_destroy;
     wl_signal_add(&seat->seat->events.destroy, &seat->destroy.seat);
 
-    seat->cursor_image = "left_ptr";
+    const char *const default_cursor = "default";
+    seat->cursor_img_buf_len = strlen(default_cursor) + 1;
+    seat->cursor_image   = calloc(20, sizeof(char));
+    memcpy(seat->cursor_image, default_cursor, seat->cursor_img_buf_len);
 
     return true;
 }

--- a/heart/src/seat.c
+++ b/heart/src/seat.c
@@ -1,34 +1,13 @@
-#include <hrt/hrt_input.h>
-
 #include <stdlib.h>
 #include <string.h>
+
+#include <hrt/hrt_input.h>
+
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_pointer.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/util/log.h>
 #include <xkbcommon/xkbcommon.h>
-
-void hrt_seat_set_cursor_img(struct hrt_seat *seat, char *img_name) {
-    // Ensure that our buffer is big enough,
-    // unless the string is super big
-    const size_t len = strlen(img_name) + 1;
-    if (len > seat->cursor_img_buf_len) {
-        if (len > 100) {
-            wlr_log(WLR_ERROR, "Ignoring hrt_set_cursor_img: cursor name is unreasonable large: %s",
-                   img_name);
-          return;
-        }
-        char *new_ptr = realloc(seat->cursor_image, len);
-        if (!new_ptr) {
-            wlr_log(WLR_ERROR, "Failed to realloc cursor name buffer");
-            return;
-        }
-    }
-    memcpy(seat->cursor_image, img_name, len);
-
-    wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager,
-                           seat->cursor_image);
-}
 
 void hrt_seat_notify_button(struct hrt_seat *seat,
                             struct wlr_pointer_button_event *event) {
@@ -58,22 +37,23 @@ bool hrt_seat_set_keymap(struct hrt_seat *seat, struct xkb_rule_names *rules,
 
 bool hrt_seat_keyboard_focus_surface(struct hrt_seat *seat,
                                      struct wlr_surface *surface) {
-    struct wlr_seat *wlr_seat        = seat->seat;
-    struct wlr_surface *prev_surface = wlr_seat->keyboard_state.focused_surface;
+    struct wlr_seat *wlr_seat = seat->seat;
+    if (!seat->grabbed) {
+        struct wlr_surface *prev_surface =
+            wlr_seat->keyboard_state.focused_surface;
+        if (prev_surface == surface) {
+            // Don't re-focus an already focused surface:
+            return false;
+        }
+        struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(wlr_seat);
 
-    if (prev_surface == surface) {
-        // Don't re-focus an already focused surface:
-        return false;
+        if (keyboard != NULL) {
+            wlr_seat_keyboard_notify_enter(
+                wlr_seat, surface, keyboard->keycodes, keyboard->num_keycodes,
+                &keyboard->modifiers);
+            return true;
+        }
     }
-    struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(wlr_seat);
-
-    if (keyboard != NULL) {
-        wlr_seat_keyboard_notify_enter(wlr_seat, surface, keyboard->keycodes,
-                                       keyboard->num_keycodes,
-                                       &keyboard->modifiers);
-        return true;
-    }
-
     return false;
 }
 
@@ -96,4 +76,66 @@ double hrt_seat_cursor_lx(struct hrt_seat *seat) {
 
 double hrt_seat_cursor_ly(struct hrt_seat *seat) {
     return seat->cursor->y;
+}
+
+static void seat_set_cursor_img(struct hrt_seat *seat, char *img_name) {
+    // Ensure that our buffer is big enough,
+    // unless the string is super big
+    const size_t len = strlen(img_name) + 1;
+    if (len > seat->cursor_img_buf_len) {
+        if (len > 100) {
+            wlr_log(WLR_ERROR,
+                    "Ignoring hrt_set_cursor_img: cursor name is unreasonable "
+                    "large: %s",
+                    img_name);
+            return;
+        }
+        char *new_ptr = realloc(seat->cursor_image, len);
+        if (!new_ptr) {
+            wlr_log(WLR_ERROR, "Failed to realloc cursor name buffer");
+            return;
+        }
+    }
+    memcpy(seat->cursor_image, img_name, len);
+}
+
+/**
+ * Set the seat's default cursor image to the given cursor name.
+ *
+ * Does not take ownership of the string.
+ *
+ * See themes section of man xcursor(3) to find where to find valid cursor
+ * names.
+ */
+static void hrt_seat_set_cursor_img(struct hrt_seat *seat, char *img_name) {
+    seat_set_cursor_img(seat, img_name);
+    wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager,
+                           seat->cursor_image);
+}
+
+/**
+ * Set the cursor image back to the default.
+ **/
+static void hrt_seat_reset_cursor_img(struct hrt_seat *seat) {
+    seat_set_cursor_img(seat, "default");
+    // TODO: investigate; this may send the pointer_enter event
+    // when the pointer is already in the view. Does that matter?
+    hrt_seat_reset_view_under(seat);
+}
+
+void hrt_seat_grab(struct hrt_seat *seat, char *img_name) {
+    hrt_seat_set_cursor_img(seat, img_name);
+    wlr_seat_keyboard_notify_clear_focus(seat->seat);
+    wlr_seat_pointer_notify_clear_focus(seat->seat);
+    // To prevent input from being processed, we watch this flag.
+    // Considering this is on a hot path, could we do better
+    // by unregistering event listeners or similar? We would
+    // still need to listen to keyboard events...
+    seat->grabbed = true;
+}
+
+void hrt_seat_ungrab(struct hrt_seat *seat) {
+    seat->grabbed = false;
+    hrt_seat_reset_cursor_img(seat);
+    hrt_seat_reset_view_under(seat);
 }

--- a/heart/src/seat.c
+++ b/heart/src/seat.c
@@ -1,12 +1,31 @@
 #include <hrt/hrt_input.h>
 
+#include <stdlib.h>
+#include <string.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_pointer.h>
 #include <wlr/types/wlr_seat.h>
+#include <wlr/util/log.h>
 #include <xkbcommon/xkbcommon.h>
 
 void hrt_seat_set_cursor_img(struct hrt_seat *seat, char *img_name) {
-    seat->cursor_image = img_name;
+    // Ensure that our buffer is big enough,
+    // unless the string is super big
+    const size_t len = strlen(img_name) + 1;
+    if (len > seat->cursor_img_buf_len) {
+        if (len > 100) {
+            wlr_log(WLR_ERROR, "Ignoring hrt_set_cursor_img: cursor name is unreasonable large: %s",
+                   img_name);
+          return;
+        }
+        char *new_ptr = realloc(seat->cursor_image, len);
+        if (!new_ptr) {
+            wlr_log(WLR_ERROR, "Failed to realloc cursor name buffer");
+            return;
+        }
+    }
+    memcpy(seat->cursor_image, img_name, len);
+
     wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager,
                            seat->cursor_image);
 }

--- a/lisp/heart/hrt-bindings.lisp
+++ b/lisp/heart/hrt-bindings.lisp
@@ -34,6 +34,7 @@
   (callbacks (:pointer (:struct hrt-seat-callbacks)))
   (cursor-image (:pointer :char))
   (cursor-img-buf-len :size)
+  (grabbed :bool)
   (destroy (:struct hrt-seat-destroy)))
 
 (cffi:defcstruct hrt-keypress-info
@@ -57,7 +58,8 @@
 (declaim (inline hrt-seat-reset-view-under))
 (cffi:defcfun ("hrt_seat_reset_view_under" hrt-seat-reset-view-under) :void
   "Send the appropriate cursor event to the view under the
-cursor."
+cursor and ensure the cursor has the correct image
+for what it is hovering over."
   (seat (:pointer (:struct hrt-seat))))
 
 #-HRT-DEBUG
@@ -71,6 +73,23 @@ See themes section of man xcursor(3) to find where to find valid cursor
 names."
   (seat (:pointer (:struct hrt-seat)))
   (img-name (:pointer :char)))
+
+#-HRT-DEBUG
+(declaim (inline hrt-seat-reset-cursor-img))
+(cffi:defcfun ("hrt_seat_reset_cursor_img" hrt-seat-reset-cursor-img) :void
+  "Set the cursor image back to the default."
+  (seat (:pointer (:struct hrt-seat))))
+
+#-HRT-DEBUG
+(declaim (inline hrt-seat-grab))
+(cffi:defcfun ("hrt_seat_grab" hrt-seat-grab) :void
+  (seat (:pointer (:struct hrt-seat)))
+  (img-name (:pointer :char)))
+
+#-HRT-DEBUG
+(declaim (inline hrt-seat-ungrab))
+(cffi:defcfun ("hrt_seat_ungrab" hrt-seat-ungrab) :void
+  (seat (:pointer (:struct hrt-seat))))
 
 #-HRT-DEBUG
 (declaim (inline hrt-seat-notify-button))

--- a/lisp/heart/hrt-bindings.lisp
+++ b/lisp/heart/hrt-bindings.lisp
@@ -33,6 +33,7 @@
   (start-drag (:struct wl-listener))
   (callbacks (:pointer (:struct hrt-seat-callbacks)))
   (cursor-image (:pointer :char))
+  (cursor-img-buf-len :size)
   (destroy (:struct hrt-seat-destroy)))
 
 (cffi:defcstruct hrt-keypress-info

--- a/lisp/heart/package.lisp
+++ b/lisp/heart/package.lisp
@@ -62,6 +62,9 @@
            ;; Seat
            #:hrt-seat
            #:hrt-seat-reset-view-under
+           #:seat-grabbed-p
+           #:seat-grab
+           #:hrt-seat-ungrab
            #:hrt-seat-notify-button
            #:hrt-seat-notify-axis
            #:hrt-seat-cursor-lx

--- a/lisp/heart/seat.lisp
+++ b/lisp/heart/seat.lisp
@@ -1,0 +1,13 @@
+(in-package #:hrt)
+
+(defun seat-grab (seat cursor-name)
+  (declare (type string cursor-name)
+           (type cffi:foreign-pointer seat))
+  (cffi:with-foreign-string (str cursor-name)
+    (hrt-seat-grab seat str)))
+
+#-HRT-DEBUG
+(declare (inline seat-grabbed-p))
+(defun seat-grabbed-p (seat)
+  (cffi:foreign-slot-value seat '(:struct hrt-seat)
+                           'grabbed))

--- a/lisp/input.lisp
+++ b/lisp/input.lisp
@@ -66,25 +66,26 @@ Values:
            (optimize (speed 3)))
   (when (not (key-modifier-key-p key))
     (let* ((handling-keybinding (key-state-active-p key-state)))
-      (log-string :trace "Already handling keybinding: ~A" handling-keybinding)
       (flet ((reset-state ()
                (log-string :trace "Reseting keyboard state")
+               (state-ungrab-seat *compositor-state*)
                (server-keystate-reset *compositor-state*)))
         (multiple-value-bind (matched result)
             (key-state-advance key key-state)
           (cond
             (;; A known keybinding was pressed:
              matched
-             (when result
-               (reset-state)
-               ;; Only consume the pressed key if we have a command
-               ;; and not a special keyword:
-               (if (eq :pass-through result)
-                   (return-from check-and-run-keybinding nil)
-                   (execute-command result
-		                    (key-state-sequence key-state) seat)))
-             ;; Consume the pressed key)
-	         t)
+             (cond
+               (result
+                (reset-state)
+                ;; Only consume the pressed key if we have a command
+                ;; and not a special keyword:
+                (if (eq :pass-through result)
+                    (return-from check-and-run-keybinding nil)
+                    (execute-command result
+		                             (key-state-sequence key-state) seat)))
+               (t (state-grab-seat *compositor-state*)
+                  t)))
             (;; No keybinding was pressed but we were expecting one.
              handling-keybinding
              (toast-message *compositor-state* (%unkown-keybinding-message key-state key))

--- a/lisp/state.lisp
+++ b/lisp/state.lisp
@@ -331,6 +331,21 @@ the current group or a layer shell frame"
     (when (> (ring-list:ring-list-size hidden-groups) 0)
       (setf (state-current-group state) (ring-list:swap-previous hidden-groups current-group)))))
 
+(defun state-grab-seat (state)
+  (declare (type mahogany-state state))
+  (let ((seat (server-seat state)))
+    (unless (hrt:seat-grabbed-p seat)
+      (tree:unmark-frame-focused (state-%current-frame state)
+                                 seat)
+      (hrt:seat-grab seat "help"))))
+
+(defun state-ungrab-seat (state)
+  (declare (type mahogany-state state))
+  (let ((seat (server-seat state)))
+    (hrt:hrt-seat-ungrab seat)
+    (tree:mark-frame-focused (state-%current-frame state)
+                               seat)))
+
 (defun mahogany-set-keymap (state &key (rules (cffi:null-pointer)) (keymap-flags :no-flags))
   "Set the xkb keymap using the provided rules and flags. Signals a
 KEYMAP-CREATION-ERROR if the rules are invalid or malformed."

--- a/mahogany.asd
+++ b/mahogany.asd
@@ -59,6 +59,8 @@
                               :depends-on ("cffi-util" "hrt-bindings" "output"))
                              (:file "border-box"
                               :depends-on ("cffi-util" "hrt-bindings"))
+                             (:file "seat"
+                              :depends-on ("package"))
                              (:file "server"
                               :depends-on ("package" "hrt-bindings" "callback"))
                              (:file "layer-shell")


### PR DESCRIPTION
Unfocus all clients and change the cursor image while keybindings are entered.

See #189.