### PR TITLE
log: Set default log output to *error-output*

### DIFF
--- a/lisp/log.lisp
+++ b/lisp/log.lisp
@@ -150,7 +150,7 @@ level is not high enough."
 (defun (setf log-colored) (enablep)
   (setf cl-ansi-text:*enabled* enablep))
 
-(defun log-init (&key (level *log-level*) (output *debug-io*) (color t))
+(defun log-init (&key (level *log-level*) (output *error-output*) (color t))
   "Initialize logging. Call this to setup colorized output, ect.
 It is not necessary to call this for logging to work properly, but coloring may be messed up.
 If *log-output-file* is changed, it is a good idea to call this function again.


### PR DESCRIPTION
This fixes several issues:
+ Colorized / non-colorized output is now correct
+ On my system, `*debug-io*` was getting placed somewhere strange on TTYs and couldn't be redirected to a file. This fixes that.