### PR TITLE
Rename `frame-view` and change how `close-current-view` works

### DIFF
--- a/lisp/group.lisp
+++ b/lisp/group.lisp
@@ -123,7 +123,7 @@
         (let ((first-leaf (tree:find-first-leaf new-tree)))
           (setf current-frame first-leaf)
           (alexandria:when-let ((spare (%pop-hidden-item hidden-views)))
-            (setf (tree:frame-view first-leaf) spare))))
+            (setf (tree:frame-surface first-leaf) spare))))
       (log-string :trace "Group map: ~S" output-map)
       new-tree)))
 
@@ -177,7 +177,7 @@ to match."
         (group-unfocus-frame group (mahogany-group-current-frame group) seat)
         (alexandria:when-let ((other-tree (%first-hash-table-value output-map)))
           (setf cur-frame (tree:find-first-leaf other-tree))))
-      (tree:remove-frame tree (lambda (x) (alexandria:when-let ((v (tree:frame-view x)))
+      (tree:remove-frame tree (lambda (x) (alexandria:when-let ((v (tree:frame-surface x)))
 				                            (%add-hidden hidden-views v)))))))
 
 (defun group-add-initialize-view (group view-ptr)
@@ -215,7 +215,7 @@ to match."
       (let* ((layer (mahogany-group-tiled-container group))
              (hrt-layer (tree:layer-container-layer layer)))
         (hrt:scene-layer-add-view hrt-layer view))
-      (alexandria:when-let ((to-hide (tree:frame-view current-frame)))
+      (alexandria:when-let ((to-hide (tree:frame-surface current-frame)))
         (%add-hidden hidden to-hide))
       (%swap-view-into-frame group current-frame view))))
 
@@ -224,7 +224,7 @@ to match."
   (dolist (tree (tree:tree-children (mahogany-group-tiled-container group)))
     ;; TODO: use foreach-leaf here:
     (dolist (f (mahogany/tree:get-populated-frames tree))
-      (when (equalp (tree:frame-view f) view)
+      (when (equalp (tree:frame-surface f) view)
         (funcall fn f)))))
 
 (defun group-unmap-view (group view)
@@ -249,11 +249,11 @@ to match."
                 (let ((to-focus (tree:find-focused-frame f)))
                   ;; Don't pull from the hidden list unless we land on an empty frame:
                   (when (and to-replace
-                             (not (tree:frame-view to-focus)))
-                    (setf (tree:frame-view to-focus) (%pop-hidden-item hidden)))
+                             (not (tree:frame-surface to-focus)))
+                    (setf (tree:frame-surface to-focus) (%pop-hidden-item hidden)))
                   (setf (mahogany-group-current-frame group) to-focus))))))
           (tree:view-frame
-           (setf (tree:frame-view f) nil)
+           (setf (tree:frame-surface f) nil)
            (when (> (ring-list:ring-list-size hidden) 0)
              (%swap-view-into-frame group f (%pop-hidden-item hidden)))))
         (hrt:dirty-view-transaction))
