### PR TITLE
Make timers accessible from lisp side

### DIFF
--- a/heart/include/hrt/hrt_event_loop.h
+++ b/heart/include/hrt/hrt_event_loop.h
@@ -13,6 +13,16 @@ enum hrt_event_mask {
     HRT_EVENT_ERROR    = WL_EVENT_ERROR
 };
 
+struct hrt_fd_semaphore {
+    int fd;
+    struct wl_event_source *event_source;
+};
+
+struct hrt_event_loop_timer {
+    struct wl_event_source *event_source;
+};
+
+typedef wl_event_loop_timer_func_t hrt_event_loop_timer_func_t;
 typedef wl_event_loop_fd_func_t hrt_event_loop_fd_func_t;
 
 struct wl_event_source *hrt_event_loop_add_fd(struct hrt_server *server, int fd,
@@ -21,11 +31,6 @@ struct wl_event_source *hrt_event_loop_add_fd(struct hrt_server *server, int fd,
                                               void *data);
 
 void hrt_event_loop_remove(struct wl_event_source *source);
-
-struct hrt_fd_semaphore {
-    int fd;
-    struct wl_event_source *event_source;
-};
 
 /**
  * Create a semaphore fd (via eventfd(2)), and call the provided function
@@ -50,5 +55,14 @@ bool hrt_event_loop_semaphore_decrement(struct hrt_fd_semaphore *fd);
  * Close the semaphore fd and remove it from the event loop.
  **/
 void hrt_event_loop_semaphore_close(struct hrt_fd_semaphore *fd);
+
+struct hrt_event_loop_timer *
+hrt_event_loop_timer_add(struct hrt_server *server,
+                         hrt_event_loop_timer_func_t callback);
+
+int hrt_event_loop_timer_update(struct hrt_event_loop_timer *timer,
+                                 int ms_delay);
+
+void hrt_event_loop_timer_destroy(struct hrt_event_loop_timer *timer);
 
 #endif

--- a/heart/src/event_loop.c
+++ b/heart/src/event_loop.c
@@ -78,3 +78,26 @@ void hrt_event_loop_semaphore_close(struct hrt_fd_semaphore *fd) {
     close(fd->fd);
     free(fd);
 }
+
+struct hrt_event_loop_timer *
+hrt_event_loop_timer_add(struct hrt_server *server,
+                         hrt_event_loop_timer_func_t callback) {
+  struct hrt_event_loop_timer *timer = calloc(1, sizeof(*timer));
+    if (!timer) {
+        return nullptr;
+    }
+    struct wl_event_loop *event_loop =
+        wl_display_get_event_loop(server->wl_display);
+    timer->event_source = wl_event_loop_add_timer(event_loop, callback, timer);
+    return timer;
+}
+
+int hrt_event_loop_timer_update(struct hrt_event_loop_timer *timer,
+                                int ms_delay) {
+    return wl_event_source_timer_update(timer->event_source, ms_delay);
+}
+
+void hrt_event_loop_timer_destroy(struct hrt_event_loop_timer *timer) {
+    hrt_event_loop_remove(timer->event_source);
+    free(timer);
+}

--- a/lisp/heart/hrt-bindings.lisp
+++ b/lisp/heart/hrt-bindings.lisp
@@ -490,7 +490,16 @@ Returns the view that was in the node."
   (+hrt-event-hangup+ 4)
   (+hrt-event-error+ 8))
 
