### PR TITLE
lisp: add stumpwm loadrc

### DIFF
--- a/doc/manual/configuration-files.org
+++ b/doc/manual/configuration-files.org
@@ -12,6 +12,24 @@ many other parts of the compositor.
 To skip loading the init file, you can pass =-q= or =--no-init-file=
 to Mahogany when starting it.
 
+*** Re-loading the Init File
+
+The init file can be loaded again without restarting Mahogany, using
+the =loadrc= command. It has no default keybinding, and is run from the
+=colon= prompt.
+
+Only the first load binds =mahogany::*initializing*= to true.
+Guard anything that should not run a second time with it,
+such as creating groups or launching startup programs:
+
+#+BEGIN_SRC lisp
+  (when mh::*initializing*
+    (uiop:launch-program "waybar"))
+#+END_SRC
+
+Re-loading adds and redefines, keybindings and commands that the init
+file no longer defines are still present until Mahogany is restarted.
+
 ** Authoring Init files
 
 Init files are composed of Common Lisp code, and should be formatted

--- a/lisp/main.lisp
+++ b/lisp/main.lisp
@@ -1,5 +1,9 @@
 (in-package #:mahogany)
 
+(defvar *initializing* nil
+  "Use this variable in your config file to run code that should only
+be executed once, when mahogany starts up and loads the config file.")
+
 (defun load-config-file (&optional (catch-errors nil))
   "Load the user's config file. Returns a values list: whether the file loaded (t if no
 rc files exist), the error if it didn't, and the config file that was
@@ -23,6 +27,19 @@ further up. "
         (progn
           (log-string :info "Did not find config file")
           (values t nil nil)))))
+
+(defcommand loadrc ()
+  (:documentation "Reload the config file")
+  (:method ()
+    (handler-case (load-config-file nil)
+      (error (c)
+        (log-string :error "Error loading config file: ~A" c)
+        (toast-message *compositor-state*
+                       (format nil "Error loading config file: ~A" c)
+                       :theme *message-error-theme*))
+      (:no-error (&rest args)
+        (declare (ignore args))
+        (toast-message *compositor-state* "config file loaded successfully.")))))
 
 (defun init-frame-border-styles ()
   (setf tree::*frame-focus-border-style*
@@ -95,7 +112,8 @@ further up. "
     (log-string :debug "Initialized mahogany state")
     (if (gethash 'no-init-file args)
         (log-string :info "Init file loading skipped")
-        (load-config-file))
+        (let ((*initializing* t))
+          (load-config-file)))
     (unwind-protect
          (hrt:server-start server)
       (log-string :debug "Cleaning up...")


### PR DESCRIPTION
stumpwm does not have a binding and also rc is kinda confusing, so i think mahogany could add a binding and change the name of the function to something more friendly, which is not currently in this commit.