### PR TITLE
frames: fix a one pixel gap between splits

### DIFF
--- a/lisp/tree/frame.lisp
+++ b/lisp/tree/frame.lisp
@@ -165,7 +165,10 @@ Used to initially split all frames, regardless of type."
                    (old-x frame-x)
                    (old-y frame-y))
       frame
+    ;; OLD-WIDTH follows FRAME's width as it changes, so name the remainder
+    ;; before anything assigns to it.
     (let* ((new-frame-width (round (* old-width ratio)))
+           (other-frame-width (- old-width new-frame-width))
            (new-parent (make-instance parent-type
                                       :split-direction :horizontal
                                       :parent (frame-parent frame)
@@ -181,9 +184,9 @@ Used to initially split all frames, regardless of type."
                                           :parent new-parent
                                           :width new-frame-width
                                           :height old-height
-                                          :x (+ old-x (- old-width new-frame-width))
+                                          :x (+ old-x other-frame-width)
                                           :y old-y))
-           (setf (frame-width frame) (- old-width new-frame-width)
+           (setf (frame-width frame) other-frame-width
                  (tree-children new-parent) (list frame new-frame))
            (psetf (%frame-prev new-frame) frame
                   (%frame-next new-frame) (frame-next frame)
@@ -192,12 +195,12 @@ Used to initially split all frames, regardless of type."
           (:left
            (setf new-frame (make-instance 'view-frame
                                           :parent new-parent
-                                          :width (- old-width new-frame-width)
+                                          :width other-frame-width
                                           :height old-height
                                           :x old-x
                                           :y old-y)
                  (frame-width frame) new-frame-width
-                 (frame-x frame) (+ old-x new-frame-width)
+                 (frame-x frame) (+ old-x other-frame-width)
                  (tree-children new-parent) (list new-frame frame))
            (psetf (%frame-prev new-frame) (frame-prev frame)
                   (%frame-next new-frame) frame
@@ -221,7 +224,10 @@ Used to initially split all frames, regardless of type."
                    (old-x frame-x)
                    (old-y frame-y))
       frame
+    ;; OLD-HEIGHT follows FRAME's height as it changes, so name the remainder
+    ;; before anything assigns to it.
     (let* ((new-frame-height (round (* old-height ratio)))
+           (other-frame-height (- old-height new-frame-height))
            (new-parent (make-instance parent-type
                                       :split-direction :vertical
                                       :parent (frame-parent frame)
@@ -239,7 +245,7 @@ Used to initially split all frames, regardless of type."
                                           :height new-frame-height
                                           :x old-x
                                           :y old-y))
-           (setf (frame-height frame) (- old-height new-frame-height))
+           (setf (frame-height frame) other-frame-height)
            (setf (frame-y frame) (+ old-y new-frame-height))
            (setf (tree-children new-parent) (list new-frame frame))
            (psetf (%frame-prev new-frame) (frame-prev frame)
@@ -250,9 +256,9 @@ Used to initially split all frames, regardless of type."
            (setf new-frame (make-instance 'view-frame
                                           :parent new-parent
                                           :width old-width
-                                          :height (- old-height new-frame-height)
+                                          :height other-frame-height
                                           :x old-x
-                                          :y (+ old-y (- old-height new-frame-height))))
+                                          :y (+ old-y new-frame-height)))
            (setf (frame-height frame) new-frame-height)
            (setf (tree-children new-parent) (list frame new-frame))
            (psetf (%frame-prev new-frame) frame

--- a/test/tree-tests.lisp
+++ b/test/tree-tests.lisp
@@ -399,6 +399,22 @@
         (check-children-dimensions new-parent (list 128 127)
                                    #'tree:frame-height)))))
 
+(define-matrix binary-split-h-child-placement ((direction :left :right))
+  (with-border-box-mocks ()
+    (let ((tree (make-tree-for-tests :width 155 :height 255)))
+      (multiple-value-bind (new-frame new-parent) (tree:split-frame-h tree :direction direction)
+        (declare (ignore new-frame))
+        (check-children-dimensions new-parent (list 0 77)
+                                   #'tree:frame-x)))))
+
+(define-matrix binary-split-v-child-placement ((direction :top :bottom))
+  (with-border-box-mocks ()
+    (let ((tree (make-tree-for-tests :width 155 :height 255)))
+      (multiple-value-bind (new-frame new-parent) (tree:split-frame-v tree :direction direction)
+        (declare (ignore new-frame))
+        (check-children-dimensions new-parent (list 0 128)
+                                   #'tree:frame-y)))))
+
 (defun split-frame-times (frame times split-fn)
   (with-border-box-mocks ()
     (multiple-value-bind (new-frame parent) (funcall split-fn frame)


### PR DESCRIPTION
Both binary split functions place the second child at its own size rather than at the size of the first. When there's any odd width or height the children are misaligned or overlapping by 1px.

before:
<img width="1920" height="1080" alt="before_with_waybar" src="https://github.com/user-attachments/assets/7bc5dcff-fc47-4045-a92f-19b183a67d3a" />

after:
<img width="1920" height="1080" alt="after_with_waybar" src="https://github.com/user-attachments/assets/b6dcd10e-5717-44f4-b42d-303f691e0939" />

a simple reproduction is to press c-t s some amount of times without switching the frame, the error varies depending on your resolution

the background is swaybg which i fixed by correcting the name of a layer-shell variable that currently crashes displaying an error in the repl