### PR TITLE
tree: fix crash when unfocusing layer shell

### DIFF
--- a/lisp/tree/layer-shell.lisp
+++ b/lisp/tree/layer-shell.lisp
@@ -46,7 +46,10 @@
 (defmethod mark-frame-focused :after ((frame layer-shell-frame) seat)
   (hrt::layer-surface-focus (slot-value frame 'layer-shell) seat))
 
-(defmethod mark-frame-unfocused :after ((frame layer-shell-frame) seat)
+(defmethod unmark-frame-focused ((frame layer-shell-frame) seat)
+  (setf (slot-value frame 'focused) nil))
+
+(defmethod unmark-frame-focused :after ((frame layer-shell-frame) seat)
   (hrt::layer-surface-unfocus (slot-value frame 'layer-shell) seat))
 
 (defmethod frame-position ((frame layer-shell-frame))


### PR DESCRIPTION
Pressing C-t while a layer shell holds focus crashes with a missing method unmark-frame-focused, the function mark-frame-unfocused is not called anywhere so i think is a typo.

i use tofi for a menu application, if you use guix you can test with `guix shell tofi -- tofi-drun` just C-t after running it.

are you running rofi through xwayland? im kinda perplexed you didnt run into this