### PR TITLE
heart: Initial touchpad support

### DIFF
--- a/cffi/hrt-bindings.yml
+++ b/cffi/hrt-bindings.yml
@@ -28,6 +28,7 @@ enum-constants:
     - window-gravity
     - hrt-border-style
     - hrt-layer-shell-keyboard-interactivity
+    - hrt-touchpad-state
 make-inline:
   - include:
       match: "hrt.*"

--- a/doc/manual/touchpad.org
+++ b/doc/manual/touchpad.org
@@ -1,0 +1,29 @@
+* Touchpad
+
+Mahogany can configure touchpads through libinput.
+
+  + =(config-system:set-config touchpad-tap-to-click value)= :: Whether
+    tapping the touchpad is a click: one finger left, two right, three
+    middle. Many touchpads ship with this disabled.
+    - =:default= :: /Default/ Use libinput default for each device.
+    - =t= :: Enable tap-to-click.
+    - =nil= :: Disable tap-to-click.
+  + =(config-system:set-config touchpad-disable-while-typing value)= :: Whether
+    the touchpad stops responding while you are typing. Touchpads that
+    do not support this are left alone.
+    - =:default= :: /Default/ Use libinput default for each device.
+    - =t= :: Ignore the touchpad while typing.
+    - =nil= :: Always respond to the touchpad.
+  + =(config-system:set-config touchpad-accel-speed speed)= :: Pointer
+    speed, from =-1= (slowest) through =0= to =1= (fastest). Defaults
+    to =nil=, which leaves libinput's own default, the same as =0=.
+
+  Setting a value back to =:default= (or =nil= for accel-speed) restores
+  libinput default for each device, so a setting can be undone
+  without restarting the compositor.
+
+#+BEGIN_SRC lisp
+  (config-system:set-config touchpad-tap-to-click t
+                            touchpad-disable-while-typing t
+                            touchpad-accel-speed 0.3)
+#+END_SRC

--- a/heart/include/hrt/hrt_input.h
+++ b/heart/include/hrt/hrt_input.h
@@ -14,6 +14,12 @@
 struct hrt_server;
 struct hrt_seat_callbacks;
 
