### PR TITLE
Fix VT switching crashes

### DIFF
--- a/heart/src/output.c
+++ b/heart/src/output.c
@@ -44,6 +44,10 @@ static void handle_output_destroy(struct wl_listener *listener, void *data) {
     struct hrt_server *server = output->server;
     wlr_log(WLR_DEBUG, "Output destroyed %s", output->wlr_output->name);
 
+    // take the output out of the scene first so nothing can enter a surface on it
+    wlr_scene_output_destroy(output->wlr_scene);
+    output->wlr_scene = nullptr;
+
     // close the layer surfaces raw pointers as well as the hrt_scene_output
     // and the scene trees owned by it, while they are still valid.
     hrt_layer_shell_output_destroy(output);

--- a/lisp/group.lisp
+++ b/lisp/group.lisp
@@ -150,9 +150,8 @@ to match."
       value)))
 
 (defun %group-current-output-node (group)
-  (let* ((cur-frame (mahogany-group-current-frame group))
-         (output-node (tree:find-root-frame cur-frame)))
-    output-node))
+  (alexandria:when-let ((cur-frame (mahogany-group-current-frame group)))
+    (tree:find-root-frame cur-frame)))
 
 (declaim (ftype (function (mahogany-group) (or null hrt:output)) group-current-output))
 (defun group-current-output (group)


### PR DESCRIPTION
heart: destroy the scene output first on teardown 

Switching VT multiple times hits a wlroots assert
but only with waybar, swaybg and a window open:

>  mahogany: types/output/output.c:401: wlr_output_finish:
>    Assertion `wl_list_empty(&output->events.bind.listener_list)' failed.

All three conditions are necessary and the first
switch always works fine.

Take the output out of the scene first so nothing
below can enter a surface on it, surfaces that
entered before the emit began are not affected,
their listeners were registered earlier and the
emission progress still reaches them.

---

lisp: let a group report it has no current output 

A layer surface arriving while there are no outputs
kills the session, switch VT with a notification visible:

>  Unhandled TYPE-ERROR: The value NIL is not of type
>    (OR MAHOGANY/TREE:FRAME MAHOGANY/TREE:OUTPUT-NODE)
>    0: (MAHOGANY/TREE:FIND-ROOT-FRAME NIL)
>    1: (MAHOGANY::%GROUP-CURRENT-OUTPUT-NODE ...)
>    2: (MAHOGANY::GROUP-CURRENT-OUTPUT ...)
>    3: (MAHOGANY::%GET-OR-AUTOASSIGN-OUTPUT ...)
>    4: (MAHOGANY::MAHOGANY-STATE-LAYER-SHELL-HANDLE ...)
>  unhandled condition in --disable-debugger mode, quitting

This is already handled everywhere, we only need
to guard the frame instead of the result.