### PR TITLE
Fix output configuration problems

### DIFF
--- a/lisp/heart/output.lisp
+++ b/lisp/heart/output.lisp
@@ -14,6 +14,13 @@
   ;; a cons of (x . y)
   (position nil :type (or cons null) :read-only t))
 
+(defun output-config= (a b)
+  (and (equal (output-config-scale a) (output-config-scale b))
+       (equal (output-config-refresh-rate a) (output-config-refresh-rate b))
+       (eq (output-config-custom-mode a) (output-config-custom-mode b))
+       (equalp (output-config-dimensions a) (output-config-dimensions b))
+       (equalp (output-config-position a) (output-config-position b))))
+
 (defun output-config-merge (base override)
   (macrolet ((override-val (accessor)
                  `(if (,accessor override)
@@ -25,13 +32,13 @@
       (when (output-config-dimensions override)
         (setf dimensions (output-config-dimensions override)
               refresh-rate (output-config-refresh-rate override)
-              custom-mode (output-config-custom-mode override))
+              custom-mode (output-config-custom-mode override)))
       (make-output-config
        :scale (override-val output-config-scale)
        :position (override-val output-config-position)
        :dimensions dimensions
        :refresh-rate refresh-rate
-       :custom-mode custom-mode)))))
+       :custom-mode custom-mode))))
 
 (defun %transfer-output-config (hrt-config config)
   (declare (type output-config config))

--- a/lisp/output-config.lisp
+++ b/lisp/output-config.lisp
@@ -270,14 +270,15 @@ configurations"
       (let ((base (find-output-config o))
             (from-layout (alexandria:when-let
                              ((l (find o layout :key '%config-match-output)))
-                           (%config-match-config l))))
+                           (output-match-data-config (%config-match-config l)))))
         (cond
           ((and base from-layout)
            (setf (gethash o configurations)
-                 (hrt:output-config-merge base from-layout)))
+                 (hrt:output-config-merge
+                  (output-match-data-config base) from-layout)))
           (base
            (setf (gethash o configurations)
-                 base))
+                 (output-match-data-config base)))
           (from-layout
            (setf (gethash o configurations)
                  from-layout)))))

--- a/lisp/output-config.lisp
+++ b/lisp/output-config.lisp
@@ -281,5 +281,8 @@ configurations"
                  (output-match-data-config base)))
           (from-layout
            (setf (gethash o configurations)
-                 from-layout)))))
+                 from-layout))
+          (t
+           (setf (gethash o configurations)
+                 nil)))))
     configurations))

--- a/lisp/package.lisp
+++ b/lisp/package.lisp
@@ -1,6 +1,7 @@
 (defpackage #:mahogany/output-config
   (:use #:cl)
   (:export #:find-output-configurations
+           #:find-output-config
            #:define-output-config
            #:define-output-layout))
 
@@ -13,6 +14,7 @@
         #:mahogany/keyboard)
   (:import-from #:mahogany/output-config
                 #:find-output-configurations
+                #:find-output-config
                 #:define-output-config
                 #:define-output-layout)
   (:import-from #:cl-interactive/input-method

--- a/test/heart/output-tests.lisp
+++ b/test/heart/output-tests.lisp
@@ -5,20 +5,33 @@
 
 (in-package #:mahogany-tests/heart/output)
 
-(fiasco:deftest output-config-merge-handles-mode ()
-  (let* ((base (hrt:make-output-config
-                :scale 2
-                :refresh-rate 60
-                :custom-mode t
-                :dimensions (cons 600 600)
-                :position (cons 20 20)))
-         (override (hrt:make-output-config
-                    :dimensions (cons 1080 960)
-                    :refresh-rate 90))
-         (merged (hrt:output-config-merge base override)))
-    (is (equal (hrt::output-config-dimensions merged)
-               (cons 1080 960)))
-    (is (equal  (hrt::output-config-refresh-rate merged)
-                90))
-    (is (eq (hrt::output-config-custom-mode merged)
-            nil))))
+(defmacro define-output-config-merge-test (name default override expected)
+  (let ((def-symb (gensym "default"))
+        (override-symb (gensym "override"))
+        (expected-symb (gensym "expected")))
+    `(fiasco:deftest ,name ()
+       (let ((,def-symb (hrt:make-output-config ,@default))
+             (,override-symb (hrt:make-output-config ,@override))
+             (,expected-symb (hrt:make-output-config ,@expected)))
+         (let ((result (hrt:output-config-merge ,def-symb ,override-symb)))
+           (is (hrt::output-config= result ,expected-symb)))))))
+
+(define-output-config-merge-test output-config-merge-handles-mode
+	(:scale 2
+     :refresh-rate 60
+     :custom-mode t
+     :dimensions (cons 600 600)
+     :position (cons 20 20))
+  (:scale 1
+   :dimensions (cons 1080 960)
+   :refresh-rate 90)
+  (:scale 1
+   :dimensions (cons 1080 960)
+   :refresh-rate 90
+   :custom-mode nil
+   :position (cons 20 20)))
+
+(define-output-config-merge-test output-config-merge-basic
+    (:scale 1)
+  (:scale 2)
+  (:scale 2))

--- a/test/output-config-tests.lisp
+++ b/test/output-config-tests.lisp
@@ -100,7 +100,8 @@
 (defmacro define-layout-test (name args &body body)
   `(fiasco:deftest ,name ,args
      (with-mock-layout
-       ,@body)))
+       (with-mock-configurations
+         ,@body))))
 
 (define-layout-test define-output-layout-sets-priority ()
   (let ((layout (mh/output:define-output-layout ("name" 5)
@@ -221,6 +222,49 @@
 
 (define-layout-test find-output-configurations-no-layouts ()
   (with-output-properties ((output :name "output"))
-	(let* ((result (mh/output::find-output-configurations
+	(let* ((result (mh/output:find-output-configurations
 					(list output))))
 	  (is (= (hash-table-count result) 0)))))
+
+(define-layout-test find-output-configurations-merges ()
+  (mh/output:define-output-config "first"
+	"first"
+    (:scale 1))
+  (mh/output:define-output-config "second"
+	"second"
+    (:scale 1))
+  (mh/output:define-output-layout "first-second"
+    ("first"
+     (:scale 2))
+    ("second"))
+  (with-output-properties ((output-1 :name "first")
+                           (output-2 :name "second"))
+    (let ((result (mh/output:find-output-configurations
+                   (list output-1 output-2))))
+      (let ((output-1-result (gethash output-1 result)))
+        (is (hrt::output-config=
+             (hrt:make-output-config :scale 2)
+             output-1-result)))
+      (let ((output-2-result (gethash output-2 result)))
+        (is (hrt::output-config=
+             (hrt:make-output-config :scale 1)
+             output-2-result))))))
+
+(define-layout-test find-output-configurations-without-merges ()
+  (mh/output:define-output-layout "first-second"
+    ("first"
+     (:scale 2))
+    ("second"
+     (:scale 3)))
+  (with-output-properties ((output-1 :name "first")
+                           (output-2 :name "second"))
+    (let ((result (mh/output:find-output-configurations
+                   (list output-1 output-2))))
+      (let ((output-1-result (gethash output-1 result)))
+        (is (hrt::output-config=
+             (hrt:make-output-config :scale 2)
+             output-1-result)))
+      (let ((output-2-result (gethash output-2 result)))
+        (is (hrt::output-config=
+             (hrt:make-output-config :scale 3)
+             output-2-result))))))

--- a/test/output-config-tests.lisp
+++ b/test/output-config-tests.lisp
@@ -224,7 +224,10 @@
   (with-output-properties ((output :name "output"))
 	(let* ((result (mh/output:find-output-configurations
 					(list output))))
-	  (is (= (hash-table-count result) 0)))))
+	  (is (= (hash-table-count result) 1))
+      (multiple-value-bind (output-result found) (gethash output result)
+        (is found)
+        (is (null output-result))))))
 
 (define-layout-test find-output-configurations-merges ()
   (mh/output:define-output-config "first"


### PR DESCRIPTION
Add badly needed tests to the output configuration functions and fix the problems that they exposed.
+ `hrt:output-config-merge` wasn't always returning a value
+ type errors were occurring in `find-output-configurations` due to mixing output match objects and output config objects.
+ Make `find-output-configurations` return hash table include all outputs given to the function.