### PR TITLE
Fix UAF and rename scene/node destroy to layer_surface

### DIFF
--- a/heart/include/hrt/hrt_layer_shell.h
+++ b/heart/include/hrt/hrt_layer_shell.h
@@ -26,7 +26,7 @@ struct hrt_layer_shell_surface {
         struct wl_listener map;
         struct wl_listener unmap;
         struct wl_listener new_popup;
-        struct wl_listener scene_destroy;
+        struct wl_listener layer_surface_destroy;
     } events;
 };
 

--- a/heart/src/layer_shell.c
+++ b/heart/src/layer_shell.c
@@ -357,7 +357,6 @@ static void handle_node_destroy(struct wl_listener *listener, void *data) {
     struct hrt_layer_shell_surface *surface =
         wl_container_of(listener, surface, events.scene_destroy);
 
-    scene_descriptor_destroy(&surface->tree->node, HRT_SCENE_DESC_LAYER_SHELL);
     if (surface->output) {
         hrt_layer_shell_arrange_layers(surface->output, true);
     }

--- a/heart/src/layer_shell.c
+++ b/heart/src/layer_shell.c
@@ -352,17 +352,18 @@ static void handle_new_popup(struct wl_listener *listener, void *data) {
     create_popup(wlr_popup, surface, surface->tree);
 }
 
-static void handle_node_destroy(struct wl_listener *listener, void *data) {
-    wlr_log(WLR_DEBUG, "layer shell surface node destroy");
+static void handle_layer_surface_destroy(struct wl_listener *listener,
+                                         void *data) {
+    wlr_log(WLR_DEBUG, "layer shell surface destroy");
     struct hrt_layer_shell_surface *surface =
-        wl_container_of(listener, surface, events.scene_destroy);
+        wl_container_of(listener, surface, events.layer_surface_destroy);
 
     if (surface->output) {
         hrt_layer_shell_arrange_layers(surface->output, true);
     }
 
     wl_list_remove(&surface->link);
-    wl_list_remove(&surface->events.scene_destroy.link);
+    wl_list_remove(&surface->events.layer_surface_destroy.link);
     wl_list_remove(&surface->events.new_popup.link);
     wl_list_remove(&surface->events.unmap.link);
     wl_list_remove(&surface->events.map.link);
@@ -392,9 +393,9 @@ void hrt_layer_shell_finish_init(struct hrt_layer_shell_surface *surface) {
     surface->events.new_popup.notify = handle_new_popup;
     wl_signal_add(&layer_surface->events.new_popup, &surface->events.new_popup);
 
-    surface->events.scene_destroy.notify = handle_node_destroy;
-    wl_signal_add(&surface->scene_surface->layer_surface->events.destroy,
-                  &surface->events.scene_destroy);
+    surface->events.layer_surface_destroy.notify = handle_layer_surface_destroy;
+    wl_signal_add(&surface->layer_surface->events.destroy,
+                  &surface->events.layer_surface_destroy);
 }
 
 struct hrt_output *

--- a/lisp/heart/hrt-bindings.lisp
+++ b/lisp/heart/hrt-bindings.lisp
@@ -554,7 +554,7 @@ whenever the semaphore is non-zero."
   (map (:struct wl-listener))
   (unmap (:struct wl-listener))
   (new-popup (:struct wl-listener))
-  (scene-destroy (:struct wl-listener)))
+  (layer-surface-destroy (:struct wl-listener)))
 
 (cffi:defcstruct hrt-layer-shell-surface
   (layer-surface :pointer #| (:struct wlr-layer-surface-v1) |#)


### PR DESCRIPTION
The ASan report shows that this event is actually layer_surface_destroy, but scene_descriptor_destroy is a node_destroy thing that only makes sense on sway that has that handler on the node, mahogany does not have that handler on layer surfaces at all and "handle_node_destroy" runs after the node is freed