### PR TITLE
Apply output layout configurations when outputs are added or removed

### DIFF
--- a/doc/manual/output-configuration.org
+++ b/doc/manual/output-configuration.org
@@ -55,9 +55,6 @@ configuration without that property.
 
 ** Configuring Output Layouts
 
-**Note: the functionality in this section is partially
-implemented and will not work as described.**
-
 When multiple outputs are present, you can use the
 =define-output-layout= macro to declare configurations that are only
 active when certain outputs are connected. This macro is similar to

--- a/heart/include/hrt/hrt_output.h
+++ b/heart/include/hrt/hrt_output.h
@@ -55,6 +55,9 @@ struct hrt_output_callbacks {
 bool hrt_output_init(struct hrt_output *output,
                      struct hrt_output_config *config);
 
+bool hrt_output_configure(struct hrt_output *output,
+                          struct hrt_output_config *config);
+
 /**
  * Get the effective output resolution of the output that can be used to
  * set the width and height of views.

--- a/heart/src/output.c
+++ b/heart/src/output.c
@@ -203,10 +203,9 @@ static void set_mode(struct wlr_output *output,
     wlr_output_state_set_mode(pending, best);
 }
 
-bool hrt_output_init(struct hrt_output *output,
-                     struct hrt_output_config *config) {
-    struct hrt_server *server     = output->server;
-    struct wlr_output *wlr_output = output->wlr_output;
+static struct wlr_output_layout_output *
+output_configure(struct hrt_server *server, struct wlr_output *wlr_output,
+                 struct hrt_output_config *config) {
     struct wlr_output_state state;
     wlr_output_state_init(&state);
     wlr_output_state_set_enabled(&state, true);
@@ -222,7 +221,7 @@ bool hrt_output_init(struct hrt_output *output,
     set_transform(&state);
 
     if (config && config->scale > 0) {
-        // The factional-scale-v1 protocol uses increments of 120ths to send
+        // The fractional-scale-v1 protocol uses increments of 120ths to send
         // the scale factor to the client. Adjust the scale so that we use the
         // same value as the clients'.
         wlr_output_state_set_scale(&state, round(config->scale * 120) / 120);
@@ -234,7 +233,7 @@ bool hrt_output_init(struct hrt_output *output,
     if (!wlr_output_commit_state(wlr_output, &state)) {
         // FIXME: Actually do some error handling instead of just logging:
         wlr_log(WLR_ERROR, "Output state could not be committed");
-        return false;
+        return nullptr;
     }
     wlr_output_state_finish(&state);
 
@@ -251,7 +250,22 @@ bool hrt_output_init(struct hrt_output *output,
         l_output =
             wlr_output_layout_add_auto(server->output_layout, wlr_output);
     }
-    assert(l_output != nullptr);
+    return l_output;
+}
+
+bool hrt_output_init(struct hrt_output *output,
+                     struct hrt_output_config *config) {
+    struct hrt_server *server     = output->server;
+    struct wlr_output *wlr_output = output->wlr_output;
+
+    struct wlr_output_layout_output *l_output =
+        output_configure(server, wlr_output, config);
+
+    if (!l_output) {
+        wlr_log(WLR_ERROR,
+                "Could not initialize output due to configuration error");
+        return false;
+    }
     struct wlr_scene_output *scene_output =
         wlr_scene_output_create(server->scene, wlr_output);
     wlr_scene_output_layout_add_output(server->scene_layout, l_output,
@@ -263,6 +277,22 @@ bool hrt_output_init(struct hrt_output *output,
     output->request_state.notify = handle_request_state;
     wl_signal_add(&wlr_output->events.request_state, &output->request_state);
 
+    return true;
+}
+
+bool hrt_output_configure(struct hrt_output *output,
+                          struct hrt_output_config *config) {
+    struct hrt_server *server     = output->server;
+    struct wlr_output *wlr_output = output->wlr_output;
+
+    struct wlr_output_layout_output *l_output =
+        output_configure(server, wlr_output, config);
+
+    if (!l_output) {
+        wlr_log(WLR_ERROR,
+                "Could not initialize output due to configuration error");
+        return false;
+    }
     return true;
 }
 

--- a/lisp/heart/hrt-bindings.lisp
+++ b/lisp/heart/hrt-bindings.lisp
@@ -287,6 +287,12 @@ the output will not be displayed.
   (config (:pointer (:struct hrt-output-config))))
 
 #-HRT-DEBUG
+(declaim (inline hrt-output-configure))
+(cffi:defcfun ("hrt_output_configure" hrt-output-configure) :bool
+  (output (:pointer (:struct hrt-output)))
+  (config (:pointer (:struct hrt-output-config))))
+
+#-HRT-DEBUG
 (declaim (inline hrt-output-resolution))
 (cffi:defcfun ("hrt_output_resolution" hrt-output-resolution) :void
   "Get the effective output resolution of the output that can be used to

--- a/lisp/heart/output.lisp
+++ b/lisp/heart/output.lisp
@@ -5,6 +5,12 @@
   (hrt-output (cffi:null-pointer) :type cffi:foreign-pointer :read-only t)
   (full-name "" :type string :read-only t))
 
+(defun output= (output1 output2)
+  (declare (type output output1 output2))
+  (cffi:pointer-eq
+   (output-hrt-output output1)
+   (output-hrt-output output2)))
+
 (defstruct output-config
   (scale 1 :type (or number null) :read-only t)
   (refresh-rate nil :type (or number null) :read-only t)
@@ -99,6 +105,18 @@
         (with-output-config (hrt-config config)
           (hrt-output-init hrt-output hrt-config))
         (hrt-output-init hrt-output (cffi:null-pointer)))))
+
+(defun output-configure (output config)
+  (declare (type output output)
+           (type (or null output-config) config))
+  (let ((hrt-output (output-hrt-output output)))
+    (mahogany/log:log-string
+           :info "Appyling configuration to output ~S: ~S"
+           (output-full-name output) config)
+    (if config
+        (with-output-config (hrt-config config)
+          (hrt-output-configure hrt-output hrt-config))
+        (hrt-output-configure hrt-output (cffi:null-pointer)))))
 
 (defun destroy-output (mh-output)
   (declare (ignore mh-output)))

--- a/lisp/heart/package.lisp
+++ b/lisp/heart/package.lisp
@@ -81,6 +81,7 @@
            #:output-init
            #:make-output-config
            #:output-config
+           #:output-config=
            #:output-config-merge
            #:hrt-keypress-info
            ;; output callbacks
@@ -88,6 +89,8 @@
            #:output-removed
            #:output-layout-changed
            ;; output methods:
+           #:output=
+           #:output-configure
            #:output-scene
            #:output-scene-layer
            #:output-resolution

--- a/lisp/objects.lisp
+++ b/lisp/objects.lisp
@@ -26,7 +26,9 @@
   (%prefix-key (kbd "C-t") :type key)
   (outputs (make-array 0 :element-type 'tree::output-container
                          :adjustable t :fill-pointer t)
-   :type (vector tree::output-container *))
+           :type (vector tree::output-container *))
+  (pending-output-timer nil
+                        :type (or null hrt:timer-handle))
   (groups (make-array 0 :element-type 'mahogany-group
                         :adjustable t :fill-pointer t)
    :type (vector mahogany-group *))

--- a/lisp/package.lisp
+++ b/lisp/package.lisp
@@ -1,7 +1,6 @@
 (defpackage #:mahogany/output-config
   (:use #:cl)
   (:export #:find-output-configurations
-           #:find-output-config
            #:define-output-config
            #:define-output-layout))
 
@@ -14,7 +13,6 @@
         #:mahogany/keyboard)
   (:import-from #:mahogany/output-config
                 #:find-output-configurations
-                #:find-output-config
                 #:define-output-config
                 #:define-output-layout)
   (:import-from #:cl-interactive/input-method

--- a/lisp/state.lisp
+++ b/lisp/state.lisp
@@ -141,29 +141,76 @@ the current group or a layer shell frame"
   (unless (key-state-active-p (state-key-state state))
     (server-keystate-reset state)))
 
+(defglobal *output-debounce-msec* 1)
+
+(defstruct pending-output-changes
+  (added nil :type list))
+
+(defun %get-output-list (pending-changes cur-outputs)
+  (declare (type vector cur-outputs)
+           (type pending-output-changes pending-changes))
+  (let* ((added (pending-output-changes-added pending-changes))
+         (all-outputs (append (map 'list
+                                   #'tree:output-container-output
+                                   cur-outputs)
+                              added)))
+    (values all-outputs added)))
+
+(defun %add-output (state mh-output output-config)
+  (let ((outputs (state-outputs state))
+        (groups (state-groups state))
+        (output-container (tree::make-output-container mh-output)))
+    (hrt:output-init mh-output output-config)
+    (vector-push-extend output-container outputs)
+    (loop for g across groups
+          do (group-add-output g output-container))))
+
+(defun process-output-changes (timer)
+  (declare (type hrt:timer-handle timer))
+  (hrt:timer-handle-destroy timer)
+  (setf (state-pending-output-timer *compositor-state*) nil)
+  (multiple-value-bind (full-list added)
+      (%get-output-list (hrt:timer-handle-data timer)
+                        (state-outputs *compositor-state*))
+    (log-string
+     :trace
+     "After configuration:~%~2TAdded: ~S~%~2T~%~2TAll: ~S"
+     added full-list)
+    (let ((configuration (find-output-configurations full-list)))
+      (maphash (lambda (output output-config)
+                 (if (find output added :test #'hrt:output=)
+                     (%add-output *compositor-state* output
+                                  output-config)
+                     (hrt:output-configure output
+                                           output-config)))
+               configuration))
+    (unless (state-%current-frame *compositor-state*)
+      (let ((cur-group (state-current-group *compositor-state*)))
+        (group-focus cur-group (server-seat *compositor-state*))
+        (setf (state-%current-frame *compositor-state*) (mahogany-group-current-frame cur-group))))))
+
+(defun %make-output-process-timer (state change-data)
+  (declare (type mahogany-state state))
+  (let ((timer (hrt:server-make-timer (state-server state)
+                                      #'process-output-changes
+                                      change-data)))
+    (hrt:timer-handle-update timer *output-debounce-msec*)
+    timer))
+
 (defun mahogany-state-output-add (state hrt-output)
   (declare (type mahogany-state state)
            (type cffi:foreign-pointer hrt-output))
-  (with-accessors ((outputs state-outputs)
-                   (groups state-groups)
-                   (scene mahogany-state-scene))
-      state
-    (let* ((mh-output (hrt:make-output hrt-output))
-           (output-container (tree::make-output-container mh-output)))
-      (log-string :debug "New output added ~S" (hrt:output-full-name mh-output))
-      ;; (mahogany/output-config::
-      (hrt:output-init mh-output
-                       (let ((output-match-data (find-output-config mh-output)))
-                         (if output-match-data
-                             (mahogany/output-config::output-match-data-config output-match-data)
-                             nil)))
-      (vector-push-extend output-container outputs)
-      (loop for g across groups
-            do (group-add-output g output-container))
-      (unless (state-%current-frame state)
-        (let ((cur-group (state-current-group state)))
-          (group-focus cur-group (server-seat state))
-        (setf (state-%current-frame state) (mahogany-group-current-frame cur-group)))))))
+  (let* ((mh-output (hrt:make-output hrt-output)))
+    (log-string :debug "New output added ~S" (hrt:output-full-name mh-output))
+    (alexandria:if-let ((timer (state-pending-output-timer state)))
+      (let ((data (hrt:timer-handle-data timer)))
+        (hrt:timer-handle-update timer *output-debounce-msec*)
+        (push mh-output (pending-output-changes-added data)))
+      (setf (state-pending-output-timer state)
+            (%make-output-process-timer
+             state
+             (make-pending-output-changes
+              :added (list mh-output)))))))
 
 (declaim (inline %find-output-container))
 (defun %find-output-container (hrt-output state)
@@ -188,19 +235,43 @@ or HRT-OUTPUT is NIL or a null pointer."
                    (groups state-groups)
                    (cur-frame state-%current-frame))
       state
+    ;; The output is now invalid, so remove it from the state.
+    ;; Leave the reconfiguring and re-arranging to the output configuration
+    ;; timer; as long as the output is destroyed, we can leave everything
+    ;; in place.
     (alexandria:if-let ((output-container (%find-output-container hrt-output state)))
       (let ((mh-output (tree::output-container-output output-container)))
         (log-string :debug "Output removed ~S" (hrt:output-full-name mh-output))
         (loop for g across groups
               do (group-remove-output g output-container (server-seat state)))
-        ;; TODO: Is there a better way to remove an item from a vector when we could know the index?
         (setf outputs (delete output-container outputs :test #'equalp))
-        (hrt:destroy-output mh-output))
+        (hrt:destroy-output mh-output)
+        ;; We could have removed the current frame, so
+        ;; change it unless a non-titled frame is focused.
+        ;; TODO: do this in the output configuration timer handler
+        ;;  so that if multiple outputs are removed at once,
+        ;;  we don't do more work than needed.
+        (unless (typep cur-frame 'tree:layer-container)
+          (setf cur-frame (mahogany-group-current-frame
+                           (state-current-group state))))
+        (when (and cur-frame (> (length outputs) 0))
+          (tree:mark-frame-focused cur-frame (server-seat state))))
       (log-string :error "Removed an output that was never added"))
-    (setf cur-frame (mahogany-group-current-frame
-                     (state-current-group state)))
-    (when (and cur-frame (> (length outputs) 0))
-      (tree:mark-frame-focused cur-frame (server-seat state)))))
+    ;; Start the timer:
+    (alexandria:if-let ((timer (state-pending-output-timer state)))
+      (let ((data (hrt:timer-handle-data timer)))
+        (hrt:timer-handle-update timer *output-debounce-msec*)
+        ;; We really shouldn't be using pointer-eq here,
+        ;;  but it appears to be the best choice right now
+        (alexandria:deletef (pending-output-changes-added data)
+                            hrt-output
+                            :test #'cffi:pointer-eq
+                            :key #'hrt:output-hrt-output))
+      (setf (state-pending-output-timer state)
+            (%make-output-process-timer
+             state
+             (make-pending-output-changes
+              :added (list)))))))
 
 (defun %next-group-name (index)
   (concatenate 'string "GROUP-" (write-to-string index)))


### PR DESCRIPTION
See #59. This makes the `define-output-layout` macro work fully, with the exception of mirrored outputs and enabling / disabling outputs.

One thing that is mentioned in that issue but isn't added yet is the use of the swapchain manager. Without this, we don't get atomic modesetting and there is one modeset per output instead of doing every output at once.

## How it works

This delays oncoming output configuration changes via a timer so that the compositor gets a complete picture of which outputs are available when starting up or anytime many changes occur at once.

When removing outputs, remove them from the state immediately, but don't shuffle around the focus until the timer expires. This is done because outputs are invalid as soon as we get the removal notification; we still wait for the timer to expire to move the focus and do any other shuffling we might need to do.

+ Add `output-config=` and `output=` to make finding and testing these objects easier.
+ Hide `find-output-config` from `mh/output-config` package, as `find-output-configurations` is fully sufficient for getting the information we need.