-(cffi:defctype hrt-event-loop-fd-func-t :pointer)
+(cffi:defcstruct hrt-fd-semaphore
+  (fd :int)
+  (event-source :pointer #| (:struct wl-event-source) |#))
+
+(cffi:defcstruct hrt-event-loop-timer
+  (event-source :pointer #| (:struct wl-event-source) |#))
+
+(cffi:defctype hrt-event-loop-timer-func-t :pointer #| wl-event-loop-timer-func-t |#)
+
+(cffi:defctype hrt-event-loop-fd-func-t :pointer #| wl-event-loop-fd-func-t |#)
 
 #-HRT-DEBUG
 (declaim (inline hrt-event-loop-add-fd))
@@ -505,10 +514,6 @@ Returns the view that was in the node."
 (declaim (inline hrt-event-loop-remove))
 (cffi:defcfun ("hrt_event_loop_remove" hrt-event-loop-remove) :void
   (source :pointer #| (:struct wl-event-source) |#))
-
-(cffi:defcstruct hrt-fd-semaphore
-  (fd :int)
-  (event-source :pointer #| (:struct wl-event-source) |#))
 
 #-HRT-DEBUG
 (declaim (inline hrt-event-loop-semaphore-add))
@@ -537,6 +542,23 @@ whenever the semaphore is non-zero."
 (cffi:defcfun ("hrt_event_loop_semaphore_close" hrt-event-loop-semaphore-close) :void
   "Close the semaphore fd and remove it from the event loop."
   (fd (:pointer (:struct hrt-fd-semaphore))))
+
+#-HRT-DEBUG
+(declaim (inline hrt-event-loop-timer-add))
+(cffi:defcfun ("hrt_event_loop_timer_add" hrt-event-loop-timer-add) (:pointer (:struct hrt-event-loop-timer))
+  (server (:pointer (:struct hrt-server)))
+  (callback hrt-event-loop-timer-func-t))
+
+#-HRT-DEBUG
+(declaim (inline hrt-event-loop-timer-update))
+(cffi:defcfun ("hrt_event_loop_timer_update" hrt-event-loop-timer-update) :int
+  (timer (:pointer (:struct hrt-event-loop-timer)))
+  (ms-delay :int))
+
+#-HRT-DEBUG
+(declaim (inline hrt-event-loop-timer-destroy))
+(cffi:defcfun ("hrt_event_loop_timer_destroy" hrt-event-loop-timer-destroy) :void
+  (timer (:pointer (:struct hrt-event-loop-timer))))
 
 ;; next section imported from file heart/include/hrt/hrt_layer_shell.h
 

--- a/lisp/heart/hrt-bindings.lisp
+++ b/lisp/heart/hrt-bindings.lisp
@@ -497,7 +497,16 @@ Returns the view that was in the node."
   (+hrt-event-hangup+ 4)
   (+hrt-event-error+ 8))
 
-(cffi:defctype hrt-event-loop-fd-func-t :pointer)
+(cffi:defcstruct hrt-fd-semaphore
+  (fd :int)
+  (event-source :pointer #| (:struct wl-event-source) |#))
+
+(cffi:defcstruct hrt-event-loop-timer
+  (event-source :pointer #| (:struct wl-event-source) |#))
+
+(cffi:defctype hrt-event-loop-timer-func-t :pointer #| wl-event-loop-timer-func-t |#)
+
+(cffi:defctype hrt-event-loop-fd-func-t :pointer #| wl-event-loop-fd-func-t |#)
 
 #-HRT-DEBUG
 (declaim (inline hrt-event-loop-add-fd))
@@ -512,10 +521,6 @@ Returns the view that was in the node."
 (declaim (inline hrt-event-loop-remove))
 (cffi:defcfun ("hrt_event_loop_remove" hrt-event-loop-remove) :void
   (source :pointer #| (:struct wl-event-source) |#))
-
-(cffi:defcstruct hrt-fd-semaphore
-  (fd :int)
-  (event-source :pointer #| (:struct wl-event-source) |#))
 
 #-HRT-DEBUG
 (declaim (inline hrt-event-loop-semaphore-add))
@@ -544,6 +549,23 @@ whenever the semaphore is non-zero."
 (cffi:defcfun ("hrt_event_loop_semaphore_close" hrt-event-loop-semaphore-close) :void
   "Close the semaphore fd and remove it from the event loop."
   (fd (:pointer (:struct hrt-fd-semaphore))))
+
+#-HRT-DEBUG
+(declaim (inline hrt-event-loop-timer-add))
+(cffi:defcfun ("hrt_event_loop_timer_add" hrt-event-loop-timer-add) (:pointer (:struct hrt-event-loop-timer))
+  (server (:pointer (:struct hrt-server)))
+  (callback hrt-event-loop-timer-func-t))
+
+#-HRT-DEBUG
+(declaim (inline hrt-event-loop-timer-update))
+(cffi:defcfun ("hrt_event_loop_timer_update" hrt-event-loop-timer-update) :int
+  (timer (:pointer (:struct hrt-event-loop-timer)))
+  (ms-delay :int))
+
+#-HRT-DEBUG
+(declaim (inline hrt-event-loop-timer-destroy))
+(cffi:defcfun ("hrt_event_loop_timer_destroy" hrt-event-loop-timer-destroy) :void
+  (timer (:pointer (:struct hrt-event-loop-timer))))
 
 ;; next section imported from file heart/include/hrt/hrt_layer_shell.h
 

--- a/lisp/heart/package.lisp
+++ b/lisp/heart/package.lisp
@@ -122,6 +122,11 @@
            #:server-start
            #:server-group-create
            #:hrt-server-stop
+           #:server-make-timer
+           #:timer-handle-update
+           #:timer-handle-destroy
+           #:timer-handle
+           #:timer-handle-data
            #:run-in-main-thread
            ;; Toast messages:
            #:toast-message

--- a/lisp/heart/package.lisp
+++ b/lisp/heart/package.lisp
@@ -123,6 +123,11 @@
            #:server-start
            #:server-group-create
            #:hrt-server-stop
+           #:server-make-timer
+           #:timer-handle-update
+           #:timer-handle-destroy
+           #:timer-handle
+           #:timer-handle-data
            #:run-in-main-thread
            ;; Toast messages:
            #:toast-message

--- a/lisp/heart/server.lisp
+++ b/lisp/heart/server.lisp
@@ -11,6 +11,10 @@ constructs that need a reference to it.")
 (declaim (type (or null cffi:foreign-pointer) *workqueue-semaphore*))
 (defparameter *workqueue-semaphore* nil)
 
+(declaim (type hash-table *timer-table*))
+(mahogany/util::defglobal *timer-table* (make-hash-table)
+    "Table holding the pending timers")
+
 #-ATOMICS-CAS-SPECIAL-VAR
 (error "Lisp implementation does not have support for required CAS operation")
 
@@ -40,6 +44,7 @@ constructs that need a reference to it.")
     ()
   (declare (ignore fd data))
   (flet ((run-with-restarts (func)
+           (declare (type function func))
            (restart-case (funcall func)
              (continue ()
                :report "Continue executing, ignoring the error"))))
@@ -74,6 +79,44 @@ The order of execution is not guaranteed if multiple lambdas are added at the sa
   ;; get woken up too early:
   (cas-enque *work-queue* func)
   (hrt-event-loop-semaphore-increment *workqueue-semaphore* 1))
+
+(defstruct (timer-handle
+            (:constructor make-timer-handle (handle callback data)))
+  (handle nil :type cffi:foreign-pointer :read-only t)
+  (callback nil :type (function (timer-handle) t) :read-only t)
+  (data nil))
+
+(define-hrt-callback timer-callback :int
+    ((data :pointer))
+    ()
+  (declare (inline gethash))
+  (let ((handle (gethash (cffi:pointer-address data) *timer-table*)))
+    (declare (type timer-handle handle))
+    (mahogany/log:log-string :trace "timer callback called: ~S" handle)
+    (funcall (timer-handle-callback handle) handle)))
+
+(defun server-make-timer (server callback &optional data)
+  (let* ((timer
+           (hrt-event-loop-timer-add server (cffi:callback timer-callback)))
+         (handle (make-timer-handle timer callback data)))
+    (setf (gethash (cffi:pointer-address timer) *timer-table*)
+          handle)
+    handle))
+
+(defun timer-handle-update (handle msec-delay)
+  (declare (type timer-handle handle))
+  (let ((result
+          (hrt-event-loop-timer-update (timer-handle-handle handle)
+                                       msec-delay)))
+    (if (< 0 result)
+        t
+        nil)))
+
+(defun timer-handle-destroy (handle)
+  (declare (type timer-handle handle))
+  (let ((timer-handle (timer-handle-handle handle)))
+    (remhash (cffi:pointer-address timer-handle) *timer-table*)
+    (hrt-event-loop-timer-destroy timer-handle)))
 
 (declaim (inline %hrt-server))
 (defun %hrt-server ()

--- a/lisp/heart/server.lisp
+++ b/lisp/heart/server.lisp
@@ -11,6 +11,10 @@ constructs that need a reference to it.")
 (declaim (type (or null cffi:foreign-pointer) *workqueue-semaphore*))
 (defparameter *workqueue-semaphore* nil)
 
+(declaim (type hash-table *timer-table*))
+(mahogany/util::defglobal *timer-table* (make-hash-table)
+    "Table holding the pending timers")
+
 #-ATOMICS-CAS-SPECIAL-VAR
 (error "Lisp implementation does not have support for required CAS operation")
 
@@ -40,6 +44,7 @@ constructs that need a reference to it.")
     ()
   (declare (ignore fd data))
   (flet ((run-with-restarts (func)
+           (declare (type function func))
            (restart-case (funcall func)
              (continue ()
                :report "Continue executing, ignoring the error"))))
@@ -74,6 +79,45 @@ The order of execution is not guaranteed if multiple lambdas are added at the sa
   ;; get woken up too early:
   (cas-enque *work-queue* func)
   (hrt-event-loop-semaphore-increment *workqueue-semaphore* 1))
+
+(defstruct (timer-handle
+            (:constructor make-timer-handle (handle callback data)))
+  (handle nil :type cffi:foreign-pointer :read-only t)
+  (callback nil :type (function (timer-handle) t) :read-only t)
+  (data nil))
+
+(define-hrt-callback timer-callback :int
+    ((data :pointer))
+    ()
+  (declare (inline gethash))
+  (let ((handle (gethash (cffi:pointer-address data) *timer-table*)))
+    (declare (type timer-handle handle))
+    (mahogany/log:log-string :trace "timer callback called: ~S" handle)
+    (funcall (timer-handle-callback handle) handle)
+    0))
+
+(defun server-make-timer (server callback &optional data)
+  (let* ((timer
+           (hrt-event-loop-timer-add server (cffi:callback timer-callback)))
+         (handle (make-timer-handle timer callback data)))
+    (setf (gethash (cffi:pointer-address timer) *timer-table*)
+          handle)
+    handle))
+
+(defun timer-handle-update (handle msec-delay)
+  (declare (type timer-handle handle))
+  (let ((result
+          (hrt-event-loop-timer-update (timer-handle-handle handle)
+                                       msec-delay)))
+    (if (< 0 result)
+        t
+        nil)))
+
+(defun timer-handle-destroy (handle)
+  (declare (type timer-handle handle))
+  (let ((timer-handle (timer-handle-handle handle)))
+    (remhash (cffi:pointer-address timer-handle) *timer-table*)
+    (hrt-event-loop-timer-destroy timer-handle)))
 
 (declaim (inline %hrt-server))
 (defun %hrt-server ()


### PR DESCRIPTION
Add `hrt_event_loop_timer` (hrt) and `timer-handle` (lisp) structs. These wrappers allow us to associate data as well as callback information to the callback. `hrt_event_loop_timer` gives us a stable pointer that we can use to lookup the data on the lisp side, and `timer-handle` contains that data.