### PR TITLE
hrt: Grab pointer by disabling cursor events

### DIFF
--- a/heart/include/seat_impl.h
+++ b/heart/include/seat_impl.h
@@ -23,6 +23,9 @@ bool hrt_seat_keyboard_focus_surface(struct hrt_seat *seat,
 bool hrt_seat_keyboard_focus_surface_clear(struct hrt_seat *seat,
                                            struct wlr_surface *surface);
 
+void hrt_seat_enable_cursor_events(struct hrt_seat *seat);
+void hrt_seat_disable_cursor_events(struct hrt_seat *seat);
+
 void hrt_keyboard_init(struct hrt_seat *seat);
 void hrt_keyboard_destroy(struct hrt_seat *seat);
 

--- a/heart/src/cursor.c
+++ b/heart/src/cursor.c
@@ -41,40 +41,36 @@ static void *find_view_at(struct hrt_server *server, double lx, double ly,
 }
 
 void hrt_seat_reset_view_under(struct hrt_seat *seat) {
-    if (!seat->grabbed) {
-        double sx, sy;
-        struct wlr_surface *found_surface = NULL;
-        void *view = find_view_at(seat->server, seat->cursor->x,
-                                  seat->cursor->y, &found_surface, &sx, &sy);
+    double sx, sy;
+    struct wlr_surface *found_surface = NULL;
+    void *view = find_view_at(seat->server, seat->cursor->x, seat->cursor->y,
+                              &found_surface, &sx, &sy);
 
-        if (!view) {
-            wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager,
-                                   seat->cursor_image);
-        }
-        if (found_surface) {
-            wlr_seat_pointer_notify_enter(seat->seat, found_surface, sx, sy);
-        } else {
-            wlr_seat_pointer_clear_focus(seat->seat);
-        }
+    if (!view) {
+        wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager,
+                               seat->cursor_image);
+    }
+    if (found_surface) {
+        wlr_seat_pointer_notify_enter(seat->seat, found_surface, sx, sy);
+    } else {
+        wlr_seat_pointer_clear_focus(seat->seat);
     }
 }
 
 static void handle_cursor_motion(struct hrt_seat *seat, uint32_t time) {
-    if (!seat->grabbed) {
-        double sx, sy;
-        struct wlr_surface *found_surface = NULL;
-        void *view = find_view_at(seat->server, seat->cursor->x,
-                                  seat->cursor->y, &found_surface, &sx, &sy);
-        if (!view) {
-            wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager,
-                                   seat->cursor_image);
-        }
-        if (found_surface) {
-            wlr_seat_pointer_notify_enter(seat->seat, found_surface, sx, sy);
-            wlr_seat_pointer_notify_motion(seat->seat, time, sx, sy);
-        } else {
-            wlr_seat_pointer_clear_focus(seat->seat);
-        }
+    double sx, sy;
+    struct wlr_surface *found_surface = NULL;
+    void *view = find_view_at(seat->server, seat->cursor->x, seat->cursor->y,
+                              &found_surface, &sx, &sy);
+    if (!view) {
+        wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager,
+                               seat->cursor_image);
+    }
+    if (found_surface) {
+        wlr_seat_pointer_notify_enter(seat->seat, found_surface, sx, sy);
+        wlr_seat_pointer_notify_motion(seat->seat, time, sx, sy);
+    } else {
+        wlr_seat_pointer_clear_focus(seat->seat);
     }
 }
 