@@ -271,7 +271,7 @@ to match."
       (or
        (ring-list:remove-item hidden view)
        (alexandria:when-let ((f (tree:find-view-frame tiled-container view)))
-         (setf (tree:frame-view f) nil))))
+         (setf (tree:frame-surface f) nil))))
     (setf view-list (remove view view-list :test #'equalp))))
 
 (defmethod tree:find-empty-frame ((group mahogany-group))
@@ -291,7 +291,7 @@ to match."
     (return-from %maximize-frame nil))
   (let ((topmost-frame (mahogany/tree:find-topmost-frame frame)))
     (flet ((hide-and-disable (view-frame)
-             (alexandria:when-let ((view (tree:frame-view view-frame)))
+             (alexandria:when-let ((view (tree:frame-surface view-frame)))
                (%add-hidden (mahogany-group-hidden-views group) view))))
       (tree:replace-frame topmost-frame frame #'hide-and-disable)))
   (hrt:dirty-view-transaction)
@@ -326,7 +326,7 @@ currently focused frame"
     (ring-list:foreach-item (v hidden-views)
       (setf (gethash v hidden-set) t))
     (dolist (f (tree:get-populated-frames output-node))
-      (let ((v (tree:frame-view f)))
+      (let ((v (tree:frame-surface f)))
         (unless (gethash v hidden-set)
           (funcall add-fun hidden-views v)
           (hrt:view-set-hidden v t))
@@ -349,7 +349,7 @@ currently focused frame"
       (unless output-node
         (mahogany/log:log-string :warn "Could not find output when making view fullscreen")
         (return-from %group-make-fullscreen nil))
-      (setf (tree:frame-view frame) nil)
+      (setf (tree:frame-surface frame) nil)
       (let ((prev-fullscreen (tree:set-fullscreen output-node view)))
         (cond
           (prev-fullscreen
@@ -401,9 +401,9 @@ After this function is ran, the current frame needs to be set and focused."
        (%clear-fullscreen-state group frame)
        (let ((to-focus (tree:find-focused-frame frame)))
          (setf (mahogany-group-current-frame group) to-focus)
-         (alexandria:when-let ((prev (tree:frame-view to-focus)))
+         (alexandria:when-let ((prev (tree:frame-surface to-focus)))
            (%add-hidden (mahogany-group-hidden-views group) prev))
-         (setf (tree:frame-view to-focus) view)))
+         (setf (tree:frame-surface to-focus) view)))
       (t
        ;; We aren't doing anything; communicate that to the calling code
        nil))
@@ -441,15 +441,15 @@ After this function is ran, the current frame needs to be set and focused."
             (t
              (let ((to-focus (tree:find-focused-frame current-frame)))
                (setf (mahogany-group-current-frame group) to-focus)
-               (alexandria:when-let ((prev (tree:frame-view to-focus)))
+               (alexandria:when-let ((prev (tree:frame-surface to-focus)))
                  (%add-hidden (mahogany-group-hidden-views group) prev))
-               (setf (tree:frame-view to-focus) view)))))
+               (setf (tree:frame-surface to-focus) view)))))
          (tree:view-frame
           (when hidden-data
-            (setf (tree:frame-view (%hidden-view-info-frame hidden-data))
+            (setf (tree:frame-surface (%hidden-view-info-frame hidden-data))
                   nil)
             (remhash view (mahogany-group-hidden-view-map group)))
-          (setf (tree:frame-view current-frame) view))))))
+          (setf (tree:frame-surface current-frame) view))))))
   (hrt:dirty-view-transaction))
 
 (defun group-next-hidden (group)
@@ -458,7 +458,7 @@ After this function is ran, the current frame needs to be set and focused."
         (hidden-views (mahogany-group-hidden-views group))
         (next-view))
     (when (> (ring-list:ring-list-size hidden-views) 0)
-      (alexandria:if-let ((view (tree:frame-view current-frame)))
+      (alexandria:if-let ((view (tree:frame-surface current-frame)))
         (setf next-view (%swap-next-hidden hidden-views view))
         (setf next-view (%pop-hidden-item hidden-views)))
       (%swap-view-into-frame group current-frame next-view))))
@@ -469,7 +469,7 @@ After this function is ran, the current frame needs to be set and focused."
         (hidden-views (mahogany-group-hidden-views group))
         (next-view))
     (when (> (ring-list:ring-list-size hidden-views) 0)
-      (alexandria:if-let ((view (tree:frame-view current-frame)))
+      (alexandria:if-let ((view (tree:frame-surface current-frame)))
         (setf next-view (%swap-prev-hidden hidden-views view))
         (setf next-view (%pop-hidden-item hidden-views)))
       (%swap-view-into-frame group current-frame next-view))))
