### PR TITLE
Add ability to customize cursor theme

### DIFF
--- a/doc/manual/theming.org
+++ b/doc/manual/theming.org
@@ -1,0 +1,46 @@
+* Customizing Mahogany's Appearance
+
+** Cursor Theming
+
+Mahogany uses xcursor themes to customize the appearance of the
+cursor. To set an xcursor theme, use the =mh::state-set-cursor-theme=
+function:
+
+#+BEGIN_SRC lisp
+  (mh::state-set-cursor-theme
+   mh::*compositor-state*
+   "mahogany_default")
+#+END_SRC
+
+When =nil= is passed as the name argument, the theme is set to the
+system's default theme.
+
+This function can also be used to set the size of the cursor, which is
+specified as an optional argument:
+
+#+BEGIN_SRC lisp
+  (mh::state-set-cursor-theme
+   mh::*compositor-state*
+   nil ; Use the default theme
+   24 ; This is the default size.
+   )
+#+END_SRC
+
+** Customizing the grab pointer
+
+When a keybinding is in the process of being entered, the pointer
+changes to signify that input is not being passed to clients. To
+change the cursor used, you can set the =mh::grab-pointer-cursor=
+configuration property:
+
+#+BEGIN_SRC lisp
+  (config-system:set-config mh::grab-pointer-cursor "mahogany_grab")
+#+END_SRC
+
+*** Adding custom grab pointer cursors
+
+You can use arbitrary images for the grab pointer by
+[[https://wiki.archlinux.org/title/Xcursorgen][adding a custom cursor theme]]. For the name of the cursor, use
+something like =mahogany_grab= to differentiate it from the other
+standardized cursor names. Activate that theme in mahogany, and
+set =mh::grab-pointer-cursor= to the name that you chose.

--- a/heart/include/hrt/hrt_input.h
+++ b/heart/include/hrt/hrt_input.h
@@ -1,6 +1,7 @@
 #ifndef HRT_HRT_INPUT_H
 #define HRT_HRT_INPUT_H
 
+#include <stdint.h>
 #include <wayland-server-protocol.h>
 #include <wayland-server.h>
 #include <wlr/types/wlr_input_device.h>
@@ -114,6 +115,12 @@ void hrt_seat_notify_axis(struct hrt_seat *seat,
 
 bool hrt_seat_set_keymap(struct hrt_seat *seat, struct xkb_rule_names *rules,
                          enum xkb_keymap_compile_flags flags);
+
+/**
+ * Set the xcursor theme used by the cursor as well as the cursor size.
+ **/
+bool hrt_seat_cursor_set_theme(struct hrt_seat *seat, char *theme_name,
+                               uint32_t base_size);
 
 double hrt_seat_cursor_lx(struct hrt_seat *seat);
 

--- a/heart/src/cursor.c
+++ b/heart/src/cursor.c
@@ -1,4 +1,5 @@
 #include "wlr/util/log.h"
+#include <stdint.h>
 #include <wayland-util.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/types/wlr_cursor.h>
@@ -117,6 +118,39 @@ static void seat_frame(struct wl_listener *listener, void *data) {
     wlr_seat_pointer_notify_frame(seat->seat);
 }
 
+constexpr uint32_t xcursor_base_size = 24;
+
+bool hrt_seat_cursor_set_theme(struct hrt_seat *seat, char *theme_name,
+                               uint32_t base_size) {
+    if (base_size < 1) {
+        wlr_log(WLR_ERROR, "Cannot set cursor base size to zero.");
+    }
+    struct wlr_xcursor_manager *manager =
+        wlr_xcursor_manager_create(theme_name, base_size);
+    if (!manager) {
+        return false;
+    }
+
+    struct wlr_output_layout_output *output;
+    wl_list_for_each(output, &seat->server->output_layout->outputs, link) {
+        struct wlr_output *wlr_output = output->output;
+        const float scale             = wlr_output->scale;
+        if (!wlr_xcursor_manager_load(manager, scale)) {
+            wlr_log(WLR_ERROR, "Failed to load cursor theme for scale %f",
+                    scale);
+            goto error;
+        }
+    }
+    wlr_xcursor_manager_destroy(seat->xcursor_manager);
+    seat->xcursor_manager = manager;
+    hrt_seat_reset_view_under(seat);
+
+    return true;
+error:
+    wlr_xcursor_manager_destroy(manager);
+    return false;
+}
+
 bool hrt_cursor_init(struct hrt_seat *seat, struct hrt_server *server) {
     seat->cursor = wlr_cursor_create();
     if (!seat->cursor) {
@@ -124,11 +158,10 @@ bool hrt_cursor_init(struct hrt_seat *seat, struct hrt_server *server) {
     }
     wlr_cursor_attach_output_layout(seat->cursor, server->output_layout);
 
-    seat->xcursor_manager = wlr_xcursor_manager_create(NULL, 24);
+    seat->xcursor_manager = wlr_xcursor_manager_create(NULL, xcursor_base_size);
     if (!seat->xcursor_manager) {
         return false;
     }
-    wlr_xcursor_manager_load(seat->xcursor_manager, 1);
 
     seat->motion.notify = seat_motion;
     wl_signal_add(&seat->cursor->events.motion, &seat->motion);

--- a/heart/src/output.c
+++ b/heart/src/output.c
@@ -14,6 +14,7 @@
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/backend/headless.h>
 #include <wlr/types/wlr_xdg_output_v1.h>
+#include <wlr/types/wlr_xcursor_manager.h>
 
 #include <hrt/hrt_output.h>
 
@@ -243,6 +244,11 @@ bool hrt_output_init(struct hrt_output *output,
         return false;
     }
     wlr_output_state_finish(&state);
+
+    if (!wlr_xcursor_manager_load(server->seat.xcursor_manager, state.scale)) {
+        wlr_log(WLR_ERROR, "Could not load xcursor theme for scale %f",
+                state.scale);
+    }
 
     struct wlr_output_layout_output *l_output;
     if (config && config->custom_position) {

--- a/lisp/heart/hrt-bindings.lisp
+++ b/lisp/heart/hrt-bindings.lisp
@@ -96,6 +96,14 @@ and set the cursor image to the given image name."
   (flags xkb:keymap-compile-flags))
 
 #-HRT-DEBUG
+(declaim (inline hrt-seat-cursor-set-theme))
+(cffi:defcfun ("hrt_seat_cursor_set_theme" hrt-seat-cursor-set-theme) :bool
+  "Set the xcursor theme used by the cursor as well as the cursor's base size."
+  (seat (:pointer (:struct hrt-seat)))
+  (theme-name (:pointer :char))
+  (base-size :uint32))
+
+#-HRT-DEBUG
 (declaim (inline hrt-seat-cursor-lx))
 (cffi:defcfun ("hrt_seat_cursor_lx" hrt-seat-cursor-lx) :double
   (seat (:pointer (:struct hrt-seat))))

--- a/lisp/heart/package.lisp
+++ b/lisp/heart/package.lisp
@@ -64,6 +64,7 @@
            #:hrt-seat-reset-view-under
            #:seat-grabbed-p
            #:seat-grab
+           #:seat-cursor-set-theme
            #:hrt-seat-ungrab
            #:hrt-seat-notify-button
            #:hrt-seat-notify-axis

--- a/lisp/heart/seat.lisp
+++ b/lisp/heart/seat.lisp
@@ -11,3 +11,13 @@
 (defun seat-grabbed-p (seat)
   (cffi:foreign-slot-value seat '(:struct hrt-seat)
                            'grabbed))
+
+(defun seat-cursor-set-theme (seat theme-name cursor-size)
+  "Set the theme of the cursor to THEME-NAME. If THEME-NAME is NIL,
+use the system's default theme."
+  (declare (type (or string null) cursor-name))
+  (if theme-name
+      (progn
+        (cffi:with-foreign-string (str theme-name)
+          (hrt-seat-cursor-set-theme seat str cursor-size)))
+      (hrt-seat-cursor-set-theme seat (cffi:null-pointer) cursor-size)))

--- a/lisp/state.lisp
+++ b/lisp/state.lisp
@@ -331,20 +331,30 @@ the current group or a layer shell frame"
     (when (> (ring-list:ring-list-size hidden-groups) 0)
       (setf (state-current-group state) (ring-list:swap-previous hidden-groups current-group)))))
 
+(config-system:defconfig grab-pointer-cursor "help"
+  string
+  "The cursor image to use for the grab pointer.")
+
 (defun state-grab-seat (state)
   (declare (type mahogany-state state))
   (let ((seat (server-seat state)))
     (unless (hrt:seat-grabbed-p seat)
       (tree:unmark-frame-focused (state-%current-frame state)
                                  seat)
-      (hrt:seat-grab seat "help"))))
+      (hrt:seat-grab seat grab-pointer-cursor))))
 
 (defun state-ungrab-seat (state)
   (declare (type mahogany-state state))
   (let ((seat (server-seat state)))
     (hrt:hrt-seat-ungrab seat)
     (tree:mark-frame-focused (state-%current-frame state)
-                               seat)))
+                             seat)))
+
+(defun state-set-cursor-theme (state theme-name &optional (cursor-size 24))
+  (declare (type mahogany-state state))
+  (hrt:seat-cursor-set-theme (server-seat state)
+									   theme-name
+                                       cursor-size))
 
 (defun mahogany-set-keymap (state &key (rules (cffi:null-pointer)) (keymap-flags :no-flags))
   "Set the xkb keymap using the provided rules and flags. Signals a


### PR DESCRIPTION
+ Add `hrt_seat_cursor_set_theme` to set the theme of the cursor.
+ Add config property `grab-pointer-cursor` to allow customization of the grab pointer.

Together, these allow a completely custom grab pointer to be used; to do so, add a new cursor theme that extends your normal cursor theme, and add a new cursor icon to it that is grab-pointer specific.

See #189.