### PR TITLE
lisp: Add ability to convert data in defcommand

### DIFF
--- a/lisp/command.lisp
+++ b/lisp/command.lisp
@@ -80,7 +80,7 @@ See the documentation for cl-interactive:define-command for more details.
 
 (defcommand colon (sequence
                    seat
-                   (cmd-line (:function read-command-name ": ")))
+                   (cmd-line (:function read-command-name :data ": ")))
   (:method (sequence seat (exec string))
     (let ((cmd (cl-interactive:find-command
                 cl-interactive:*default-command-database*

--- a/lisp/key-bindings.lisp
+++ b/lisp/key-bindings.lisp
@@ -1,7 +1,7 @@
 (in-package #:mahogany)
 
 (defcommand run-shell-command
-    ((shell-command (:function interactively-read-string "Exec: ")))
+    ((shell-command (:function interactively-read-string :data "Exec")))
   (:method ((exec string))
     (uiop:launch-program exec)))
 
@@ -63,14 +63,14 @@
       (state-focus-frame *compositor-state* (tree:frame-prev cur-frame) seat))))
 
 (defcommand gnew
-    ((name (:function interactively-read-string "Name")))
+    ((name (:function interactively-read-string :data "Name")))
   (:method ((name string))
     (mahogany-state-group-add
      *compositor-state*
      :group-name (if (string= name "") nil name))))
 
 (defcommand gnewbg
-    ((name (:function interactively-read-string "Name")))
+    ((name (:function interactively-read-string :data "Name")))
   (:method ((name string))
     (mahogany-state-group-add
      *compositor-state*


### PR DESCRIPTION
This was added to cl-interactive, so bump the version and adapt to the changes.

BREAKING: `defcommand` signature changed.

Closes #253.