@@ -493,7 +493,7 @@ After this function is ran, the current frame needs to be set and focused."
   ;; attempt to stop abuse by only doing something
   ;; if the view is focused:
   (let* ((cur-frame (mahogany-group-current-frame group))
-         (cur-view (tree:frame-view cur-frame)))
+         (cur-view (tree:frame-surface cur-frame)))
     (if (equal cur-view view)
         (progn
           (log-string :trace "\"minimizing\" view ~S" view)

--- a/lisp/key-bindings.lisp
+++ b/lisp/key-bindings.lisp
@@ -34,9 +34,14 @@
 
 (defcommand close-current-view ()
   (:method ()
-    (let ((frame (state-current-frame *compositor-state*)))
-      (when frame
-        (tree:close-frame frame)))))
+    (alexandria:when-let*
+        ((frame (state-current-frame *compositor-state*))
+         (surface (tree:frame-surface frame)))
+      (typecase surface
+        (hrt:view
+         (hrt:view-request-close surface))
+        (hrt:layer-surface
+         (hrt:layer-surface-close surface))))))
 
 (defcommand next-view ()
   (:documentation "Raise the next hidden view in the current group")

--- a/lisp/tree/frame.lisp
+++ b/lisp/tree/frame.lisp
@@ -530,7 +530,7 @@ REMOVE-FUNC is called with one argument: the view that was removed."
 
 (defmethod find-empty-frame ((root frame))
   (foreach-leaf (frame root)
-    (unless (frame-view frame)
+    (unless (frame-surface frame)
       (return-from find-empty-frame frame))))
 
 (defun find-first-leaf (tree)
@@ -541,7 +541,7 @@ REMOVE-FUNC is called with one argument: the view that was removed."
   "Return a list of view-frames that contain views"
   (let ((populated nil))
     (foreach-leaf (l root)
-      (when (frame-view l)
+      (when (frame-surface l)
         (push l populated)))
     populated))
 

--- a/lisp/tree/layer-shell.lisp
+++ b/lisp/tree/layer-shell.lisp
@@ -2,6 +2,7 @@
 
 (defclass layer-shell-frame ()
   ((layer-shell :initarg :layer-shell
+                :reader frame-surface
                 :type hrt:layer-surface)
    (parent :initarg :parent
            :initform nil

--- a/lisp/tree/layer-shell.lisp
+++ b/lisp/tree/layer-shell.lisp
@@ -20,9 +20,6 @@
             :type boolean))
   (:documentation "Frame tree node that contains a layer shell surface"))
 
-(defmethod close-frame ((frame layer-shell-frame))
-  (hrt:layer-surface-close (slot-value frame 'layer-shell)))
-
 (defmethod split-frame-h ((frame layer-shell-frame) &key &allow-other-keys)
   (declare (ignore frame))
   (error 'mahogany/util:invalid-operation

--- a/lisp/tree/output-node.lisp
+++ b/lisp/tree/output-node.lisp
@@ -81,12 +81,12 @@ view, if there was one."
     (log-string :trace "fullscreen frame unfocused ~S" frame)
     (hrt:unfocus-view (%fullscreen-data-view data) seat)))
 
-(defmethod frame-view ((frame output-node))
+(defmethod frame-surface ((frame output-node))
   (alexandria:when-let ((data (output-node-fullscreen frame)))
     (%fullscreen-data-view data)))
 
 (defmethod close-frame ((frame output-node))
-  (alexandria:when-let ((view (frame-view frame)))
+  (alexandria:when-let ((view (frame-surface frame)))
     (hrt:view-request-close view)))
 
 (defmethod in-frame-p ((parent output-node) x y)

--- a/lisp/tree/package.lisp
+++ b/lisp/tree/package.lisp
@@ -49,7 +49,7 @@
            #:reconfigure-node
            ;; View-frame functions / objects
            #:view-frame
-           #:frame-view
+           #:frame-surface
            #:frame-next
            #:frame-prev
            #:frame-find-layer

--- a/lisp/tree/tree-interface.lisp
+++ b/lisp/tree/tree-interface.lisp
@@ -46,6 +46,9 @@ of an already existing frame with the `set-split-frame-type` function")
 depends on what the frame holds: an xdg toplevel is asked and can refuse,
 a layer shell surface cannot."))
 
+(defgeneric frame-surface (frame)
+  (:documentation "Get the client that is displayed within the frame"))
+
 (defgeneric frame-prev (frame)
   (:documentation "Get the previous edge node in the tree from this node"))
 

--- a/lisp/tree/tree-interface.lisp
+++ b/lisp/tree/tree-interface.lisp
@@ -41,11 +41,6 @@ of an already existing frame with the `set-split-frame-type` function")
             :type boolean))
   (:documentation "A frame that is positioned on an output"))
 
-(defgeneric close-frame (frame)
-  (:documentation "Close the surface held by this frame. Whether its a request
-depends on what the frame holds: an xdg toplevel is asked and can refuse,
-a layer shell surface cannot."))
-
 (defgeneric frame-surface (frame)
   (:documentation "Get the client that is displayed within the frame"))
 

--- a/lisp/tree/view.lisp
+++ b/lisp/tree/view.lisp
@@ -78,10 +78,6 @@ and position as the frame"
       (t
        (hrt:hrt-border-box-set-enabled border-box t)))))
 
-(defmethod close-frame ((frame view-frame))
-  (alexandria:when-let ((view (frame-surface frame)))
-    (hrt:view-request-close view)))
-
 (defmethod mark-frame-focused :after ((frame view-frame) seat)
   (setf (slot-value frame 'seat) seat)
   (hrt:border-box-set-style (slot-value frame 'border-box) *frame-focus-border-style*)

--- a/lisp/tree/view.lisp
+++ b/lisp/tree/view.lisp
@@ -10,7 +10,7 @@
 
 (defclass view-frame (frame)
   ((view :initarg :view
-         :accessor frame-view
+         :accessor frame-surface
          :initform nil
          :type (or hrt:view null)
          :documentation "The client of the frame")
@@ -63,7 +63,7 @@
 (defmethod (setf %frame-next) (next (frame view-frame))
   (setf (slot-value frame 'next) next))
 
-(defmethod (setf frame-view) :after (view (frame view-frame))
+(defmethod (setf frame-surface) :after (view (frame view-frame))
   "Place the view in the frame and make it have the same dimensions
 and position as the frame"
   (with-slots (border-box) frame
@@ -79,19 +79,19 @@ and position as the frame"
        (hrt:hrt-border-box-set-enabled border-box t)))))
 
 (defmethod close-frame ((frame view-frame))
-  (alexandria:when-let ((view (frame-view frame)))
+  (alexandria:when-let ((view (frame-surface frame)))
     (hrt:view-request-close view)))
 
 (defmethod mark-frame-focused :after ((frame view-frame) seat)
   (setf (slot-value frame 'seat) seat)
   (hrt:border-box-set-style (slot-value frame 'border-box) *frame-focus-border-style*)
-  (alexandria:when-let ((hrt-view (frame-view frame)))
+  (alexandria:when-let ((hrt-view (frame-surface frame)))
     (log-string :trace "view frame focused")
     (hrt:focus-view hrt-view seat)))
 
 (defmethod unmark-frame-focused :after ((frame view-frame) seat)
   (hrt:border-box-set-style (slot-value frame 'border-box) *frame-unfocus-border-style*)
-  (alexandria:when-let ((hrt-view (frame-view frame)))
+  (alexandria:when-let ((hrt-view (frame-surface frame)))
     (log-string :trace "view frame unfocused")
     (hrt:unfocus-view hrt-view seat))
   (setf (slot-value frame 'seat) nil))
@@ -106,58 +106,58 @@ and position as the frame"
 (defmethod (setf frame-x) :before (new-x (frame view-frame))
   (let ((round-x (round new-x))
         (round-y (round (frame-y frame))))
-    (when (frame-view frame)
-      (set-position (frame-view frame) round-x round-y))
+    (when (frame-surface frame)
+      (set-position (frame-surface frame) round-x round-y))
     (hrt:hrt-border-box-set-relative (slot-value frame 'border-box)
                                      round-x round-y)))
 
 (defmethod (setf frame-y) :before (new-y (frame view-frame))
   (let ((round-y (round new-y))
         (round-x (round (frame-x frame))))
-    (when (frame-view frame)
-      (set-position (frame-view frame) round-x round-y))
+    (when (frame-surface frame)
+      (set-position (frame-surface frame) round-x round-y))
     (hrt:hrt-border-box-set-relative (slot-value frame 'border-box)
                                      round-x round-y)))
 
 (defmethod set-dimensions :before ((frame view-frame) width height)
   (let ((w-adjusted (round width))
         (h-adjusted (round height)))
-    (when (frame-view frame)
-      (set-dimensions (frame-view frame) w-adjusted h-adjusted))
+    (when (frame-surface frame)
+      (set-dimensions (frame-surface frame) w-adjusted h-adjusted))
     (hrt:hrt-border-box-set-size (slot-value frame 'border-box)
                                  w-adjusted h-adjusted)))
 
 (defmethod set-position :before ((frame view-frame) x y)
   (let ((round-x (round x))
         (round-y (round y)))
-    (when (frame-view frame)
-      (set-position (frame-view frame) round-x round-y))
+    (when (frame-surface frame)
+      (set-position (frame-surface frame) round-x round-y))
     (hrt:hrt-border-box-set-relative (slot-value frame 'border-box)
                                      round-x round-y)))
 
 (defmethod (setf frame-width) :before (new-width (frame view-frame))
   (let ((round-width (round new-width))
         (round-height (round (frame-height frame))))
-    (when (frame-view frame)
-      (set-dimensions (frame-view frame) round-width round-height))
+    (when (frame-surface frame)
+      (set-dimensions (frame-surface frame) round-width round-height))
     (hrt:hrt-border-box-set-size (slot-value frame 'border-box)
                                  round-width round-height)))
 
 (defmethod (setf frame-height) :before (new-height (frame view-frame))
   (let ((round-width (round (frame-width frame)))
         (round-height (round new-height)))
-    (when (frame-view frame)
-      (set-dimensions (frame-view frame) round-width round-height))
+    (when (frame-surface frame)
+      (set-dimensions (frame-surface frame) round-width round-height))
     (hrt:hrt-border-box-set-size (slot-value frame 'border-box)
                                  round-width round-height)))
 
 (defmethod find-view-frame ((frame view-frame) view)
-  (when (equal (frame-view frame) view)
+  (when (equal (frame-surface frame) view)
     frame))
 
 ;; (defmethod find-view-frame ((frame view-frame)
 ;;        (view sb-sys:system-area-pointer))
-;;   (let ((hrt-view (frame-view frame)))
+;;   (let ((hrt-view (frame-surface frame)))
 ;;  (when (and hrt-view
-;;       (equal (hrt:view-hrt-view (frame-view frame)) view))
+;;       (equal (hrt:view-hrt-view (frame-surface frame)) view))
 ;;    frame)))


### PR DESCRIPTION
Address concerns in #334 and the comments of #332 by changing how the `close-current-view` command works. This is done in two ways:

## Rename `frame-view` to `frame-surface`

To make manipulating and doing things with client surfaces easier, standardize how to extract the surfaces from frames by renaming `frame-view` to `frame-surface` and adding an implementation to the `tree:layer-shell-frame` class. Since they aren't all views, using the term `surface` for the method name seemed like the better option. `client` might also work, but since these are wrappers around the surface exposed by a client, `surface` seems to make more sense.

## Remove `tree:frame-close`

Since the close behavior of views and layer surfaces appears to be different, force users to differentiate between the two by checking their type. This isn't as ergonomic and maybe a bit unsafe, but it could lead to less surprising behavior.

## Breaking changes
+  `frame-view` is now called `frame-surface`. The method is otherwise equivalent, so a search-and-replace should be sufficient  to adapt any custom code. Example command:

   ``` bash
     find . -name "*.lisp" -exec sed -i "s/frame-view/frame-surface/g" {} \;
   ```
+ `tree:frame-close` has been removed with a replacement still in the works.