### PR TITLE
kmaps: Require kmaps to be named

### DIFF
--- a/doc/manual/kmap-keybindings.org
+++ b/doc/manual/kmap-keybindings.org
@@ -74,7 +74,7 @@ command to a key, you can bind another keymap:
 
 #+BEGIN_SRC lisp
   (add-to-kmap *root-map*
-    (kbd "j") (define-kmap
+    (kbd "j") (define-kmap nest-kmap
   			  (kbd "k") #'open-terminal))
 #+END_SRC
 

--- a/lisp/key-bindings.lisp
+++ b/lisp/key-bindings.lisp
@@ -87,34 +87,31 @@
         (log-string :info "Output added"))))
 
 #+:hrt-debug
-(defvar *debug-map*
-    (define-kmap
-      (kbd "a") #'add-output))
+(defvar-kmap *debug-map*
+  (kbd "a") #'add-output)
 
-(defvar *group-map*
-  (define-kmap
-    (kbd "c") #'gnew
-    (kbd "k") #'gkill
-    (kbd "n") #'gnext
-    (kbd "p") #'gprev))
+(defvar-kmap *group-map*
+  (kbd "c") #'gnew
+  (kbd "k") #'gkill
+  (kbd "n") #'gnext
+  (kbd "p") #'gprev)
 
-(defvar *root-map*
-  (define-kmap
-    (kbd "!") #'run-shell-command
-    (kbd ";") #'colon
-    (kbd "o") #'next-frame
-    (kbd "O") #'prev-frame
-    (kbd "q") #'handle-server-stop
-    (kbd "k") #'close-current-view
-    (kbd "c") #'open-terminal
-    (kbd "s") #'split-frame-v
-    (kbd "S") #'split-frame-h
-    (kbd "Q") #'maximize-current-frame
-    (kbd "n") #'next-view
-    (kbd "p") #'previous-view
-    (kbd "g") *group-map*))
+(defvar-kmap *root-map*
+  (kbd "!") #'run-shell-command
+  (kbd ";") #'colon
+  (kbd "o") #'next-frame
+  (kbd "O") #'prev-frame
+  (kbd "q") #'handle-server-stop
+  (kbd "k") #'close-current-view
+  (kbd "c") #'open-terminal
+  (kbd "s") #'split-frame-v
+  (kbd "S") #'split-frame-h
+  (kbd "Q") #'maximize-current-frame
+  (kbd "n") #'next-view
+  (kbd "p") #'previous-view
+  (kbd "g") *group-map*)
 
-(defvar *top-map* (define-kmap))
+(defvar-kmap *top-map*)
 
 #+:hrt-debug
 (progn

--- a/lisp/keyboard/kmap.lisp
+++ b/lisp/keyboard/kmap.lisp
@@ -4,7 +4,8 @@
   (key nil :type key)
   command)
 
-(defstruct kmap
+(defstruct (kmap (:constructor %make-kmap (name)))
+  (name nil :type string :read-only t)
   (bindings
    ;; Using a custom hash function yeilds a small performance improvement
    ;; on SBCL, but not on CCL. Clasp hasn't been tested yet.
@@ -14,6 +15,9 @@
    #-sbcl
    (make-hash-table :test 'equalp)
    :read-only t :type hash-table))
+
+(defun make-kmap (name)
+  (%make-kmap (format nil "~S" name)))
 
 (defun define-key (map key cmd)
   (if cmd
@@ -31,14 +35,26 @@
            (push `(define-key ,map-var ,key ,binding) forms))
        ,map-var)))
 
-(defmacro define-kmap (&body body)
+(defmacro define-kmap (name &body body)
   "Create a keymap and add the given bindings to it.
 
 Example:
-   (define-kmap
+   (define-kmap example-kmap
      (kbd \"C-s\") 'foo
      (kbd \"M-;\") 'bar)"
-  (%build-define-list '(make-kmap) body))
+  (%build-define-list `(make-kmap (quote ,name)) body))
+
+(defmacro defvar-kmap (name &body body)
+  "Create a kmap and bind it to the special variable NAME.
+Uses the SYMBOL-NAME of NAME to name the kmap.
+
+Example:
+  (define-kmap-var *example-kmap*
+    (kdb \"C-s\"))"
+  (check-type name symbol)
+  `(defvar ,name
+     (define-kmap (symbol-name ,name)
+       ,@body)))
 
 (defmacro add-to-kmap (kmap &body bindings)
   "Add bindings to a keymap.

--- a/lisp/keyboard/package.lisp
+++ b/lisp/keyboard/package.lisp
@@ -14,6 +14,7 @@
            #:kbd
            #:kbd-parse-error
            #:define-kmap
+           #:defvar-kmap
            #:add-to-kmap
            #:define-key
            #:kmap-p

--- a/lisp/kmap-modes.lisp
+++ b/lisp/kmap-modes.lisp
@@ -34,7 +34,7 @@ the KEYBINDINGS list."
   (declare (type kmap-mode kmap-mode)
            (type key prefix-key)
            (type list keybindings))
-  (let ((top-kmap (define-kmap
+  (let ((top-kmap (define-kmap prefix-map
                     prefix-key (kmap-mode-prefix-binding kmap-mode))))
     (setf (kmap-mode-top-kmap kmap-mode) top-kmap)
     (push top-kmap keybindings)
@@ -72,6 +72,16 @@ the KEYBINDINGS list."
       ((not (string-equal "-mode" (subseq name (- len 5))))
        (error must-end-msg)))))
 
+(defun %make-kmap-mode-kmap-symbol (name type)
+  (declare (type symbol name)
+           (type string type))
+  (string-upcase
+   (concatenate 'string
+                (symbol-name name)
+                "-"
+                type
+                "-map")))
+
 ;; TODO: Make it possible to redefine kmap-modes
 (defmacro define-kmap-mode (name &key
                                    documentation
@@ -79,19 +89,22 @@ the KEYBINDINGS list."
                                    prefix-binding)
 
   (%validate-kmap-mode-symbol name)
-  `(let ((kmap-mode (make-kmap-mode (quote ,name)
-                                    (or ,top-binding (make-kmap))
-                                    (or ,prefix-binding (make-kmap))
-                                    ,documentation)))
-     (pushnew kmap-mode *kmap-modes* :key #'kmap-mode-name)
-     (defun ,name (&optional (activate t))
-       (if activate
-           (kmap-mode-activate *compositor-state* kmap-mode)
-           (kmap-mode-deactivate *compositor-state* kmap-mode)))))
+  (let ((top-binding-name (%make-kmap-mode-kmap-symbol name "top"))
+        (prefix-binding-name (%make-kmap-mode-kmap-symbol name "prefix")))
+    `(let ((kmap-mode (make-kmap-mode (quote ,name)
+                                      (or ,top-binding (make-kmap
+                                                        ,top-binding-name))
+                                      (or ,prefix-binding (make-kmap
+                                                           ,prefix-binding-name))
+                                      ,documentation)))
+       (pushnew kmap-mode *kmap-modes* :key #'kmap-mode-name)
+       (defun ,name (&optional (activate t))
+         (if activate
+             (kmap-mode-activate *compositor-state* kmap-mode)
+             (kmap-mode-deactivate *compositor-state* kmap-mode))))))
 
-(defvar *prefix-passthrough-kmap*
-  (define-kmap
-    (state-prefix-key *compositor-state*) :pass-through))
+(defvar-kmap *prefix-passthrough-kmap*
+  (state-prefix-key *compositor-state*) :pass-through)
 
 (defun (setf state-prefix-key) (key state)
   (declare (type key key)

--- a/lisp/package.lisp
+++ b/lisp/package.lisp
@@ -25,6 +25,7 @@
                     (#:colors #:cl-colors2)
                     (#:config #:config-system))
   (:export #:define-kmap
+           #:defvar-kmap
            #:kbd
            #:add-to-kmap
            #:*root-map*


### PR DESCRIPTION
To facilitate help messages, require kmaps to be named. Add `defvar-kmap` to make defining kmap variables less verbose.

BREAKING: `define-kmap` requires a name argument.