### PR TITLE
Fix some crashes

### DIFF
--- a/heart/include/hrt/hrt_layer_shell.h
+++ b/heart/include/hrt/hrt_layer_shell.h
@@ -55,6 +55,14 @@ enum hrt_layer_shell_keyboard_interactivity {
  */
 void hrt_layer_shell_surface_abort(struct hrt_layer_shell_surface *surface);
 
+/**
+ * Send the layer surface the `closed` event and take it down.
+ * `closed` means the surface will no longer be shown and further changes
+ * to it are ignored, so the surface is unmapped and freed.
+ * The client wlr_layer_surface destroy is up for the client to handle once it sees the event.
+ */
+void hrt_layer_surface_close(struct hrt_layer_shell_surface *surface);
+
 struct hrt_output *
 hrt_layer_surface_output(struct hrt_layer_shell_surface *layer_shell);
 

--- a/heart/src/layer_shell.c
+++ b/heart/src/layer_shell.c
@@ -41,6 +41,10 @@ void hrt_layer_shell_surface_abort(struct hrt_layer_shell_surface *surface) {
     free(surface);
 }
 
+void hrt_layer_surface_close(struct hrt_layer_shell_surface *surface) {
+    wlr_layer_surface_v1_destroy(surface->layer_surface);
+}
+
 static void handle_new_layer_surface(struct wl_listener *listener, void *data) {
     wlr_log(WLR_DEBUG, "New layer surface");
     struct wlr_layer_surface_v1 *layer_surface = data;

--- a/lisp/group.lisp
+++ b/lisp/group.lisp
@@ -275,20 +275,29 @@ to match."
                 (go :top)))))))
 
 (defun %maximize-frame (group frame)
+  "Maximize FRAME. Returns NIL if FRAME is already the topmost frame in its tree"
   (declare (type mahogany-group group))
+  (when (tree:topmost-frame-p frame)
+    (return-from %maximize-frame nil))
   (let ((topmost-frame (mahogany/tree:find-topmost-frame frame)))
     (flet ((hide-and-disable (view-frame)
              (alexandria:when-let ((view (tree:frame-view view-frame)))
                (%add-hidden (mahogany-group-hidden-views group) view))))
       (tree:replace-frame topmost-frame frame #'hide-and-disable)))
-  (hrt:dirty-view-transaction))
+  (hrt:dirty-view-transaction)
+  t)
 
 (defun group-maximize-current-frame (group)
   "Remove all of the splits in the current window tree and replae it with the
 currently focused frame"
   (declare (type mahogany-group group))
   (let ((current-frame (mahogany-group-current-frame group)))
-    (%maximize-frame group current-frame)))
+    (unless current-frame
+      (error 'mahogany/util:invalid-operation
+             :text "No frame to maximize!"))
+    (unless (%maximize-frame group current-frame)
+      (error 'mahogany/util:invalid-operation
+             :text "Frame is already maximized!"))))
 
 (defstruct (%hidden-view-info (:constructor %make-hidden-view-info (output frame)))
   (output nil :type tree:output-node :read-only t)

--- a/lisp/heart/hrt-bindings.lisp
+++ b/lisp/heart/hrt-bindings.lisp
@@ -588,6 +588,15 @@ whenever the semaphore is non-zero."
   (surface (:pointer (:struct hrt-layer-shell-surface))))
 
 #-HRT-DEBUG
+(declaim (inline hrt-layer-surface-close))
+(cffi:defcfun ("hrt_layer_surface_close" hrt-layer-surface-close) :void
+  "Send the layer surface the `closed` event and take it down.
+`closed` means the surface will no longer be shown and further changes
+to it are ignored and the surface is unmapped and freed.
+The client wlr_layer_surface destroy is up for the client to handle once it sees the event."
+  (surface (:pointer (:struct hrt-layer-shell-surface))))
+
+#-HRT-DEBUG
 (declaim (inline hrt-layer-surface-output))
 (cffi:defcfun ("hrt_layer_surface_output" %hrt-layer-surface-output) (:pointer (:struct hrt-output))
   (layer-shell (:pointer (:struct hrt-layer-shell-surface))))

--- a/lisp/heart/layer-shell.lisp
+++ b/lisp/heart/layer-shell.lisp
@@ -41,6 +41,12 @@
                                  (hrt:output-hrt-output output)))
 
 #-HRT-DEBUG
+(declaim (inline layer-surface-close))
+(defun layer-surface-close (layer-surface)
+  (declare (type layer-surface layer-surface))
+  (hrt-layer-surface-close (layer-surface-hrt-layer-surface layer-surface)))
+
+#-HRT-DEBUG
 (declaim (inline layer-surface-focus))
 (defun layer-surface-focus (layer-surface seat)
   (declare (type layer-surface layer-surface))

--- a/lisp/heart/package.lisp
+++ b/lisp/heart/package.lisp
@@ -162,6 +162,7 @@
            #:hrt-layer-surface-output
            #:layer-surface
            #:layer-surface-keyboard-interactivity
+           #:layer-surface-close
            #:layer-surface-position
            #:layer-surface-dimensions
            #:layer-changed

--- a/lisp/key-bindings.lisp
+++ b/lisp/key-bindings.lisp
@@ -35,8 +35,8 @@
 (defcommand close-current-view ()
   (:method ()
     (let ((frame (state-current-frame *compositor-state*)))
-      (alexandria:when-let ((view (mahogany/tree:frame-view frame)))
-        (hrt:view-request-close view)))))
+      (when frame
+        (tree:close-frame frame)))))
 
 (defcommand next-view ()
   (:documentation "Raise the next hidden view in the current group")

--- a/lisp/tree/layer-shell.lisp
+++ b/lisp/tree/layer-shell.lisp
@@ -19,6 +19,9 @@
             :type boolean))
   (:documentation "Frame tree node that contains a layer shell surface"))
 