+enum hrt_touchpad_state {
+    HRT_TOUCHPAD_DEFAULT  = 0,
+    HRT_TOUCHPAD_ENABLED  = 1,
+    HRT_TOUCHPAD_DISABLED = 2,
+};
+
 struct hrt_seat {
     struct hrt_server *server;
 
@@ -54,6 +60,13 @@ struct hrt_seat {
         struct wl_listener seat;
         struct wl_listener keyboard;
     } destroy;
+
+    struct {
+        enum hrt_touchpad_state tap;
+        enum hrt_touchpad_state dwt;
+        bool accel_set;
+        double accel;
+    } touchpad;
 };
 
 struct hrt_keypress_info {
@@ -128,6 +141,23 @@ bool hrt_seat_cursor_set_theme(struct hrt_seat *seat, char *theme_name,
  **/
 void hrt_seat_set_repeat_info(struct hrt_seat *seat, int32_t rate_hz,
                               int32_t delay_ms);
+
+void hrt_seat_set_touchpad_tap(struct hrt_seat *seat,
+                               enum hrt_touchpad_state state);
+
+void hrt_seat_set_touchpad_dwt(struct hrt_seat *seat,
+                               enum hrt_touchpad_state state);
+
+/**
+ * Pointer acceleration, from -1.0 (slowest) through 0.0 (libinput's default)
+ * to 1.0 (fastest).
+ **/
+void hrt_seat_set_touchpad_accel(struct hrt_seat *seat, double speed);
+
+/**
+ * Return the pointer acceleration to libinput's default for each device.
+ **/
+void hrt_seat_reset_touchpad_accel(struct hrt_seat *seat);
 
 double hrt_seat_cursor_lx(struct hrt_seat *seat);
 

--- a/heart/meson.build
+++ b/heart/meson.build
@@ -26,6 +26,7 @@ cc = meson.get_compiler('c')
 wlroots_version = ['>=0.20.0', '<0.21.0']
 
 cairo          = dependency('cairo', required: true)
+libinput       = dependency('libinput', required: true)
 pangocairo     = dependency('pangocairo', required: true)
 pixman         = dependency(
   'pixman-1',
@@ -106,6 +107,7 @@ subdir('src')
 
 hrt_deps = [
   cairo,
+  libinput,
   pangocairo,
   pixman,
   server_protos,

--- a/heart/src/input.c
+++ b/heart/src/input.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include "seat_impl.h"
 
+#include <wlr/backend/libinput.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_data_device.h>
@@ -24,8 +25,113 @@ static void add_new_keyboard(struct hrt_input *input, struct hrt_seat *seat) {
     }
 }
 
+static void log_config_status(struct libinput_device *ldev, const char *what,
+                              enum libinput_config_status status) {
+    if (status != LIBINPUT_CONFIG_STATUS_SUCCESS) {
+        wlr_log(WLR_ERROR, "Touchpad %s not applied to %s: %s", what,
+                libinput_device_get_name(ldev),
+                libinput_config_status_to_str(status));
+    }
+}
+
+static struct libinput_device *get_touchpad_device(struct wlr_input_device *dev) {
+    // Null for devices that don't come from libinput, headless, or nested.
+    if (!wlr_input_device_is_libinput(dev)) {
+        return nullptr;
+    }
+    struct libinput_device *ldev = wlr_libinput_get_device_handle(dev);
+    // libinput only configures tap on touchpads
+    // so this is null on a mouse or trackpoint
+    if (!ldev || libinput_device_config_tap_get_finger_count(ldev) == 0) {
+        return nullptr;
+    }
+    return ldev;
+}
+
+static enum libinput_config_tap_state tap_state(struct hrt_seat *seat,
+                                                struct libinput_device *ldev) {
+    switch (seat->touchpad.tap) {
+        case HRT_TOUCHPAD_ENABLED:
+            return LIBINPUT_CONFIG_TAP_ENABLED;
+        case HRT_TOUCHPAD_DISABLED:
+            return LIBINPUT_CONFIG_TAP_DISABLED;
+        case HRT_TOUCHPAD_DEFAULT:
+        default:
+            return libinput_device_config_tap_get_default_enabled(ldev);
+    }
+}
+
+static enum libinput_config_dwt_state dwt_state(struct hrt_seat *seat,
+                                                struct libinput_device *ldev) {
+    switch (seat->touchpad.dwt) {
+        case HRT_TOUCHPAD_ENABLED:
+            return LIBINPUT_CONFIG_DWT_ENABLED;
+        case HRT_TOUCHPAD_DISABLED:
+            return LIBINPUT_CONFIG_DWT_DISABLED;
+        case HRT_TOUCHPAD_DEFAULT:
+        default:
+            return libinput_device_config_dwt_get_default_enabled(ldev);
+    }
+}
+
+static void apply_touchpad_config(struct hrt_input *input) {
+    struct hrt_seat *seat        = input->seat;
+    struct libinput_device *ldev = get_touchpad_device(input->wlr_input_device);
+    if (!ldev) {
+        return;
+    }
+    log_config_status(ldev, "tap-to-click",
+                      libinput_device_config_tap_set_enabled(
+                          ldev, tap_state(seat, ldev)));
+    if (libinput_device_config_dwt_is_available(ldev)) {
+        log_config_status(ldev, "disable-while-typing",
+                          libinput_device_config_dwt_set_enabled(
+                              ldev, dwt_state(seat, ldev)));
+    }
+    if (libinput_device_config_accel_is_available(ldev)) {
+        double speed =
+            seat->touchpad.accel_set
+                ? seat->touchpad.accel
+                : libinput_device_config_accel_get_default_speed(ldev);
+        log_config_status(ldev, "acceleration",
+                          libinput_device_config_accel_set_speed(ldev, speed));
+    }
+}
+
+static void reapply_touchpad_config(struct hrt_seat *seat) {
+    struct hrt_input *input;
+    wl_list_for_each(input, &seat->inputs, link) {
+        apply_touchpad_config(input);
+    }
+}
+
+void hrt_seat_set_touchpad_tap(struct hrt_seat *seat,
+                               enum hrt_touchpad_state state) {
+    seat->touchpad.tap = state;
+    reapply_touchpad_config(seat);
+}
+
+void hrt_seat_set_touchpad_dwt(struct hrt_seat *seat,
+                               enum hrt_touchpad_state state) {
+    seat->touchpad.dwt = state;
+    reapply_touchpad_config(seat);
+}
+
+void hrt_seat_set_touchpad_accel(struct hrt_seat *seat, double speed) {
+    seat->touchpad.accel     = speed;
+    seat->touchpad.accel_set = true;
+    reapply_touchpad_config(seat);
+}
+
+void hrt_seat_reset_touchpad_accel(struct hrt_seat *seat) {
+    seat->touchpad.accel     = 0.0;
+    seat->touchpad.accel_set = false;
+    reapply_touchpad_config(seat);
+}
+
 static void add_new_pointer(struct hrt_input *input, struct hrt_seat *seat) {
     wlr_cursor_attach_input_device(seat->cursor, input->wlr_input_device);
+    apply_touchpad_config(input);
 }
 
 static uint32_t find_input_caps(struct hrt_seat *seat,

--- a/lisp/heart/hrt-bindings.lisp
+++ b/lisp/heart/hrt-bindings.lisp
@@ -6,9 +6,20 @@
 
 (cffi:defcstruct hrt-seat-callbacks)
 
+(cffi:defcenum hrt-touchpad-state
+  (:hrt-touchpad-default 0)
+  (:hrt-touchpad-enabled 1)
+  (:hrt-touchpad-disabled 2))
+
 (cffi:defcstruct hrt-seat-destroy
   (seat (:struct wl-listener))
   (keyboard (:struct wl-listener)))
+
+(cffi:defcstruct hrt-seat-touchpad
+  (tap hrt-touchpad-state)
+  (dwt hrt-touchpad-state)
+  (accel-set :bool)
+  (accel :double))
 
 (cffi:defcstruct hrt-seat
   (server (:pointer (:struct hrt-server)))
@@ -35,7 +46,8 @@
   (cursor-image (:pointer :char))
   (cursor-img-buf-len :size)
   (grabbed :bool)
-  (destroy (:struct hrt-seat-destroy)))
+  (destroy (:struct hrt-seat-destroy))
+  (touchpad (:struct hrt-seat-touchpad)))
 
 (cffi:defcstruct hrt-keypress-info
   (keysyms :pointer #| xkb-keysym-t |#)
@@ -101,6 +113,32 @@ and set the cursor image to the given image name."
   (seat (:pointer (:struct hrt-seat)))
   (rate-hz :int32)
   (delay-ms :int32))
+
+#-HRT-DEBUG
+(declaim (inline hrt-seat-set-touchpad-tap))
+(cffi:defcfun ("hrt_seat_set_touchpad_tap" hrt-seat-set-touchpad-tap) :void
+  (seat (:pointer (:struct hrt-seat)))
+  (state hrt-touchpad-state))
+
+#-HRT-DEBUG
+(declaim (inline hrt-seat-set-touchpad-dwt))
+(cffi:defcfun ("hrt_seat_set_touchpad_dwt" hrt-seat-set-touchpad-dwt) :void
+  (seat (:pointer (:struct hrt-seat)))
+  (state hrt-touchpad-state))
+
+#-HRT-DEBUG
+(declaim (inline hrt-seat-set-touchpad-accel))
+(cffi:defcfun ("hrt_seat_set_touchpad_accel" hrt-seat-set-touchpad-accel) :void
+  "Pointer acceleration, from -1.0 (slowest) through 0.0 (libinput's default)
+to 1.0 (fastest)."
+  (seat (:pointer (:struct hrt-seat)))
+  (speed :double))
+
+#-HRT-DEBUG
+(declaim (inline hrt-seat-reset-touchpad-accel))
+(cffi:defcfun ("hrt_seat_reset_touchpad_accel" hrt-seat-reset-touchpad-accel) :void
+  "Return the pointer acceleration to libinput's default for each device."
+  (seat (:pointer (:struct hrt-seat))))
 
 #-HRT-DEBUG
 (declaim (inline hrt-seat-cursor-set-theme))

--- a/lisp/heart/package.lisp
+++ b/lisp/heart/package.lisp
@@ -72,6 +72,11 @@
            #:hrt-seat-cursor-ly
            #:hrt-seat-set-keymap
            #:hrt-seat-set-repeat-info
+           #:hrt-touchpad-state
+           #:hrt-seat-set-touchpad-tap
+           #:hrt-seat-set-touchpad-dwt
+           #:hrt-seat-set-touchpad-accel
+           #:hrt-seat-reset-touchpad-accel
            ;; output symbols:
            #:output
            #:hrt-output

--- a/lisp/input.lisp
+++ b/lisp/input.lisp
@@ -81,6 +81,62 @@ Values:
            val)
   (:getter () *keyboard-repeat-delay*))
 
+(defglobal *touchpad-tap-to-click* :default)
+(defglobal *touchpad-disable-while-typing* :default)
+(defglobal *touchpad-accel-speed* nil)
+
+(deftype touchpad-state () '(member :default t nil))
+
+(defun %touchpad-state (val)
+  (declare (type touchpad-state val))
+  (ecase val
+    (:default :hrt-touchpad-default)
+    ((t) :hrt-touchpad-enabled)
+    ((nil) :hrt-touchpad-disabled)))
+
+(config-system:define-setf-config
+    (touchpad-tap-to-click :default :type touchpad-state)
+    "Whether tapping the touchpad is a click: one finger left, two right,
+three middle.
+
+Applies to every tap-capable touchpad, and to any plugged in later. :default
+goes back to libinput default for each device."
+  (:setter (val)
+           (setf *touchpad-tap-to-click* val)
+           (when (state-server *compositor-state*)
+             (hrt:hrt-seat-set-touchpad-tap (server-seat *compositor-state*)
+                                            (%touchpad-state val)))
+           val)
+  (:getter () *touchpad-tap-to-click*))
+
+(config-system:define-setf-config
+    (touchpad-disable-while-typing :default :type touchpad-state)
+    "Whether the touchpad stops responding while you are typing.
+
+Applies to every touchpad that supports it, and to any plugged in later.
+:default goes back to libinput default for each device."
+  (:setter (val)
+           (setf *touchpad-disable-while-typing* val)
+           (when (state-server *compositor-state*)
+             (hrt:hrt-seat-set-touchpad-dwt (server-seat *compositor-state*)
+                                            (%touchpad-state val)))
+           val)
+  (:getter () *touchpad-disable-while-typing*))
+
+(config-system:define-setf-config
+    (touchpad-accel-speed nil :type (or null (real -1 1)))
+    "Pointer speed for the touchpad, from -1 (slowest) through 0 to 1 (fastest).
+NIL goes back to libinput's default, which is the same as 0."
+  (:setter (val)
+           (setf *touchpad-accel-speed* val)
+           (when (state-server *compositor-state*)
+             (let ((seat (server-seat *compositor-state*)))
+               (if val
+                   (hrt:hrt-seat-set-touchpad-accel seat (float val 1.0d0))
+                   (hrt:hrt-seat-reset-touchpad-accel seat))))
+           val)
+  (:getter () *touchpad-accel-speed*))
+
 (defun %unkown-keybinding-message (key-state last)
   (declare (optimize (speed 3) (safety 0))
            (type key-state key-state)


### PR DESCRIPTION
We can make use of libinput heuristics for a default option instead of choosing between enabled/disabled.

#316 I think is basically asking for this, since this enables people on laptops to tap-to-click on the touchpad (which is great one handed)