### PR TITLE
Fix VT switching and layer surface teardown on output destroy

### DIFF
--- a/heart/include/hrt/hrt_layer_shell.h
+++ b/heart/include/hrt/hrt_layer_shell.h
@@ -17,6 +17,7 @@ struct hrt_layer_shell_surface {
     struct wlr_layer_surface_v1 *layer_surface;
     struct wlr_scene_layer_surface_v1 *scene_surface;
     struct hrt_output *output;
+    struct wl_list link;
     struct wlr_scene_tree *tree;
     bool mapped;
     const struct hrt_layer_shell_callbacks *callbacks;

--- a/heart/include/hrt/hrt_output.h
+++ b/heart/include/hrt/hrt_output.h
@@ -32,6 +32,8 @@ struct hrt_output {
 
     struct wlr_box usable_area;
 
+    struct wl_list layer_surfaces;
+
     struct wl_listener request_state;
     struct wl_listener frame;
     struct wl_listener destroy;

--- a/heart/include/layer_shell_impl.h
+++ b/heart/include/layer_shell_impl.h
@@ -21,4 +21,6 @@ bool hrt_layer_shell_init(struct hrt_server *server,
 
 void hrt_layer_shell_arrange_layers(struct hrt_output *output, bool emit_event);
 
+void hrt_layer_shell_output_destroy(struct hrt_output *output);
+
 #endif

--- a/heart/src/layer_shell.c
+++ b/heart/src/layer_shell.c
@@ -29,6 +29,9 @@ hrt_layer_shell_surface_create(struct wlr_layer_surface_v1 *surface,
 
     shell_surface->layer_surface = surface;
     shell_surface->callbacks     = server->layer_shell_callbacks;
+    // even though they are not in an output yet, the links have to be safe to
+    // remove, a surface can be destroyed before its even placed.
+    wl_list_init(&shell_surface->link);
 
     return shell_surface;
 }
@@ -76,6 +79,7 @@ void hrt_layer_shell_surface_place(struct hrt_layer_shell_surface *surface,
     surface->output                = output;
     surface->layer_surface->output = output->wlr_output;
     surface->tree                  = surface->scene_surface->tree;
+    wl_list_insert(&output->layer_surfaces, &surface->link);
 }
 
 void hrt_layer_shell_surface_set_output(
@@ -358,6 +362,7 @@ static void handle_node_destroy(struct wl_listener *listener, void *data) {
         hrt_layer_shell_arrange_layers(surface->output, true);
     }
 
+    wl_list_remove(&surface->link);
     wl_list_remove(&surface->events.scene_destroy.link);
     wl_list_remove(&surface->events.new_popup.link);
     wl_list_remove(&surface->events.unmap.link);
@@ -365,6 +370,14 @@ static void handle_node_destroy(struct wl_listener *listener, void *data) {
     wl_list_remove(&surface->events.commit.link);
 
     free(surface);
+}
+
+void hrt_layer_shell_output_destroy(struct hrt_output *output) {
+    struct hrt_layer_shell_surface *surface, *tmp;
+    wl_list_for_each_safe(surface, tmp, &output->layer_surfaces, link) {
+        // sends "closed" to the client and run unmap-then-destroy synchronously.
+        wlr_layer_surface_v1_destroy(surface->layer_surface);
+    }
 }
 
 void hrt_layer_shell_finish_init(struct hrt_layer_shell_surface *surface) {

--- a/heart/src/output.c
+++ b/heart/src/output.c
@@ -44,6 +44,10 @@ static void handle_output_destroy(struct wl_listener *listener, void *data) {
     struct hrt_server *server = output->server;
     wlr_log(WLR_DEBUG, "Output destroyed %s", output->wlr_output->name);
 
+    // close the layer surfaces raw pointers as well as the hrt_scene_output
+    // and the scene trees owned by it, while they are still valid.
+    hrt_layer_shell_output_destroy(output);
+
     if (output != server->fallback_output) {
         server->output_callback->output_removed(output);
     }
@@ -73,6 +77,7 @@ struct hrt_output *hrt_output_create(struct hrt_server *server,
     output->wlr_output        = wlr_output;
     output->server            = server;
     output->scene             = hrt_scene_output_create(server->scene_root);
+    wl_list_init(&output->layer_surfaces);
 
     // temp background color:
     // {0.730473, 0.554736, 0.665036, 1.000000} is really pretty.

--- a/lisp/group.lisp
+++ b/lisp/group.lisp
@@ -171,7 +171,7 @@ to match."
     (let* ((output-name (hrt:output-full-name output))
            (tree (gethash output-name output-map)))
       (remhash output-name output-map)
-      (when (equalp output-container (group-current-output group))
+      (when (equalp output (group-current-output group))
         (group-unfocus-frame group (mahogany-group-current-frame group) seat)
         (alexandria:when-let ((other-tree (%first-hash-table-value output-map)))
           (setf cur-frame (tree:find-first-leaf other-tree))))

--- a/lisp/state.lisp
+++ b/lisp/state.lisp
@@ -430,9 +430,10 @@ KEYMAP-CREATION-ERROR if the rules are invalid or malformed."
          (surface (gethash surface-ptr surfaces))
          (output-container (%find-output (hrt:layer-surface-output surface)
                                          state))
-         (removed-frame (tree::output-container-remove-layer-shell
-                         output-container surface)))
-    (when (eq (state-current-frame state) removed-frame)
+         (removed-frame (when output-container
+                          (tree::output-container-remove-layer-shell
+                           output-container surface))))
+    (when (and removed-frame (eq (state-current-frame state) removed-frame))
       (state-focus-frame state (mahogany-group-current-frame
                                 (state-current-group state))
                          (server-seat state)))


### PR DESCRIPTION
rationale from the commit messages:

lisp: Survive a layer surface unmapping after its output has been removed

VT switching with waybar running, currently throws with:

> Unhandled TYPE-ERROR: The value NIL is not of type
> 	MAHOGANY/TREE::OUTPUT-CONTAINER
> 	0: (MAHOGANY/TREE::OUTPUT-CONTAINER-REMOVE-LAYER-SHELL NIL
> 		#S(MAHOGANY/CORE:LAYER-SURFACE ...))
> 	1: (MAHOGANY::STATE-LAYER-SURFACE-REMOVE ...)
> 	2: ((LAMBDA (...) :IN "lisp/events.lisp"))
> 	9: (MAHOGANY/CORE:SERVER-START ...)

%find-output returns NIL when there's no output which throws the type error.

Fixing from mahogany-state-output-remove doesn't prevent unmapping
later. The client destroys the resource on its own schedule after the
closed event, so the unmap can arrive after the output is gone, and
unmapping without an output has to be a valid path.

https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_surface_v1:event:closed

> The closed event is sent by the compositor when the surface will no longer be shown.
> The output may have been destroyed or the user may have asked for it to be removed.
> Further changes to the surface will be ignored. The client should destroy the resource
> after receiving this event, and create a new surface if they so choose.

wlroots types/wlr_layer_shell_v1.c sets surface->output once at creation
and has no output.destroy listener, so the pointer is never cleared and
the surface is never told.

Only the removal needs a container, so we can skip it if there is none.

---

hrt: Close layer surfaces before their output is destroyed

surface->output is invalid after free(output) in handle_output_destroy
surface->scene_surface is invalid after wlr_scene_node_destroy in hrt_scene_output_destroy
surface->tree same as surface->scene_surface

Nothing clears any of them, and wlroots 0.20.2 has no output_destroy listener.

Before this commit, a VT switch while running waybar makes the destroy
handler hit the three stale pointers:

> Memory fault at #xFFFFFFFFFFFFFFF8
> 	1: hrt_output_position
> 	2: hrt_layer_shell_arrange_layers
> 	4: wl_signal_emit_mutable
> 	9: SERVER-START

That backtrace goes through handle_node_destroy, which already guards
with `if (surface->output)`. Nothing ever nulls the pointer, so it
passes on freed memory. handle_surface_commit dereferences
surface->output with no check at all. Closing the surfaces while the
output is still alive covers both, and is what sway does:

https://github.com/swaywm/sway/blob/1.12/sway/desktop/layer_shell.c#L500

wlr_layer_surface_v1_destroy sends closed and unmaps synchronously, so
each surface leaves the normal way while surface->output,
surface->scene_surface and surface->tree are all still valid.

hrt_output gains a layer_surfaces list, the link initialised in
_surface_create not _place, a surface can die before placement.

A per-surface destroy listener would fire too late, hrt_output_create
registers first and listeners run in insertion order.
