### PR TITLE
build: Add wrap files for hrt dependencies

### DIFF
--- a/heart/meson.build
+++ b/heart/meson.build
@@ -8,6 +8,7 @@ project(
     'warning_level=2',
     'werror=true',
   ],
+  meson_version: '>=1.1.0',
 )
 
 add_project_arguments(
@@ -26,10 +27,37 @@ wlroots_version = ['>=0.20.0', '<0.21.0']
 
 cairo          = dependency('cairo', required: true)
 pangocairo     = dependency('pangocairo', required: true)
-pixman         = dependency('pixman-1', required: true)
-wayland_server = dependency('wayland-server')
-wayland_protos = dependency('wayland-protocols', version: '>=1.14')
-xkbcommon      = dependency('xkbcommon')
+pixman         = dependency(
+  'pixman-1',
+  version: '>=0.43.0',
+  required: true
+)
+wayland_server = dependency(
+  'wayland-server',
+  version: '>=1.24',
+  fallback: 'wayland',
+  default_options: [
+    'tests=false',
+    'documentation=false'
+  ]
+)
+wayland_protos = dependency(
+  'wayland-protocols',
+  version: '>=1.47',
+  fallback: 'wayland-protocols',
+  default_options: ['tests=false'],
+)
+xkbcommon      = dependency(
+  'xkbcommon',
+  version: '>=1.8.0',
+  fallback: 'libxkbcommon',
+  default_options: [
+    'enable-tools=false',
+    'enable-x11=false',
+    'enable-docs=false',
+    'enable-xkbregistry=false'
+  ],
+)
 xcb            = dependency('xcb', required: get_option('xwayland'))
 wlroots        = dependency(
   ['wlroots-0.20', 'wlroots'],
@@ -48,7 +76,7 @@ if not wlroots.found()
   wlroots_conf = wlroots_proj.get_variable('conf_data')
   wlroots_has_xwayland = wlroots_conf.get('WLR_HAS_XWAYLAND') == 1
 else
-  wlroots_has_xwayland = wlroots.get_pkgconfig_variable('have_xwayland') == 'true'
+  wlroots_has_xwayland = wlroots.get_variable('have_xwayland') == 'true'
 endif
 
 

--- a/heart/protocols/meson.build
+++ b/heart/protocols/meson.build
@@ -3,13 +3,13 @@
 # Copyright Drew Default, GPL
 ####
 
-wl_protocol_dir = wayland_protos.get_pkgconfig_variable('pkgdatadir')
+wl_protocol_dir = wayland_protos.get_variable('pkgdatadir')
 wlr_protocol_dir = meson.current_source_dir()
 
 wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)
 if wayland_scanner_dep.found()
 	wayland_scanner = find_program(
-		wayland_scanner_dep.get_pkgconfig_variable('wayland_scanner'),
+		wayland_scanner_dep.get_variable('wayland_scanner'),
 		native: true,
 	)
 else

--- a/heart/subprojects/libxkbcommon.wrap
+++ b/heart/subprojects/libxkbcommon.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/xkbcommon/libxkbcommon.git
+revision = HEAD

--- a/heart/subprojects/wayland-protocols.wrap
+++ b/heart/subprojects/wayland-protocols.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://gitlab.freedesktop.org/wayland/wayland-protocols.git
+revision = HEAD

--- a/heart/subprojects/wayland.wrap
+++ b/heart/subprojects/wayland.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://gitlab.freedesktop.org/wayland/wayland.git
+revision = HEAD


### PR DESCRIPTION
Add facility to download unfulfilled dependencies for the heart project via meson's wrap files
+ Set the minimal versions required by wlroots in the heart build config so that meson finds those versions instead of the potentially out-of-date ones installed on the system.
+ Remove deprecated `get_pkgconfig_variable` call in meson files for the newer just `get_variable`
+ Add minimum meson version to 1.1.0: this probably could be way higher (I'm running 1.5.x), but it seems like the minimum version that makes the project compile.