+(defmethod close-frame ((frame layer-shell-frame))
+  (hrt:layer-surface-close (slot-value frame 'layer-shell)))
+
 (defmethod split-frame-h ((frame layer-shell-frame) &key &allow-other-keys)
   (declare (ignore frame))
   (error 'mahogany/util:invalid-operation

--- a/lisp/tree/layer-shell.lisp
+++ b/lisp/tree/layer-shell.lisp
@@ -19,6 +19,16 @@
             :type boolean))
   (:documentation "Frame tree node that contains a layer shell surface"))
 
+(defmethod split-frame-h ((frame layer-shell-frame) &key &allow-other-keys)
+  (declare (ignore frame))
+  (error 'mahogany/util:invalid-operation
+         :text "Cannot split layer shell frames!"))
+
+(defmethod split-frame-v ((frame layer-shell-frame) &key &allow-other-keys)
+  (declare (ignore frame))
+  (error 'mahogany/util:invalid-operation
+         :text "Cannot split layer shell frames!"))
+
 (defmethod in-frame-p ((frame layer-shell-frame) x y)
   (let ((shell (slot-value frame 'layer-shell)))
     (multiple-value-bind (frame-x frame-y)

--- a/lisp/tree/output-node.lisp
+++ b/lisp/tree/output-node.lisp
@@ -85,6 +85,10 @@ view, if there was one."
   (alexandria:when-let ((data (output-node-fullscreen frame)))
     (%fullscreen-data-view data)))
 
+(defmethod close-frame ((frame output-node))
+  (alexandria:when-let ((view (frame-view frame)))
+    (hrt:view-request-close view)))
+
 (defmethod in-frame-p ((parent output-node) x y)
   ;; Use the dimensions and position of the output:
   (declare (type real x y))

--- a/lisp/tree/package.lisp
+++ b/lisp/tree/package.lisp
@@ -30,6 +30,7 @@
            #:poly-tree-frame
            #:split-frame-v
            #:split-frame-h
+           #:close-frame
            #:remove-frame
            #:swap-positions
            #:find-empty-frame

--- a/lisp/tree/tree-interface.lisp
+++ b/lisp/tree/tree-interface.lisp
@@ -41,6 +41,11 @@ of an already existing frame with the `set-split-frame-type` function")
             :type boolean))
   (:documentation "A frame that is positioned on an output"))
 
+(defgeneric close-frame (frame)
+  (:documentation "Close the surface held by this frame. Whether its a request
+depends on what the frame holds: an xdg toplevel is asked and can refuse,
+a layer shell surface cannot."))
+
 (defgeneric frame-prev (frame)
   (:documentation "Get the previous edge node in the tree from this node"))
 

--- a/lisp/tree/tree-interface.lisp
+++ b/lisp/tree/tree-interface.lisp
@@ -241,6 +241,9 @@ multiple values.")
   (:method ((frame frame))
     nil))
 
+(defmethod root-frame-p ((frame layer-container))
+  t)
+
 (defun topmost-frame-p (frame)
   "Return T if the frame is a child of a root node."
   (root-frame-p (frame-parent frame)))

--- a/lisp/tree/view.lisp
+++ b/lisp/tree/view.lisp
@@ -78,6 +78,10 @@ and position as the frame"
       (t
        (hrt:hrt-border-box-set-enabled border-box t)))))
 
+(defmethod close-frame ((frame view-frame))
+  (alexandria:when-let ((view (frame-view frame)))
+    (hrt:view-request-close view)))
+
 (defmethod mark-frame-focused :after ((frame view-frame) seat)
   (setf (slot-value frame 'seat) seat)
   (hrt:border-box-set-style (slot-value frame 'border-box) *frame-focus-border-style*)


### PR DESCRIPTION
tree: Fix layer shell frames crash on close and split 

close-current-view calls frame-view on the current frame,
layer-shell-frame has no frame-view method, i fixed it locally for now,
but maybe it should return NIL or signal something?

splitting is obviously a invalid operation and its called more directly,
so i raised invalid-operation.

---

group: Fix maximizing while in fullscreen crashes 

>  Command MAXIMIZE-CURRENT-FRAME signaled SB-PCL::NO-APPLICABLE-METHOD-ERROR:
>    There is no applicable method for the generic function
>      #<STANDARD-GENERIC-FUNCTION MAHOGANY/TREE:ROOT-FRAME-P (2)>
>    when called with arguments
>      (#<MAHOGANY/TREE:LAYER-CONTAINER :layer ... :children (#<OUTPUT-NODE
>        :fullscreen #S(%FULLSCREEN-DATA :VIEW #S(VIEW ...))>)>)

Theres two callers currently:

group-maximize-current-frame command passes the group's current frame

group-maximize-view from handle-view-maximize when a client sends
xdg_toplevel.set_maximized