### PR TITLE
Fix compositor shutdown sequence when multiple outputs are present

### DIFF
--- a/lisp/heart/server.lisp
+++ b/lisp/heart/server.lisp
@@ -109,8 +109,8 @@ The order of execution is not guaranteed if multiple lambdas are added at the sa
 (defun server-finish (server)
   (hrt-event-loop-semaphore-close *workqueue-semaphore*)
   (setf *workqueue-semaphore* nil)
-  (setf *hrt-server* nil)
-  (hrt-server-finish server))
+  (hrt-server-finish server)
+  (setf *hrt-server* nil))
 
 (defun server-group-create (server)
   (declare (type cffi:foreign-pointer server))

--- a/lisp/ring-list/ring-list.lisp
+++ b/lisp/ring-list/ring-list.lisp
@@ -4,6 +4,7 @@
    #:make-ring-list
    #:ring-list
    #:ring-list-size
+   #:clear-list
    #:add-item
    #:add-item-prev
    #:remove-item
@@ -27,6 +28,11 @@
 (defstruct (ring-list (:constructor make-ring-list ()))
   (size 0 :type fixnum)
   (head nil :type (or null ring-item)))
+
+(defun clear-list (ring-list)
+  (declare (type ring-list ring-list))
+  (setf (ring-list-size ring-list) 0
+        (ring-list-head ring-list) nil))
 
 (defun add-item (ring-list item)
   "Add the given item to the head of the list"

--- a/lisp/state.lisp
+++ b/lisp/state.lisp
@@ -35,19 +35,41 @@
 (defun server-state-reset (state)
   (declare (type mahogany-state state))
   (with-accessors ((groups state-groups)
-                   (server state-server))
+                   (server state-server)
+                   (hidden-groups state-hidden-groups)
+                   (views state-views)
+                   (layer-surfaces state-layer-surfaces))
       state
     ;; Clear the current frame so that subsequent cleanup code
     ;; doesn't try to switch focus to an invalid frame:
     (setf (state-%current-frame state) nil)
-    (let ((scene-tree (hrt:hrt-server-scene-tree server))
-          (seat (hrt:hrt-server-seat server)))
-      (loop for g across groups
-            :do (destroy-mahogany-group g scene-tree seat)))
-    (setf groups (adjust-array groups 0 :fill-pointer 0))
+    ;; This kicks off the destruction sequence, which
+    ;; calls the various output and seat removal callbacks. At the end, we
+    ;; are left in a state where all hrt and wlroots based objects
+    ;; are invalid.
     (hrt:server-finish server)
     ;; The actual scene object is freed during hrt-server-finish:
-    (setf server nil)))
+    (setf server nil)
+    ;; Since we don't listen to the callbacks that destroy the
+    ;; infrastructure needed for groups to work, we just clear them
+    ;; out here. Do a bit of checking and logging to make sure
+    ;; everything that needed to be cleaned up was.
+    (flet ((clear-toplevel-tbl (table type)
+             (declare (type hash-table table)
+                      (type string type))
+             (let ((lst (list)))
+               (maphash (lambda (k v)
+                          (declare (ignore k))
+                          (push v lst))
+                        table)
+               (when lst
+                 (log-string :error "~A were orphaned: ~A~%" type lst)))
+             (clrhash table)))
+      (clear-toplevel-tbl views "views")
+      (clear-toplevel-tbl layer-surfaces "layer surfaces"))
+    (ring-list:clear-list hidden-groups)
+    (setf (state-%current-group state) nil)
+    (setf groups (adjust-array groups 0 :fill-pointer 0))))
 
 (defun server-stop (state)
   (declare (type mahogany-state state))


### PR DESCRIPTION
Instead of trying to dismantle the groups like we would normally, just reset the values to what they were before `server-state-init` was called. This works because the all required cleanup operations (except the ones relating to front end group objects) should have been called during the `hrt:server-finish` call.

The backend objects referenced by group objects will be invalid, but since we are removing them all groups anyways, this isn't a problem for now.