### PR TITLE
hrt: Add support for wl-mirror application

### DIFF
--- a/heart/include/hrt/hrt_server.h
+++ b/heart/include/hrt/hrt_server.h
@@ -48,6 +48,9 @@ struct hrt_server {
     struct wlr_layer_shell_v1 *layer_shell;
     struct wl_listener new_layer_shell;
 
+    struct wlr_ext_image_copy_capture_manager_v1
+        *ext_image_copy_capture_manager_v1;
+
     struct {
         struct wl_listener backend;
         struct wl_listener headless;

--- a/heart/src/output.c
+++ b/heart/src/output.c
@@ -13,6 +13,7 @@
 #include <wayland-util.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/backend/headless.h>
+#include <wlr/types/wlr_xdg_output_v1.h>
 
 #include <hrt/hrt_output.h>
 
@@ -346,6 +347,7 @@ bool hrt_server_output_init(struct hrt_server *server,
                   &server->output_layout_changed);
 
     server->output_manager = wlr_output_manager_v1_create(server->wl_display);
+    wlr_xdg_output_manager_v1_create(server->wl_display, server->output_layout);
 
     if (!server->output_manager) {
         return false;

--- a/heart/src/server.c
+++ b/heart/src/server.c
@@ -21,6 +21,8 @@
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/types/wlr_viewporter.h>
+#include <wlr/types/wlr_ext_image_copy_capture_v1.h>
+#include <wlr/types/wlr_ext_image_capture_source_v1.h>
 
 #include <hrt/hrt_server.h>
 #include <hrt/hrt_output.h>
@@ -98,6 +100,9 @@ bool hrt_server_init(
     wlr_data_control_manager_v1_create(server->wl_display);
     wlr_gamma_control_manager_v1_create(server->wl_display);
     wlr_primary_selection_v1_device_manager_create(server->wl_display);
+    server->ext_image_copy_capture_manager_v1 =
+        wlr_ext_image_copy_capture_manager_v1_create(server->wl_display, 1);
+    wlr_ext_output_image_capture_source_manager_v1_create(server->wl_display, 1);
 
     server->scene         = wlr_scene_create();
     server->output_layout = wlr_output_layout_create(server->wl_display);

--- a/lisp/heart/hrt-bindings.lisp
+++ b/lisp/heart/hrt-bindings.lisp
@@ -680,6 +680,7 @@ intial placement."
   (new-xdg-toplevel (:struct wl-listener))
   (layer-shell :pointer #| (:struct wlr-layer-shell-v1) |#)
   (new-layer-shell (:struct wl-listener))
+  (ext-image-copy-capture-manager-v1 :pointer #| (:struct wlr-ext-image-copy-capture-manager-v1) |#)
   (destroy-listener (:struct hrt-server-destroy-listener))
   (output-callback (:pointer (:struct hrt-output-callbacks)))
   (view-callbacks (:pointer (:struct hrt-view-callbacks)))


### PR DESCRIPTION
Add the following protocols:
+ XDG Output Unstable v1
+ EXT Image Copy Capture v1 & EXT Image Capture Source v1
  + With these protocols, you can specify toplevels as sources and not just whole outputs. That part of the protocol isn't implemented, unless wlroots also does that part for us.

See #289.