@@ -96,25 +92,40 @@ static void seat_motion_absolute(struct wl_listener *listener, void *data) {
 
 static void seat_button(struct wl_listener *listener, void *data) {
     struct hrt_seat *seat = wl_container_of(listener, seat, button);
-    if (!seat->grabbed) {
-        struct wlr_pointer_button_event *event = data;
+    struct wlr_pointer_button_event *event = data;
 
-        /* Notify the client with pointer focus that a button press has occurred */
-        seat->callbacks->button_event(seat, event);
-    }
+    /* Notify the client with pointer focus that a button press has occurred */
+    seat->callbacks->button_event(seat, event);
 }
 
 static void seat_axis(struct wl_listener *listener, void *data) {
-    struct hrt_seat *seat = wl_container_of(listener, seat, axis);
-    if (!seat->grabbed) {
-        struct wlr_pointer_axis_event *ev = data;
-        seat->callbacks->wheel_event(seat, ev);
-    }
+    struct hrt_seat *seat             = wl_container_of(listener, seat, axis);
+    struct wlr_pointer_axis_event *ev = data;
+    seat->callbacks->wheel_event(seat, ev);
 }
 
 static void seat_frame(struct wl_listener *listener, void *data) {
     struct hrt_seat *seat = wl_container_of(listener, seat, frame);
     wlr_seat_pointer_notify_frame(seat->seat);
+}
+
+void hrt_seat_enable_cursor_events(struct hrt_seat *seat) {
+    wl_signal_add(&seat->cursor->events.motion, &seat->motion);
+    wl_signal_add(&seat->cursor->events.motion_absolute,
+                  &seat->motion_absolute);
+    wl_signal_add(&seat->cursor->events.button, &seat->button);
+    wl_signal_add(&seat->cursor->events.axis, &seat->axis);
+}
+
+void hrt_seat_disable_cursor_events(struct hrt_seat *seat) {
+    // Calling remove on the listeners puts them in an invalid state,
+    // so don't try to remove them again:
+    if (!seat->grabbed) {
+        wl_list_remove(&seat->axis.link);
+        wl_list_remove(&seat->button.link);
+        wl_list_remove(&seat->motion_absolute.link);
+        wl_list_remove(&seat->motion.link);
+    }
 }
 
 bool hrt_cursor_init(struct hrt_seat *seat, struct hrt_server *server) {
@@ -130,15 +141,11 @@ bool hrt_cursor_init(struct hrt_seat *seat, struct hrt_server *server) {
     }
     wlr_xcursor_manager_load(seat->xcursor_manager, 1);
 
-    seat->motion.notify = seat_motion;
-    wl_signal_add(&seat->cursor->events.motion, &seat->motion);
+    seat->motion.notify          = seat_motion;
     seat->motion_absolute.notify = seat_motion_absolute;
-    wl_signal_add(&seat->cursor->events.motion_absolute,
-                  &seat->motion_absolute);
-    seat->button.notify = seat_button;
-    wl_signal_add(&seat->cursor->events.button, &seat->button);
-    seat->axis.notify = seat_axis;
-    wl_signal_add(&seat->cursor->events.axis, &seat->axis);
+    seat->button.notify          = seat_button;
+    seat->axis.notify            = seat_axis;
+    hrt_seat_enable_cursor_events(seat);
     seat->frame.notify = seat_frame;
     wl_signal_add(&seat->cursor->events.frame, &seat->frame);
 
@@ -148,10 +155,7 @@ bool hrt_cursor_init(struct hrt_seat *seat, struct hrt_server *server) {
 void hrt_cursor_destroy(struct hrt_seat *seat) {
     wlr_log(WLR_DEBUG, "hrt_cursor destroyed");
     wl_list_remove(&seat->frame.link);
-    wl_list_remove(&seat->axis.link);
-    wl_list_remove(&seat->button.link);
-    wl_list_remove(&seat->motion_absolute.link);
-    wl_list_remove(&seat->motion.link);
+    hrt_seat_disable_cursor_events(seat);
 
     wlr_xcursor_manager_destroy(seat->xcursor_manager);
     wlr_cursor_destroy(seat->cursor);

--- a/heart/src/seat.c
+++ b/heart/src/seat.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include <hrt/hrt_input.h>
+#include <seat_impl.h>
 
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_pointer.h>
@@ -127,15 +128,13 @@ void hrt_seat_grab(struct hrt_seat *seat, char *img_name) {
     hrt_seat_set_cursor_img(seat, img_name);
     wlr_seat_keyboard_notify_clear_focus(seat->seat);
     wlr_seat_pointer_notify_clear_focus(seat->seat);
-    // To prevent input from being processed, we watch this flag.
-    // Considering this is on a hot path, could we do better
-    // by unregistering event listeners or similar? We would
-    // still need to listen to keyboard events...
+    hrt_seat_disable_cursor_events(seat);
     seat->grabbed = true;
 }
 
 void hrt_seat_ungrab(struct hrt_seat *seat) {
     seat->grabbed = false;
+    hrt_seat_enable_cursor_events(seat);
     hrt_seat_reset_cursor_img(seat);
     hrt_seat_reset_view_under(seat);
 }


### PR DESCRIPTION
... instead of setting a flag. This should theoretically reduce latency for all cursor inputs, but it also seems to noticiably slow down grabbing the pointer. Without knowing a way to benchmark this, I'm not sure which approach is better.

This seems to be nicer from a design perspective though.