### PR TITLE
Add FreeBSD CI workflow

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,0 +1,39 @@
+name: Build and Test (FreeBSD)
+
+on:
+  push:
+    branches: master
+  pull_request:
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    name: Build and test on FreeBSD
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: 'recursive'
+      - name: Build and test in a FreeBSD VM
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          # Cache the VM image once the packages are installed, so later runs
+          # restore it and skip the whole prepare step.
+          cache-after-prepare: true
+          # wlroots020 provides a wlroots in the 0.20.x range that heart
+          # accepts, so the bundled wlroots subproject is not built here.
+          prepare: |
+            pkg install -y \
+              curl git gmake meson ninja pkgconf sbcl \
+              wlroots020 wayland-protocols cairo pango
+          run: |
+            set -e
+            curl -o /tmp/quicklisp.lisp https://beta.quicklisp.org/quicklisp.lisp
+            sbcl --non-interactive --load /tmp/quicklisp.lisp \
+                 --eval "(quicklisp-quickstart:install)"
+            sbcl --non-interactive --load "$HOME/quicklisp/setup.lisp" \
+                 --eval "(progn (setf ql-util::*do-not-prompt* t)(ql:add-to-init-file))"
+            chmod +x scripts/install-dependencies.lisp
+            yes | ./scripts/install-dependencies.lisp
+            gmake
+            gmake test

--- a/README.org
+++ b/README.org
@@ -1,4 +1,7 @@
 * Mahogany
+  [[https://github.com/stumpwm/mahogany/actions/workflows/test.yml][https://github.com/stumpwm/mahogany/actions/workflows/test.yml/badge.svg]]
+  [[https://github.com/stumpwm/mahogany/actions/workflows/freebsd.yml][https://github.com/stumpwm/mahogany/actions/workflows/freebsd.yml/badge.svg]]
+
   Mahogany is a tiling window manager for Wayland modeled after
   StumpWM. While it is not a drop-in replacement for stumpwm, stumpwm
   users should be very comfortable with Mahogany. Its planned

--- a/heart/src/event_loop.c
+++ b/heart/src/event_loop.c
@@ -1,5 +1,4 @@
 #include "wlr/util/log.h"
-#include <asm-generic/errno-base.h>
 #include <errno.h>
 #include <stdint.h>
 #include <unistd.h>


### PR DESCRIPTION
Closes #284.

Mahogany nominally supports the BSDs, but nothing verified it. This adds a FreeBSD build-and-test job using `vmactions/freebsd-vm`, mirroring what the existing Fedora job does on Linux, plus CI status badges in the README.

**Notes**

- **A separate workflow file rather than a second job in `test.yml`** -- keeps the existing Linux CI untouched, and lets the slower VM job be tuned independently.

- **wlroots comes from packages.** FreeBSD ports ships `wlroots020-0.20.2`, which satisfies heart's `>=0.20.0, <0.21.0`, so the bundled wlroots subproject is not rebuilt. The run log confirms it: `Run-time dependency wlroots-0.20 found: YES 0.20.2`.

- **One portability fix was required.** `heart/src/event_loop.c` included `<asm-generic/errno-base.h>`, a Linux kernel UAPI header that does not exist on FreeBSD. The file only needs `EAGAIN`, which `<errno.h>` already provides, so the include was redundant on Linux as well -- the Fedora job stays green without it.

- `gmake`, not `make` -- the Makefile uses GNU make features and FreeBSD's `make` is bmake.

- `cache-after-prepare: true` caches the VM image after `pkg install`, so later runs skip package installation.

**Verification**

Both jobs pass on my fork at this exact commit ([FreeBSD](https://github.com/neilpang/mahogany/actions/runs/30339348594), [Linux](https://github.com/neilpang/mahogany/actions/runs/30339348550)). The FreeBSD job builds `libheart.so` (22 C objects, clang), links against the packaged wlroots, builds the `mahogany` executable, and runs the full fiasco suite -- all green on FreeBSD 15.1.
